### PR TITLE
Stop the README's checksum command warning about the file it just verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The README's checksum command no longer prints a warning. `dist` writes its
+  `.sha256` files with a trailing blank line, so `shasum -c` verified the
+  archive and then added `WARNING: 1 line is improperly formatted` — true of
+  the blank line, not of the hash, but a warning printed beside a checksum is
+  the one place ambiguity is worst. Piping through `grep .` drops the blank
+  line; both the macOS and Linux forms are tested to print `OK` and exit 0 on a
+  good archive and `FAILED` and exit 1 on a tampered one. A Windows form is
+  documented too, now that there is a Windows archive to verify.
+
 ## [0.2.0] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,10 +66,31 @@ cargo install --path .
 
 Or download a pre-built binary from the
 [latest release](https://github.com/jchultarsky/mirador/releases/latest).
-Every archive carries a `.sha256` beside it, so verify it before running:
+Every archive carries a `.sha256` beside it, so verify it before running. On
+macOS:
 
 ```sh
-shasum -a 256 -c mirador-aarch64-apple-darwin.tar.gz.sha256
+grep . mirador-aarch64-apple-darwin.tar.gz.sha256 | shasum -a 256 -c -
+```
+
+and on Linux:
+
+```sh
+grep . mirador-x86_64-unknown-linux-gnu.tar.gz.sha256 | sha256sum -c -
+```
+
+Either prints `… OK` and exits 0, or prints `FAILED` and exits 1. The `grep .`
+drops a trailing blank line that the checksum files are written with; without
+it the command still verifies correctly but adds `WARNING: 1 line is
+improperly formatted`, and a warning printed next to a checksum is exactly the
+wrong thing to make someone squint at.
+
+On Windows, print the hash and compare it with the `.sha256` file beside the
+archive:
+
+```powershell
+Get-FileHash .\mirador-x86_64-pc-windows-msvc.zip
+Get-Content .\mirador-x86_64-pc-windows-msvc.zip.sha256
 ```
 
 | Platform | Archive |


### PR DESCRIPTION
`dist` writes its `.sha256` files with a trailing blank line, so the command the README told people to run did this:

```
mirador-x86_64-pc-windows-msvc.zip: OK
shasum: WARNING: 1 line is improperly formatted
```

The warning is about the blank line, not the hash — verification genuinely passed. But a warning printed beside a checksum is the one place ambiguity costs most: the reader cannot tell whether the thing they were just told to check has failed.

## Fix

Pipe through `grep .` to drop the blank line.

```sh
# macOS
grep . mirador-aarch64-apple-darwin.tar.gz.sha256 | shasum -a 256 -c -

# Linux
grep . mirador-x86_64-unknown-linux-gnu.tar.gz.sha256 | sha256sum -c -
```

## Tested, not reasoned about

Both forms, against the real `v0.2.0` artifacts — including the failure path, which is the part that actually matters:

| Case | Output | Exit |
| --- | --- | --- |
| good archive, `shasum` | `mirador-aarch64-apple-darwin.tar.gz: OK` | 0 |
| good archive, `sha256sum` | `mirador-aarch64-apple-darwin.tar.gz: OK` | 0 |
| one byte appended | `corrupt.tar.gz: FAILED` | 1 |

The Linux form was run against GNU `sha256sum` rather than assumed to behave like `shasum`. Both emit the warning without the `grep`, confirming the cause is the file rather than either tool.

I also checked the aggregate `sha256.sum` as an alternative — it has the same trailing blank line, so it needs the same treatment and verifies less per command.

## Windows

Now that there is a Windows archive, it gets a form too. It prints the computed hash and the expected hash rather than comparing them in-shell, because there is no PowerShell available here to test a comparison against, and an untested one-liner in an install section is how people end up not checking at all.

## Note

This is a docs-only change, so it reaches crates.io with the next publish rather than immediately. The rendered README on GitHub updates on merge.