### PR TITLE
Stop the README drawing the CPU and network panels in braille

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,20 +198,23 @@ is a data file rather than config, which is what lets the panel own it. See
 
 ### CPU and network
 
-Braille history graphs with the colour gradient running vertically by
-magnitude, so the profile stays put as data scrolls and a graph left on screen
-all day does not shimmer.
+CPU shows average load, a moving history graph and a per-core meter row.
+Network shows receive and transmit rates as two graphs, plus a session total
+and the peak rate seen.
 
-```
-╭┤2 CPU├──┤18 cores├╮╭┤3 Network├───┤all├╮
-│   9.0% LOAD   7s  ││ ↓    611 B/s   ↑  │
-│                   ││                 ⡀ │
-│                   ││                ⡄⡇ │
-│ ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣶⣶⣴ ││ ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣿⣿ │
-│ PER CORE          ││                ⡇  │
-│ ▁▁▁▁▁▁▂▂▁▁▁▁▃▁▁▁▁ ││ ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣷⣼ │
-╰───────────────────╯╰───────────────────╯
-```
+Both draw their history in **braille**, which packs two samples into every
+character cell and four levels into every row — twice the horizontal
+resolution of a block-element sparkline in the same space. The colour gradient
+runs *vertically by magnitude*, one colour per row, so the profile stays put
+as data scrolls: a graph left on screen all day changes colour when the load
+changes, not merely because time passed.
+
+> These two panels are the one thing this README will not show you in a code
+> block. Braille is missing from several of the fonts GitHub falls back to, so
+> the glyphs render at a width the surrounding box characters do not share and
+> the panel tears itself apart. The screenshot at the top of this file shows
+> them as they actually look. It is a real terminal, which is the only place
+> the alignment is guaranteed.
 
 Both buffers grow to fill the panel, so `history` is a floor on what is kept
 rather than a cap on what a wider panel can draw.


### PR DESCRIPTION
Reported: the CPU and network example did not render correctly on GitHub.

## Cause

Those two panels were the only place in the README using **braille** (U+2800–U+28FF). Braille is missing from several of the fonts GitHub falls back to inside a code block, so those glyphs get substituted from a different face at a width the surrounding box-drawing characters do not share — and every row ends somewhere different. It renders perfectly in a terminal, which is precisely why it survived being written.

Confirmed by character audit: braille appeared on 4 lines, all in that one block. Every other example is box drawing and block elements (`▁▂▃`, `▮`), which are widely covered.

## Fix

Not a redraw in block elements. That would be a mock-up of a panel in a file that had just claimed every screen in it is a real capture, and the whole point of braille here is that it has twice the horizontal resolution a block sparkline would.

Instead the section says what the panels show and why braille earns its place — two samples per cell, four levels per row, and a gradient running vertically by magnitude so a graph left up all day changes colour when the load changes rather than because time passed. It also states plainly why there is no code block, which is more useful to a reader than a broken one.

## Verified

A width check over every box-drawing line in the README, measuring in display cells:

```
block at line  19: 17 box lines, widths [78] OK
block at line 103:  9 box lines, widths [78] OK
block at line 129: 10 box lines, widths [45] OK
block at line 155:  9 box lines, widths [33] OK
block at line 185:  7 box lines, widths [78] OK
```

Braille remaining in the file: **0**.

## One residual risk

The hero and weather examples contain `🌞` (U+1F31E). It is width-2 in a terminal and the capture is correct, but emoji in a GitHub code block are rendered by a colour emoji font whose advance width is not guaranteed to be exactly two monospace cells. If those rows ever look a cell out, that is the cause — say the word and they can go the same way as the braille.