### PR TITLE
Refuse to publish a release whose tag disagrees with the crate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,64 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Runs before anything is built, so a bad tag costs seconds rather than three
+  # target builds and a published release nobody wanted.
+  verify:
+    name: verify the tag
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.classify.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # The binary reports the version baked in from Cargo.toml, not the tag it
+      # was built from. Nothing reconciled the two, so tagging v0.2.0 without
+      # bumping the manifest would ship archives named v0.2.0 full of a binary
+      # answering `mirador 0.1.0` — and a published release cannot be quietly
+      # corrected. A v0.0.0-rc.1 test tag did exactly this and nothing objected.
+      #
+      # Equality is exact, so a pre-release tag needs a pre-release version in
+      # the manifest: v0.2.0-rc.1 requires version = "0.2.0-rc.1". That is the
+      # point rather than an inconvenience — an rc binary should say it is one.
+      - name: Check the tag matches the crate version
+        if: github.ref_type == 'tag'
+        run: |
+          set -euo pipefail
+          crate=$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "(.+)"/\1/')
+          tag="${GITHUB_REF_NAME#v}"
+
+          if [ -z "$crate" ]; then
+            echo "::error::could not read a version from Cargo.toml"
+            exit 1
+          fi
+
+          echo "Cargo.toml version: $crate"
+          echo "tag:                $GITHUB_REF_NAME (version $tag)"
+
+          if [ "$crate" != "$tag" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $crate. Bump the version in Cargo.toml and Cargo.lock, commit, then move the tag."
+            exit 1
+          fi
+
+      # A semver pre-release identifier is the hyphen: 0.2.0-rc.1 is one,
+      # 0.2.0 is not. Without this every tag published as a normal release and
+      # took over "Latest", which is how a throwaway rc ended up presented as
+      # the current version of the project. GitHub refuses to mark a
+      # prerelease as latest, so this one flag settles both.
+      - name: Classify the tag
+        id: classify
+        run: |
+          set -euo pipefail
+          case "${GITHUB_REF_NAME#v}" in
+            *-*) prerelease=true ;;
+            *)   prerelease=false ;;
+          esac
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "publishing ${GITHUB_REF_NAME} with prerelease=$prerelease"
+
   build:
     name: build ${{ matrix.target }}
+    needs: verify
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,7 +118,7 @@ jobs:
 
   release:
     name: publish release
-    needs: build
+    needs: [verify, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -76,3 +132,8 @@ jobs:
             *.tar.gz
             *.tar.gz.sha256
           generate_release_notes: true
+          prerelease: ${{ needs.verify.outputs.prerelease }}
+          # Without this, a glob matching nothing is not an error and the
+          # release publishes with no binaries attached — the one failure that
+          # looks like success from the Actions tab.
+          fail_on_unmatched_files: true


### PR DESCRIPTION
The test release proved the workflow builds and publishes. It also showed two things it would happily do wrong, plus one I noticed while fixing them.

## What was wrong

**1. Nothing reconciled the tag with `Cargo.toml`.** The binary reports the version baked in at compile time, not the tag it was built from. The `v0.0.0-rc.1` test tag produced archives named for one version containing a binary that answered `mirador 0.1.0` — and nothing objected. A published release cannot be quietly corrected.

**2. Every tag published as a normal release and took over "Latest".** `softprops/action-gh-release` defaults `prerelease` to false, which is how a throwaway rc briefly presented itself as the current version of the project.

**3. An unmatched file glob was not an error**, so a release could publish with no binaries attached — the one failure mode that looks like success from the Actions tab.

## What this does

A `verify` job runs **before anything is built**, so a bad tag costs seconds rather than three target builds and a release nobody wanted. It checks the tag against the manifest, and classifies the tag by the semver hyphen so it marks itself as a prerelease. GitHub refuses to mark a prerelease as latest, so that one flag settles both problems.

Equality is exact, so a pre-release tag needs a pre-release version in the manifest: `v0.2.0-rc.1` requires `version = "0.2.0-rc.1"`. That is the point rather than an inconvenience — an rc binary should say it is one.

## Verified end to end, not just by reading it

Both paths were driven with throwaway tags against this branch, and both artifacts have been deleted.

**Mismatch rejected** — tagged `v9.9.9` against a manifest reading `0.1.0`:

```
X verify the tag in 5s
  X Check the tag matches the crate version
  - Classify the tag          <- skipped
```
> `tag v9.9.9 does not match Cargo.toml version 0.1.0. Bump the version in Cargo.toml and Cargo.lock, commit, then move the tag.`

Failed in **5 seconds**, no target ever built, no release created.

**Match accepted and correctly classified** — tagged `v0.1.0-rc.1` against a matching manifest: all five jobs green, and the published release came out `"isPrerelease": true` with 6 assets. `GET /releases/latest` returned **404**, confirming the rc did not take over Latest.

And the original defect is closed: the released binary now answers

```
mirador 0.1.0-rc.1
```

matching its tag, where the previous test shipped `0.1.0` under a `v0.0.0-rc.1` tag.

The temporary version-bump commit used for that second test has been dropped from this branch; `Cargo.toml` and `Cargo.lock` are back at `0.1.0`.