### PR TITLE
Release 0.2.0: Windows binaries and installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-07-25
 
 ### Added
 
@@ -311,5 +311,6 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/jchultarsky/mirador/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jchultarsky/mirador/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,27 @@ No accounts. No API keys. No telemetry. Weather comes from
 
 ## Install
 
-From crates.io:
+From crates.io, if you have Rust:
 
 ```sh
 cargo install mirador
 ```
+
+Without Rust, on macOS or Linux:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/jchultarsky/mirador/releases/latest/download/mirador-installer.sh | sh
+```
+
+and on Windows:
+
+```powershell
+irm https://github.com/jchultarsky/mirador/releases/latest/download/mirador-installer.ps1 | iex
+```
+
+Both fetch the right archive for your platform, check it against its published
+checksum, and unpack the binary. If you would rather read the script before
+running it, it is an ordinary file at that URL, and the manual route is below.
 
 From source:
 
@@ -51,10 +67,6 @@ cargo install --path .
 Or download a pre-built binary from the
 [latest release](https://github.com/jchultarsky/mirador/releases/latest).
 Every archive carries a `.sha256` beside it, so verify it before running:
-
-> The Windows archive and these filenames arrive with the **next** release.
-> `v0.1.0` predates the packaging change and ships macOS and Linux only, under
-> names carrying the version (`mirador-v0.1.0-aarch64-apple-darwin.tar.gz`).
 
 ```sh
 shasum -a 256 -c mirador-aarch64-apple-darwin.tar.gz.sha256


### PR DESCRIPTION
Minor rather than patch. No source changed — but a platform that could not run this before now can, which is a feature by any reading a user would give it.

- `Cargo.toml` and `Cargo.lock` to `0.2.0`
- `[Unreleased]` stamped as `[0.2.0] - 2026-07-25`, with compare links
- The README caveat saying the new archive names arrive "with the next release" is deleted, because this is that release
- Shell and PowerShell installers documented, now that they exist

The installers are most of what `dist` buys. `curl | sh` is the only route for someone who does not have Rust and should not need it in order to run a terminal dashboard. Both check the archive against its published checksum, and the README says the script can be read first for anyone who would rather.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (339 pass), `cargo +1.95.0 check --all-targets`, `cargo publish --dry-run`, `dist generate --check` (no drift), and `dist plan` announcing `v0.2.0`.

Once merged: tag `v0.2.0`, let the generated workflow build all four targets, verify the Windows zip the way the macOS one was verified last time, then `cargo publish`.