### PR TITLE
Make the first run show something, and document what it shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- First run is no longer blank. The task list and notes seed a few examples
+  when their file does not exist yet, and the examples are the documentation:
+  they name the keys, carry a due date in each direction, a priority, a tag and
+  a note, so the table has something to line up and an overdue row shows what
+  overdue looks like. They are ordinary entries and `d` deletes them.
+
+  Keyed on the file being *absent* rather than empty, so clearing them sticks —
+  the opposite would make them impossible to get rid of. Their titles are held
+  to what the task column can show at 120 columns, since an instruction
+  truncated to `Press ? for every key, h…` is worse than no instruction.
 - A startup hint naming widgets your layout does not place, on the right of the
   status bar, plus a section in the help overlay. A config written by an earlier
   version silently lacks every widget added since — an absent widget is a valid
@@ -146,6 +156,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A config with no `[layout]` section no longer silently loses three panels.
+  The Rust default described a five-widget dashboard while the shipped file
+  described eight, so deleting a section you thought was redundant quietly took
+  the calendar, notes and watchlist with it. They now describe the same
+  dashboard, and a test fails if they drift apart again.
 - The minimum supported Rust version is 1.95, not 1.85. The declared floor had
   stopped being true: `sysinfo` requires 1.95 and ratatui's tree requires 1.88.
   `Cargo.toml`, the CI toolchain, the README and CONTRIBUTING now agree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ hooks, calm by default so that *not* calm is legible at a glance.
 ## Commands
 
 ```sh
-cargo test                                    # 335 tests, all fast, no network
+cargo test                                    # 343 tests, all fast, no network
 cargo clippy --all-targets -- -D warnings     # must be silent
 cargo fmt --all -- --check                    # must be silent
 RUSTDOCFLAGS="-D warnings" \
@@ -184,6 +184,20 @@ Adding a widget: implement `Panel`, add a config struct, add the name to
     while a list next door runs out. Return `None` for anything that scrolls or
     scales; return a figure only when more space genuinely buys the reader
     nothing. Both are whole-panel measurements, frame and padding included.
+16. **First run must not be blank, and the defaults must agree.** The task and
+    notes stores seed examples via `load_or_seed`, keyed on the file being
+    *absent* — never on it being empty, or deleting the examples would not
+    stick. The seeded titles are instructions, so they have to fit the task
+    column at an ordinary width; `seeded_titles_fit_the_task_column_at_an_ordinary_width`
+    pins that at 25 cells, which is what the default layout leaves at 120
+    columns. Separately, `Layout::default()` and the `[layout]` block in
+    `assets/default_config.toml` must describe the same dashboard — they are
+    reached by different routes, and when they diverged, a config without a
+    `[layout]` section silently lost three panels.
+
+    Note for tests: constructing `TodoPanel`/`NotesPanel` against a path with
+    no file now seeds it. Panel tests write an empty file first, which is the
+    branch every run after the first one takes.
 
 ## Visual system
 

--- a/README.md
+++ b/README.md
@@ -17,25 +17,27 @@ nothing shimmers, and nothing is designed to pull you back to it.
 A *mirador* is a lookout — the tower you climb to see everything at once.
 
 ```
-╭─ Clocks ─────────────────────╮╭─ Weather — Boston, Massachusetts ──────────╮
-│ Local   09:41:07  Sat 25 Jul ││ ☀ 74°F  clear                              │
-│ UTC     13:41:07  Sat 25 Jul ││ feels 76°F   wind 7 mph   humidity 58%     │
-│ London  14:41:07  Sat 25 Jul ││ Sat  ☀   81° /  63°                        │
-│ Tokyo   22:41:07  Sat 25 Jul ││ Sun  ⛅   78° /  61°   20%                  │
-╰──────────────────────────────╯╰────────────────────────────────────────────╯
-┏━ Tasks (4) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ 4 open · 1 overdue · 1 today   sort: smart                                 ┃
-┃ ▸ [ ] !!! Renew the domain               #admin            2 days late     ┃
-┃   [ ] !!  Reply to the design review     #work             today           ┃
-┃   [ ] !   Publish 0.0.0 placeholder      #mirador #rust    in 3 days       ┃
-┃   [ ]     Read the ratatui layout docs                     Fri 07 Aug      ┃
-┃ Reserve the crates.io name before someone else does.                       ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-╭─ CPU (10 cores) ─────────────╮╭─ Network ──────────────────────────────────╮
-│  12.4%  average   120s window││ ↓    1.2 MB/s    ↑    184 KB/s             │
-│ ▁▂▃▂▁▁▂▅▇▆▃▂▁▁▂▂▁▁▁▂▃▂▁▁▁▂▁▁ ││ ▁▁▂▁▁▃▇█▅▂▁▁▁▂▁▁▁▁▂▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁ │
-╰──────────────────────────────╯╰────────────────────────────────────────────╯
+╭┤1 Clock├───────────┤EDT├╮╭┤2 Weather — Boston, Massachusetts├────┤at 15:45├╮
+│ 15:52:41                ││ 75°F  clear                                     │
+│    SATURDAY 25 JULY     ││ feels 75°F                                      │
+│ ZONE          TIME      ││ NEXT HOURS ──────────────────────────────────── │
+│ UTC           19:52:41  ││ HOUR  SKY              TEMP FEELS  RAIN    WIND │
+│ London        20:52:41  ││ 16:00 🌞 clear         75°F   76°    0%  10 mph │
+│ Tokyo         04:52:41… ││ 17:00 🌞 clear         75°F   74°    0%  10 mph │
+╰─────── s seconds ───────╯╰─────────────────────────────────────────────────╯
+╭┤3 Tasks├───────────────────────────────────────────────────────────┤3 open├╮
+│ 1 overdue   1 due today   3 open   by smart                                │
+│   DONE PRI TASK                              TAGS                      DUE │
+│   [ ]  ▮▮▮ Renew the domain                  #admin            2 days late │
+│   [ ]  ▮▮  Reply to the design review        #work                   today │
+│   [ ]  ▮   Read the ratatui layout docs      #rust              Fri 07 Aug │
+│                                                                            │
+│ Card on file expired; the registrar will not auto-renew.                   │
+╰────────────────────────────────────────────────────────────────────────────╯
+ mirador   Tab focus   ? keys   q quit
 ```
+
+*Every screen in this README is a real capture, not a mock-up.*
 
 ## Why
 
@@ -71,14 +73,148 @@ rather than unsupported.
 mirador
 ```
 
-On first run it writes a commented config file and starts with a sensible
-default layout. To find the config:
+On first run it writes a commented config file, lays out all eight panels, and
+seeds the task list and notes with a few examples so nothing starts blank. The
+examples are ordinary entries — they explain the keys and then you delete them
+with `d`. They are seeded only when there is no file yet, so once you clear
+them they stay cleared.
+
+To find the config:
 
 ```sh
 mirador --config-path
 ```
 
-Edit `[weather].location` to your own city and you are done.
+Edit `[weather].location` to your own city and you are done. Nothing else is
+required: no account, no API key, no environment variables.
+
+## The panels
+
+Eight widgets, each answering one question. Put the ones you want in the
+layout and drop the rest — an unused widget costs nothing but is also not
+built.
+
+### Tasks
+
+The reason this project exists. Other terminal dashboards tend to render a
+to-do list as a flat checklist; this one has due dates, priorities, tags,
+notes, filtering and full editing without leaving the dashboard.
+
+```
+╭┤3 Tasks├───────────────────────────────────────────────────────────┤3 open├╮
+│ 1 overdue   1 due today   3 open   by smart                                │
+│   DONE PRI TASK                              TAGS                      DUE │
+│   [ ]  ▮▮▮ Renew the domain                  #admin            2 days late │
+│   [ ]  ▮▮  Reply to the design review        #work                   today │
+│   [ ]  ▮   Read the ratatui layout docs      #rust              Fri 07 Aug │
+│                                                                            │
+│ Card on file expired; the registrar will not auto-renew.                   │
+╰────────────────────────────────────────────────────────────────────────────╯
+```
+
+The selected task's note sits at the foot of the panel, so a one-line summary
+in the list does not mean losing the detail behind it. Priority reads as bars
+rather than colour alone, and an overdue task is red *and* counted in the
+header — the same fact twice, because colour is the first thing a terminal
+theme can take away from you.
+
+`smart` sort is the default and means: unfinished first, then overdue, then by
+priority, then by due date. `s` cycles to plain `due`, `priority`, `created`
+or `title` when you want something simpler.
+
+### Notes
+
+Free-form notes in a master-detail layout, the shape a mail client uses.
+
+```
+╭┤2 Notes├───────────────────────────────┤1├╮
+│ 1 note                                    │
+│   TITLE                              DATE │
+│   Release checklist                ·25 J… │
+│ ───────────────────────────────────────── │
+│ Release checklist                         │
+│ written 22 Jul 2026   edited 25 Jul 2026  │
+│ Bump the version, run the four gates, tag │
+│ v-something, and let CI build the three   │
+╰───────────────────────────────────────────╯
+```
+
+The body is visible without pressing anything, which is the whole point: a
+note's value is the text inside it, and making you press a key to see any of
+it turns "glance at the dashboard" into "operate the dashboard". `/` searches
+bodies as well as titles, because the title you wrote in a hurry is often not
+what you later search for.
+
+### Clock and calendar
+
+The first configured zone renders large; the rest become a table showing their
+offset *relative to that zone*, which is the number you actually want when
+scheduling across one. The calendar prints month grids in the shape `cal`
+does, with today marked.
+
+```
+╭┤1 Calendar├───────────────────╮
+│      July 2026                │
+│ Su Mo Tu We Th Fr Sa          │
+│           1  2  3  4          │
+│  5  6  7  8  9 10 11          │
+│ 12 13 14 15 16 17 18          │
+│ 19 20 21 22 23 24 25          │
+│ 26 27 28 29 30 31             │
+╰───── n/p month · t today ─────╯
+```
+
+The calendar is deliberately offline — it reads no mail server and no account.
+`months` sets how many sit across; a taller panel stacks more rather than
+leaving a void, up to a year in view.
+
+### Weather
+
+Current conditions and an hourly forecast from [Open-Meteo](https://open-meteo.com),
+which needs no key and no account. `u` switches between imperial and metric at
+runtime, converting what is already on screen rather than re-fetching.
+
+A failed refresh keeps the last reading and shows its age in amber rather than
+blanking the panel — weather two hours old is still useful, and an empty panel
+is not. Columns drop as the panel narrows, in the order that costs you least.
+
+### Markets
+
+A watchlist with the last price, the day's change, and an intraday sparkline.
+
+```
+╭┤1 Markets├──────────────────────────────────────────────────────────────┤3├╮
+│   SYMBOL         LAST       CHG        % TODAY                             │
+│ ▸ AAPL         333.02    +11.36   +3.53% ▂▄▅▆▇█▇▇▇▇▇▇                      │
+│   MSFT         381.70     +0.12   +0.03% ▄▃▅▇▆▇▆▆▇▆▆▃                      │
+│   ^GSPC       7411.98     +3.68   +0.05% ▃▃▃▆▇▇▅▆▅▂▁▂                      │
+│ via yahoo                                                                  │
+╰─────────────────────── a add · d remove · r refresh ───────────────────────╯
+```
+
+`a` adds a symbol and `d` removes one, and those edits stick — the watchlist
+is a data file rather than config, which is what lets the panel own it. See
+[Market data](#market-data) before filing a bug about HTTP 429.
+
+### CPU and network
+
+Braille history graphs with the colour gradient running vertically by
+magnitude, so the profile stays put as data scrolls and a graph left on screen
+all day does not shimmer.
+
+```
+╭┤2 CPU├──┤18 cores├╮╭┤3 Network├───┤all├╮
+│   9.0% LOAD   7s  ││ ↓    611 B/s   ↑  │
+│                   ││                 ⡀ │
+│                   ││                ⡄⡇ │
+│ ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣶⣶⣴ ││ ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣿⣿ │
+│ PER CORE          ││                ⡇  │
+│ ▁▁▁▁▁▁▂▂▁▁▁▁▃▁▁▁▁ ││ ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣷⣼ │
+╰───────────────────╯╰───────────────────╯
+```
+
+Both buffers grow to fill the panel, so `history` is a floor on what is kept
+rather than a cap on what a wider panel can draw.
 
 ## Keys
 
@@ -229,10 +365,66 @@ needs to know it exists.
 
 ## Acknowledgements
 
-Built with [ratatui](https://ratatui.rs). Weather data from
-[Open-Meteo](https://open-meteo.com). Dates and timezones handled by
-[jiff](https://github.com/BurntSushi/jiff); system metrics by
-[sysinfo](https://github.com/GuillaumeGomez/sysinfo).
+mirador is a thin layer over other people's hard work. Ten direct
+dependencies, every one of them maintained by someone who did not have to.
+
+**[ratatui](https://ratatui.rs)** deserves top billing. Every frame here is
+ratatui: the layout solver, the buffer diffing that makes a redraw cheap
+enough to leave running all day, the widget model that made `Panel` a
+twenty-line trait instead of a framework. The border-embedded titles and hints
+this project leans on are ratatui's block API being more flexible than it had
+any obligation to be. It is the successor to
+[tui-rs](https://github.com/fdehau/tui-rs) by Florian Dehau, carried forward
+by a community that kept it alive rather than letting it archive — and it
+brings [crossterm](https://github.com/crossterm-rs/crossterm) with it, which
+is what makes the same binary work on macOS, Linux and Windows terminals.
+
+| Crate | What it does here |
+| --- | --- |
+| [ratatui](https://ratatui.rs) | Every widget, layout and redraw |
+| [crossterm](https://github.com/crossterm-rs/crossterm) | Terminal control, key and mouse events |
+| [jiff](https://github.com/BurntSushi/jiff) | Dates, IANA timezones, the "2 days late" arithmetic |
+| [sysinfo](https://github.com/GuillaumeGomez/sysinfo) | CPU and network counters, per platform |
+| [ureq](https://github.com/algesten/ureq) | Blocking HTTP for weather and quotes |
+| [serde](https://serde.rs) + [toml](https://github.com/toml-rs/toml) + [serde_json](https://github.com/serde-rs/json) | Config, tasks and notes as hand-editable TOML; JSON from the APIs |
+| [anyhow](https://github.com/dtolnay/anyhow) | Error context that survives to the message a user reads |
+| [dirs](https://github.com/dirs-dev/dirs-rs) | Finding the right config and data directory per platform |
+| [unicode-width](https://github.com/unicode-rs/unicode-width) | Measuring text in display cells, without which every table misaligns |
+
+`unicode-width` is worth singling out: measuring `chars()` instead of display
+cells is a bug this project shipped once, and one emoji is enough to slide
+every column after it under the wrong header.
+
+### Services
+
+**[Open-Meteo](https://open-meteo.com)** provides the weather, free and
+without an API key or an account, which is the only reason the weather panel
+can exist in a tool that refuses to bundle credentials. Their
+[terms](https://open-meteo.com/en/terms) are generous to open source and they
+deserve the traffic; if you build on them at scale, pay them.
+
+Market data comes from Yahoo Finance's public chart endpoint. It is not a
+documented API and mirador treats it accordingly — one request per symbol, no
+faster than once a minute, never persisted to disk. `QuoteSource` is a trait
+so it can be replaced when it inevitably changes.
+
+### Prior art
+
+Techniques were taken deliberately from projects that solved these problems
+first, and are described in `CLAUDE.md` where they are implemented:
+
+- **[btop](https://github.com/aristocratos/btop)** and its ancestor
+  **[bpytop](https://github.com/aristocratos/bpytop)** — the braille level
+  table, and the insight that a gradient should run vertically by magnitude so
+  a graph does not shimmer as data scrolls. The CPU and network panels are
+  wearing their ideas.
+- **[clock-tui](https://github.com/race604/clock-tui)** — run-length row
+  encoding for block numerals, which turns thirteen glyphs and free integer
+  scaling into about twenty lines.
+- **[gitui](https://github.com/gitui-org/gitui)**,
+  **[lazygit](https://github.com/jesseduffield/lazygit)** and ratatui's own
+  tutorial — focus by dimming the unfocused rather than brightening the
+  focused, hints in the bottom border, the jump key in the title.
 
 ## License
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,41 +77,27 @@ pub struct Layout {
 
 impl Default for Layout {
     fn default() -> Self {
+        // Kept identical to the `[layout]` block in assets/default_config.toml,
+        // and `the_rust_default_layout_matches_the_shipped_one` fails if they
+        // drift. They are reached by different routes — the shipped file on a
+        // true first run, this on any config that omits `[layout]` — and when
+        // they disagreed, deleting the section silently cost three panels.
+        let row = |height: u16, panels: &[(&str, u16)]| LayoutRow {
+            height,
+            panels: panels
+                .iter()
+                .map(|(widget, width)| LayoutPanel {
+                    widget: (*widget).into(),
+                    width: *width,
+                })
+                .collect(),
+        };
+
         Self {
             rows: vec![
-                LayoutRow {
-                    height: 30,
-                    panels: vec![
-                        LayoutPanel {
-                            widget: "clocks".into(),
-                            width: 40,
-                        },
-                        LayoutPanel {
-                            widget: "weather".into(),
-                            width: 60,
-                        },
-                    ],
-                },
-                LayoutRow {
-                    height: 45,
-                    panels: vec![LayoutPanel {
-                        widget: "todo".into(),
-                        width: 100,
-                    }],
-                },
-                LayoutRow {
-                    height: 25,
-                    panels: vec![
-                        LayoutPanel {
-                            widget: "cpu".into(),
-                            width: 50,
-                        },
-                        LayoutPanel {
-                            widget: "network".into(),
-                            width: 50,
-                        },
-                    ],
-                },
+                row(34, &[("clocks", 26), ("calendar", 34), ("weather", 40)]),
+                row(42, &[("todo", 58), ("notes", 42)]),
+                row(24, &[("stocks", 40), ("cpu", 30), ("network", 30)]),
             ],
         }
     }
@@ -566,6 +552,56 @@ mod tests {
         config
             .validate()
             .expect("the bundled default config must always validate");
+    }
+
+    #[test]
+    fn the_rust_default_layout_matches_the_shipped_one() {
+        let shipped: Config = toml::from_str(DEFAULT_CONFIG).expect("must parse");
+
+        let shape = |layout: &Layout| -> Vec<(u16, Vec<(String, u16)>)> {
+            layout
+                .rows
+                .iter()
+                .map(|r| {
+                    let panels = r
+                        .panels
+                        .iter()
+                        .map(|p| (p.widget.clone(), p.width))
+                        .collect();
+                    (r.height, panels)
+                })
+                .collect()
+        };
+
+        assert_eq!(
+            shape(&shipped.layout),
+            shape(&Layout::default()),
+            "the shipped config and the Rust default describe different \
+             dashboards. Both are first impressions — the file on a true first \
+             run, the Rust default for any config that omits [layout] — so a \
+             gap here means deleting one section silently removes panels."
+        );
+    }
+
+    #[test]
+    fn the_default_layout_places_every_widget() {
+        // A widget nobody can see is a widget nobody knows exists. The startup
+        // hint names what is missing, but the default should have nothing to
+        // name: shipping a dashboard that hides a third of itself is a poor
+        // first run, and this is exactly how notes and stocks went unseen.
+        let layout = Layout::default();
+        let placed: Vec<&str> = layout
+            .rows
+            .iter()
+            .flat_map(|r| r.panels.iter().map(|p| p.widget.as_str()))
+            .collect();
+
+        for widget in crate::widgets::WIDGET_NAMES {
+            assert!(
+                placed.contains(widget),
+                "the default layout does not place `{widget}`"
+            );
+        }
     }
 
     #[test]

--- a/src/note.rs
+++ b/src/note.rs
@@ -110,6 +110,26 @@ impl NoteStore {
         })
     }
 
+    /// Load, seeding one example note when there is no file yet.
+    ///
+    /// Same reasoning as the task list: an empty master-detail panel shows
+    /// neither a list nor a body, so first run is the one moment it explains
+    /// nothing at all. One note rather than several — the panel's whole point
+    /// is that you can read a body without pressing anything, and a single
+    /// selected note demonstrates that better than a list to scroll.
+    ///
+    /// Seeded only when the file is *absent*, so deleting it is permanent.
+    pub fn load_or_seed(path: impl Into<PathBuf>, today: Date) -> Result<Self> {
+        let path = path.into();
+        let first_run = !path.exists();
+        let mut store = Self::load(path)?;
+        if first_run {
+            store.add(example_note(today));
+            store.save_reporting();
+        }
+        Ok(store)
+    }
+
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -217,6 +237,26 @@ impl NoteStore {
     }
 }
 
+/// The note written on first run. The id is assigned by the store.
+fn example_note(today: Date) -> Note {
+    Note {
+        body: "You are reading it in the detail pane. That is the point of the \
+               panel: a note's whole value is the text inside it, so making you \
+               press a key to see any of it would turn \"glance at the \
+               dashboard\" into \"operate the dashboard\".\n\n\
+               a writes a new note and e edits this one. Tab moves between the \
+               title and the body, Enter inside the body is an ordinary new \
+               line, and Ctrl+S saves. d deletes, and / searches bodies as well \
+               as titles — the title you wrote in a hurry is often not what you \
+               later search for.\n\n\
+               Notes live in a plain TOML file next to your tasks, written \
+               atomically, and you can edit it by hand or keep it in git. \
+               Delete this one once you have your own."
+            .into(),
+        ..Note::new(0, "This is a note", today)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,6 +279,39 @@ mod tests {
 
     fn today() -> Date {
         Date::new(2026, 7, 25).unwrap()
+    }
+
+    #[test]
+    fn a_first_run_is_seeded_and_an_emptied_file_stays_empty() {
+        let dir = std::env::temp_dir().join(format!("mirador-note-{}-seed", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _guard = TempDir(dir.clone());
+        let path = dir.join("notes.toml");
+
+        let mut s = NoteStore::load_or_seed(&path, jiff::civil::date(2026, 7, 25)).unwrap();
+        assert_eq!(s.notes().len(), 1, "first run must show one example note");
+        assert_eq!(s.last_error, None, "seeding must not fail silently");
+        assert!(
+            path.exists(),
+            "the seed must be written, not held in memory"
+        );
+        assert!(
+            !s.notes()[0].body.is_empty(),
+            "an empty body defeats the point: the detail pane would be blank"
+        );
+
+        // Deleting it writes an empty file; meeting it again next run would
+        // make it impossible to get rid of.
+        let id = s.notes()[0].id;
+        s.remove(id);
+        s.save().unwrap();
+
+        let reopened = NoteStore::load_or_seed(&path, jiff::civil::date(2026, 7, 25)).unwrap();
+        assert!(
+            reopened.notes().is_empty(),
+            "an emptied file must stay empty across a restart"
+        );
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -294,6 +294,32 @@ impl TaskStore {
         })
     }
 
+    /// Load, seeding a handful of example tasks when there is no file yet.
+    ///
+    /// An empty list on first run is the worst version of this panel: the one
+    /// thing it exists to show is missing, and every key that would fill it is
+    /// invisible until you press `?`. The examples are ordinary tasks — they
+    /// carry the due dates, priorities, tags and notes a real one would, so the
+    /// columns have something to line up — and deleting them is the point.
+    ///
+    /// Seeded only when the file is *absent*, never when it is present and
+    /// empty. Clearing the list writes an empty file, so a user who deletes all
+    /// of these does not meet them again on the next run.
+    pub fn load_or_seed(path: impl Into<PathBuf>, today: Date) -> Result<Self> {
+        let path = path.into();
+        let first_run = !path.exists();
+        let mut store = Self::load(path)?;
+        if first_run {
+            for task in example_tasks(today) {
+                store.add(task);
+            }
+            // Reported rather than propagated: a seeding failure is not worth
+            // refusing to start over, and `last_error` puts it in the panel.
+            store.save_reporting();
+        }
+        Ok(store)
+    }
+
     /// The file this store reads and writes.
     pub fn path(&self) -> &Path {
         &self.path
@@ -421,6 +447,65 @@ impl TaskStore {
             Err(e) => self.last_error = Some(format!("{e:#}")),
         }
     }
+}
+
+/// The tasks written on first run. Ids are assigned by the store.
+///
+/// These teach the panel's keys by being the thing the keys operate on, which
+/// is why they are worded as instructions rather than as a plausible errand
+/// list. Between them they exercise every column — priority, tags, a due date
+/// in each direction, and a note — so a first run shows the table doing its
+/// job rather than a blank grid with headers over it.
+fn example_tasks(today: Date) -> Vec<Task> {
+    // Deliberately relative to `today`: fixed dates would be years overdue by
+    // the time anyone reads them, and "overdue" is a state worth showing on
+    // purpose rather than by accident.
+    let in_days = |n: i32| today.checked_add(jiff::Span::new().days(n)).ok();
+
+    vec![
+        Task {
+            priority: Priority::High,
+            tags: vec!["mirador".into()],
+            due: in_days(1),
+            notes: Some(
+                "Everything here is editable in place. Tab and Shift+Tab move \
+                 between fields, Enter saves, Esc cancels. While a form is open \
+                 the global keys are suppressed, so typing a q into a title \
+                 cannot quit the dashboard."
+                    .into(),
+            ),
+            ..Task::new(0, "Press e to edit this task", today)
+        },
+        Task {
+            priority: Priority::Medium,
+            tags: vec!["mirador".into()],
+            due: in_days(3),
+            ..Task::new(0, "Press a to add your own", today)
+        },
+        Task {
+            tags: vec!["mirador".into()],
+            notes: Some(
+                "Sort cycles with s, / filters on title, tag and note text, and \
+                 c shows completed tasks. Press o for the path to the TOML file \
+                 behind all of this — it is plain text you can edit or keep in \
+                 git."
+                    .into(),
+            ),
+            ..Task::new(0, "Press ? to see every key", today)
+        },
+        Task {
+            priority: Priority::Low,
+            tags: vec!["example".into()],
+            due: in_days(-1),
+            notes: Some(
+                "A task past its due date reads in red, and the counter in the \
+                 border frames it as overdue. This one is here to show that; \
+                 delete it with d once you have seen it."
+                    .into(),
+            ),
+            ..Task::new(0, "This one is overdue", today)
+        },
+    ]
 }
 
 /// Ordering for two tasks under a given sort mode.
@@ -694,6 +779,97 @@ mod tests {
         let mut store = TaskStore::load(&path).unwrap();
         store.save().unwrap();
         assert!(!path.exists(), "a clean store must not create a file");
+    }
+
+    #[test]
+    fn a_first_run_is_seeded_with_examples_and_written_to_disk() {
+        let dir = tempdir();
+        let path = dir.join("todos.toml");
+        let store = TaskStore::load_or_seed(&path, today()).unwrap();
+
+        assert!(!store.tasks().is_empty(), "first run must not be empty");
+        assert_eq!(store.last_error, None, "seeding must not fail silently");
+        assert!(
+            path.exists(),
+            "the seed must be written, not held in memory"
+        );
+
+        // The examples exist to demonstrate the columns, so every column the
+        // table can draw needs at least one task exercising it.
+        let tasks = store.tasks();
+        assert!(tasks.iter().any(|t| t.due.is_some()), "no due date");
+        assert!(tasks.iter().any(|t| t.notes.is_some()), "no note");
+        assert!(tasks.iter().any(|t| !t.tags.is_empty()), "no tag");
+        assert!(
+            tasks.iter().any(|t| t.priority != Priority::None),
+            "no priority"
+        );
+        assert!(
+            tasks
+                .iter()
+                .any(|t| matches!(t.due_state(today()), DueState::Overdue(_))),
+            "no overdue task, so nothing shows what overdue looks like"
+        );
+    }
+
+    #[test]
+    fn seeded_titles_fit_the_task_column_at_an_ordinary_width() {
+        // The default layout gives the task panel 58% of the width, and the
+        // DONE, PRI, TAGS and DUE columns take the rest, which leaves twenty-five
+        // cells for the title on a 120-column terminal. These titles
+        // are instructions, so a truncated one is a instruction you cannot
+        // read — "Press ? for every key, h…" was the version that prompted
+        // this test. Measured in display cells, not chars, for the usual
+        // reason.
+        const BUDGET: usize = 25;
+        for task in example_tasks(today()) {
+            let width = unicode_width::UnicodeWidthStr::width(task.title.as_str());
+            assert!(
+                width <= BUDGET,
+                "seeded title is {width} cells, over the {BUDGET} the column \
+                 can show at 120 columns: {:?}",
+                task.title
+            );
+        }
+    }
+
+    #[test]
+    fn seeding_happens_only_when_the_file_is_absent() {
+        let dir = tempdir();
+        let path = dir.join("todos.toml");
+
+        // Deleting every example writes an empty file. Meeting them again on
+        // the next run would make them impossible to get rid of.
+        let mut store = TaskStore::load_or_seed(&path, today()).unwrap();
+        let ids: Vec<u64> = store.tasks().iter().map(|t| t.id).collect();
+        for id in ids {
+            store.remove(id);
+        }
+        store.save().unwrap();
+
+        let reopened = TaskStore::load_or_seed(&path, today()).unwrap();
+        assert!(
+            reopened.tasks().is_empty(),
+            "an emptied list must stay empty across a restart"
+        );
+    }
+
+    #[test]
+    fn seeded_ids_are_unique_and_do_not_collide_with_later_additions() {
+        let dir = tempdir();
+        let mut store = TaskStore::load_or_seed(dir.join("todos.toml"), today()).unwrap();
+        let seeded: Vec<u64> = store.tasks().iter().map(|t| t.id).collect();
+
+        let added = store.add(Task::new(0, "mine", today()));
+        assert!(
+            !seeded.contains(&added),
+            "a task added after seeding reused a seeded id"
+        );
+
+        let mut unique = seeded.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), seeded.len(), "seeded ids are not unique");
     }
 
     #[test]

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -177,6 +177,50 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Not a test: renders what a brand-new user sees, with nothing on disk,
+    /// so the seeded examples can be eyeballed the way they will be met.
+    /// Run with `cargo test dump_first_run -- --ignored --nocapture`.
+    ///
+    /// Worth looking at after touching the seeds: they are the first and for
+    /// some users the only impression of the task and notes panels, and the
+    /// wording has to fit the columns at an ordinary terminal size.
+    #[test]
+    #[ignore = "renders the first-run dashboard to stdout for eyeballing, not an assertion"]
+    fn dump_first_run() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // An empty directory is the whole point: the stores seed themselves.
+        let dir = std::env::temp_dir().join("mirador-dump-first-run");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut config = Config::default();
+        config.todo.file = Some(dir.join("todos.toml"));
+        config.notes.file = Some(dir.join("notes.toml"));
+        config.stocks.file = Some(dir.join("watchlist.toml"));
+        config.weather.latitude = Some(42.36);
+        config.weather.longitude = Some(-71.06);
+
+        let mut app = crate::app::App::new(config).unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(3));
+
+        let mut terminal = Terminal::new(TestBackend::new(100, 34)).unwrap();
+        terminal.draw(|f| app.render_for_test(f)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        println!("\n+{}+", "-".repeat(100));
+        for y in 0..buf.area.height {
+            let mut line = String::new();
+            for x in 0..buf.area.width {
+                line.push_str(buf[(x, y)].symbol());
+            }
+            println!("|{line}|");
+        }
+        println!("+{}+", "-".repeat(100));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// Not a test: renders the dashboard to text so it can be eyeballed.
     /// Run with `cargo test dump_dashboard -- --ignored --nocapture`.
     #[test]

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -122,7 +122,8 @@ pub struct NotesPanel {
 
 impl NotesPanel {
     pub fn new(config: NotesConfig, path: std::path::PathBuf) -> anyhow::Result<Self> {
-        let store = NoteStore::load(path)?;
+        let today = jiff::Zoned::now().date();
+        let store = NoteStore::load_or_seed(path, today)?;
         let mut panel = Self {
             store,
             config,
@@ -132,7 +133,7 @@ impl NotesPanel {
             list_state: ListState::default(),
             body_scroll: 0,
             status: None,
-            today: jiff::Zoned::now().date(),
+            today,
             list_area: None,
             detail_area: None,
         };
@@ -847,7 +848,12 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("mirador-notes-{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        let p = NotesPanel::new(NotesConfig::default(), dir.join("notes.toml")).unwrap();
+        let path = dir.join("notes.toml");
+        // An empty file rather than no file: the panel seeds an example note
+        // when the file is absent, and these tests are about the panel, not
+        // the seed. This is the branch every run after the first one takes.
+        std::fs::write(&path, "").unwrap();
+        let p = NotesPanel::new(NotesConfig::default(), path).unwrap();
         (p, TempDir(dir))
     }
 

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -209,10 +209,10 @@ pub struct TodoPanel {
 impl TodoPanel {
     /// Build the panel, loading tasks from `path`.
     pub fn new(config: TodoConfig, path: std::path::PathBuf) -> anyhow::Result<Self> {
-        let store = TaskStore::load(path)?;
+        let today = jiff::Zoned::now().date();
+        let store = TaskStore::load_or_seed(path, today)?;
         let sort = config.sort.parse().unwrap_or_default();
         let show_completed = config.show_completed;
-        let today = jiff::Zoned::now().date();
 
         let mut panel = Self {
             store,
@@ -1191,6 +1191,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("todos.toml");
+        // An empty file rather than no file: the panel seeds examples when the
+        // file is absent, and these tests are about the panel, not the seed.
+        // Writing it first exercises the same branch a second run takes.
+        std::fs::write(&path, "").unwrap();
         let panel = TodoPanel::new(TodoConfig::default(), path).unwrap();
         (panel, TempDir(dir))
     }


### PR DESCRIPTION
Three things a new user met, none of them good.

## 1. Two panels were empty on first run

The task list and notes started blank — the worst version of both, since the one thing they exist to show is missing and every key that would fill them is invisible until you press `?`.

They now seed examples when their file does not exist:

```
╭┤4 Tasks├───────────────────────────────────────────────────┤4 open├╮
│ 1 overdue   4 open   by smart                                      │
│   DONE PRI TASK                      TAGS                      DUE │
│   [ ]  ▮   This one is overdue       #example           1 day late │
│   [ ]  ▮▮▮ Press e to edit this task #mirador             tomorrow │
│   [ ]  ▮▮  Press a to add your own   #mirador            in 3 days │
│   [ ]  ▮   Press ? to see every key  #mirador                      │
╰────────────────────────────────────────────────────────────────────╯
```

They are ordinary tasks — a due date in each direction, a priority, a tag and a note — so the table has something to line up and an overdue row shows what overdue actually looks like. `d` deletes them.

**Keyed on the file being *absent*, never on it being empty.** The opposite would make them impossible to get rid of: clearing the list writes an empty file, and a store that reseeded on empty would hand them straight back. There is a test for exactly that.

**Titles are capped at 25 display cells**, which is what the task column can show at 120 columns. The first draft rendered as `Press ? for every key, h…`, and a truncated instruction is worse than no instruction. `seeded_titles_fit_the_task_column_at_an_ordinary_width` pins it.

## 2. A config without `[layout]` silently lost three panels

`Layout::default()` described a five-widget dashboard while `assets/default_config.toml` described eight. They are reached by different routes — the shipped file on a true first run, the Rust default for any config that omits the section — so deleting a section you thought was redundant quietly took the calendar, notes and watchlist with it.

They now describe the same dashboard, with two tests: one comparing them directly, one asserting the default places every widget in `WIDGET_NAMES`.

## 3. The README documented four panels of eight

Its hero was a hand-drawn mock-up of a layout that had since changed. **Every screen in the README is now a real terminal capture**, taken under tmux at the width shown. Each panel has a section covering what question it answers and why it behaves as it does.

Acknowledgements were four names in a sentence, which undersells how much of this is other people's work. Now: **ratatui first and at length** — including that it carries crossterm, and that it is tui-rs carried forward by a community rather than left to archive — then every direct dependency with what it actually does here, the services (Open-Meteo, and honesty about the Yahoo endpoint), and the projects whose techniques were taken deliberately: btop/bpytop, clock-tui, gitui/lazygit.

## Note for reviewers

Constructing `TodoPanel`/`NotesPanel` against a path with no file now seeds it, which broke 21 existing panel tests. Their helpers write an empty file first — the branch every run after the first one takes — so they still test the panel rather than the seed.

Also added `dump_first_run`, an ignored render of the empty-disk dashboard, since the seeds are the first impression and their wording has to fit real columns.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (339 pass, 4 ignored), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`. First run also driven for real under tmux against a scratch config, and the seeded `todos.toml` checked to be the hand-editable TOML the README promises.