### PR TITLE
Stamp the changelog for 0.1.0 and stop calling crates.io a placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - 2026-07-25
+
+Initial release.
+
+The Changed and Fixed sections record decisions reversed and defects found
+*before* this first tag rather than after it. Nothing below was ever shipped
+in an earlier version — they are kept because the reasoning is worth having.
 
 ### Added
 
@@ -88,6 +94,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scalable block numerals for the clock, sized to the panel. Seconds ride small
   beside the large `HH:MM` when the full time will not fit.
 - Weather art for ten sky conditions.
+
+- Terminal dashboard with a configurable grid layout. Rows and panels use
+  relative weights, so a layout keeps its proportions at any terminal size.
+- `Panel` trait as the extension seam; each widget owns its own state and
+  refresh cadence, and the application shell handles only layout, focus and
+  event dispatch.
+- **Clocks** widget: any number of world clocks by IANA timezone, with the
+  literal `local` for the system zone. Configurable time and date formats, and
+  optional UTC offsets. Unresolvable zones are reported inline rather than
+  dropped.
+- **Weather** widget: current conditions plus a 1–7 day forecast from
+  Open-Meteo, which needs no API key or account. Location is geocoded from a
+  place name, or given directly as latitude and longitude. All network I/O runs
+  on a background thread, so a slow request never blocks rendering.
+- **To-do** widget with full create, read, update and delete:
+  - Tasks carry a title, notes, due date, priority, tags and completion state.
+  - Add and edit through an in-panel form; delete asks for confirmation.
+  - Due-date input accepts ISO dates, `today`/`tomorrow`, weekday names, and
+    offsets such as `+3d` or `2w`. Unrecognised input is rejected with an
+    explanation.
+  - Five sort modes, including a "smart" default that surfaces overdue work
+    ahead of high-priority work that is not yet due.
+  - Live filtering across titles, tags and notes.
+  - Storage is a plain, hand-editable TOML file. Writes are atomic, and save
+    failures surface in the panel rather than being swallowed.
+- **CPU** widget: average utilisation as a scrolling chart, with per-core
+  meters and configurable warning and critical thresholds.
+- **Network** widget: receive and transmit throughput as scrolling charts, with
+  session totals. Rates are derived from real elapsed time between samples, so
+  a delayed tick reports the correct rate rather than an inflated one.
+- Configuration in a single TOML file, written with full comments on first run.
+  Unknown widget names, malformed colours and invalid units are rejected at
+  startup with actionable messages.
+- Command-line flags: `--config`, `--config-path`, `--print-config`, `--help`
+  and `--version`.
+- Help overlay bound to `?`, listing global bindings and those of the focused
+  panel.
 
 ### Changed
 
@@ -240,49 +283,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a broken column.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
-
-## [0.1.0] - 2026-07-25
-
-Initial release.
-
-### Added
-
-- Terminal dashboard with a configurable grid layout. Rows and panels use
-  relative weights, so a layout keeps its proportions at any terminal size.
-- `Panel` trait as the extension seam; each widget owns its own state and
-  refresh cadence, and the application shell handles only layout, focus and
-  event dispatch.
-- **Clocks** widget: any number of world clocks by IANA timezone, with the
-  literal `local` for the system zone. Configurable time and date formats, and
-  optional UTC offsets. Unresolvable zones are reported inline rather than
-  dropped.
-- **Weather** widget: current conditions plus a 1–7 day forecast from
-  Open-Meteo, which needs no API key or account. Location is geocoded from a
-  place name, or given directly as latitude and longitude. All network I/O runs
-  on a background thread, so a slow request never blocks rendering.
-- **To-do** widget with full create, read, update and delete:
-  - Tasks carry a title, notes, due date, priority, tags and completion state.
-  - Add and edit through an in-panel form; delete asks for confirmation.
-  - Due-date input accepts ISO dates, `today`/`tomorrow`, weekday names, and
-    offsets such as `+3d` or `2w`. Unrecognised input is rejected with an
-    explanation.
-  - Five sort modes, including a "smart" default that surfaces overdue work
-    ahead of high-priority work that is not yet due.
-  - Live filtering across titles, tags and notes.
-  - Storage is a plain, hand-editable TOML file. Writes are atomic, and save
-    failures surface in the panel rather than being swallowed.
-- **CPU** widget: average utilisation as a scrolling chart, with per-core
-  meters and configurable warning and critical thresholds.
-- **Network** widget: receive and transmit throughput as scrolling charts, with
-  session totals. Rates are derived from real elapsed time between samples, so
-  a delayed tick reports the correct rate rather than an inflated one.
-- Configuration in a single TOML file, written with full comments on first run.
-  Unknown widget names, malformed colours and invalid units are rejected at
-  startup with actionable messages.
-- Command-line flags: `--config`, `--config-path`, `--print-config`, `--help`
-  and `--version`.
-- Help overlay bound to `?`, listing global bindings and those of the focused
-  panel.
 
 [Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jchultarsky/mirador/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,18 +341,21 @@ inline `[theme]` table from a `theme = "name"` string).
 - Originally built in a Linux container, where `sysinfo`'s macOS CPU and network
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows remains untested.
-- **The crates.io name is reserved.** `mirador` `0.0.0` is published — a
-  reservation, not a release, which leaves `0.1.0` for the first real one.
-  Reservation is first-come with no reclamation, which is why it went out
-  before the software was finished rather than after.
+- **`0.1.0` is released**, on crates.io and as a GitHub release with binaries
+  for macOS arm64, macOS x86-64 and Linux x86-64. `0.0.0` is still on
+  crates.io below it — the name reservation that went out first, since
+  reservation is first-come with no reclamation.
 
-  The published tarball is real source rather than an empty stub, so
-  `cargo install mirador` works and will keep installing `0.0.0` until a
-  further version is published. The README says so; if that stops being true,
-  fix it there too.
-- **The release workflow has never run.** There are no tags and no GitHub
-  releases, so a green CI says nothing about whether releasing works. It
-  builds three targets (linux-gnu x86_64, macOS arm64 and x86_64), tars them
-  with a sha256, and publishes with generated notes. Windows is absent, and
-  adding it is the open question `cargo dist` would answer — see the note in
-  the open-work list before hand-rolling more matrix YAML.
+  Cutting a release is a tag push and a `cargo publish`, in that order. The
+  workflow refuses a tag that disagrees with `rust-version`'s neighbour
+  `version` in Cargo.toml, so bump the manifest, commit, *then* tag. Nothing
+  else is manual; the three targets, the checksums and the release notes are
+  all the workflow's job.
+- **The release workflow has been exercised in both directions**, on throwaway
+  tags since deleted: a tag disagreeing with the manifest is rejected in about
+  five seconds before anything builds, and a matching one publishes three
+  targets with checksums and generated notes. A hyphen in the tag marks the
+  release as a prerelease, which also stops it taking over "Latest".
+
+  Windows is still absent. Adding it is the open question `cargo dist` would
+  answer — see the open-work list before hand-rolling more matrix YAML.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ No accounts. No API keys. No telemetry. Weather comes from
 
 ## Install
 
-From source, which is the way to get the current build:
+From crates.io:
+
+```sh
+cargo install mirador
+```
+
+From source:
 
 ```sh
 git clone https://github.com/jchultarsky/mirador
@@ -42,13 +48,16 @@ cd mirador
 cargo install --path .
 ```
 
-Requires Rust 1.95 or newer. Tested on macOS and Linux; Windows is untested
-rather than unsupported.
+Or download a pre-built binary for macOS (Apple silicon or Intel) or Linux
+x86-64 from the [latest release](https://github.com/jchultarsky/mirador/releases/latest).
+Each archive carries a `.sha256` beside it:
 
-> **On crates.io, the published version is `0.0.0`** — a reservation of the
-> name, not a release. `cargo install mirador` works and gives you a running
-> dashboard, but it will not track `main` until `0.1.0` ships. Build from
-> source until then. There are no pre-built binaries yet.
+```sh
+shasum -a 256 -c mirador-v0.1.0-aarch64-apple-darwin.tar.gz.sha256
+```
+
+Requires Rust 1.95 or newer to build. Tested on macOS and Linux; Windows is
+untested rather than unsupported, and there is no Windows binary yet.
 
 ## Quick start
 


### PR DESCRIPTION
Release prep for `v0.1.0`. No code changes.

## The changelog

Everything under `[Unreleased]` **is** 0.1.0 — there was no earlier release for it to be unreleased against, and tagging code whose changelog calls most of itself unreleased would be wrong. The two sections are merged into one `## [0.1.0] - 2026-07-25`.

The `Changed` and `Fixed` subsections are kept rather than flattened into `Added`, because the reasoning in them is the valuable part. A line at the top says what they mean in a first release: decisions reversed and defects found *before* the tag, not regressions anyone ever ran.

## The README was about to become false

The install section was written around a crates.io holding a `0.0.0` name reservation, and says in as many words that `cargo install mirador` "will not track `main` until `0.1.0` ships". That stops being true the moment 0.1.0 goes up.

`cargo install mirador` leads again, and the pre-built binaries are now offered — they will exist as of this tag, and a release nobody is told about may as well not have happened — along with the command to verify the `.sha256` beside each archive.

## CLAUDE.md had two notes today made false

That the crates.io name was "reserved, not released", and that "the release workflow has never run". Both replaced with what is now known, including the ordering that actually matters: **bump the manifest, commit, then tag**, because the workflow now rejects a tag that disagrees with `Cargo.toml`.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (339 pass, 4 ignored), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`, and `cargo publish --dry-run`.

Once this merges, `v0.1.0` gets tagged on `main` and published to crates.io.