### PR TITLE
Say in the README what happens to an existing config when a widget is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The README says what happens when you upgrade. A new widget does not appear
+  in a config you already have — mirador never rewrites your config, which is
+  what makes it safe to hand-edit, so a config written by an earlier version
+  lays out the panels that existed when it was written and nothing since. The
+  status bar has always named the widgets a layout does not place; the README
+  now explains the notice, shows what it looks like, and gives the row to paste.
+  The first person to add the pomodoro panel to an existing config went looking
+  for a missing setting instead.
 - The README's checksum command no longer prints a warning. `dist` writes its
   `.sha256` files with a trailing blank line, so `shasum -c` verified the
   archive and then added `WARNING: 1 line is improperly formatted` — true of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,15 @@ bottom border; jump key in the title.
 **The four things the dashboard exists to answer:** what time/day is it, what
 tasks are next, what is the portfolio doing, what compute is available.
 
+**The pomodoro panel answers none of them, and is here anyway** — the owner
+asked for it directly. Worth recording rather than leaving the next reader to
+wonder whether the filter was forgotten. It is arguably a fifth question, "how
+is this stretch of work going", and it is the only panel that is *about* the
+time you spend at the dashboard rather than about something outside it. That
+makes it the one panel where a nagging design would do real damage, which is
+why the chime defaults off and a paused timer greys out instead of blinking.
+The filter still holds for anything not asked for by name.
+
 **Identified gaps, agreed:** (1) calendar / next event is the biggest hole —
 tasks are self-paced, a meeting is externally imposed and time-critical;
 (2) nothing shows what *changed* since you last looked; (3) no single "is

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ A *mirador* is a lookout — the tower you climb to see everything at once.
 
 ![The mirador dashboard: a block-numeral clock, four months of calendar, weather with an hourly forecast, the task list and notes, and a market watchlist beside live CPU and network graphs](https://raw.githubusercontent.com/jchultarsky/mirador/main/docs/screenshot.png)
 
-*All eight panels on a wide terminal, on a first run — the tasks and the note
-are the examples mirador seeds for you. Every screen in this README is a real
-capture, not a mock-up.*
+*A wide terminal on a first run — the tasks and the note are the examples
+mirador seeds for you. Every screen in this README is a real capture, not a
+mock-up. This one predates the pomodoro panel, which is shown
+[further down](#pomodoro).*
 
 ## Why
 
@@ -115,8 +116,8 @@ does not build for it.
 mirador
 ```
 
-On first run it writes a commented config file, lays out all eight panels, and
-seeds the task list and notes with a few examples so nothing starts blank. The
+On first run it writes a commented config file, lays out every panel, and seeds
+the task list and notes with a few examples so nothing starts blank. The
 examples are ordinary entries — they explain the keys and then you delete them
 with `d`. They are seeded only when there is no file yet, so once you clear
 them they stay cleared.
@@ -129,6 +130,37 @@ mirador --config-path
 
 Edit `[weather].location` to your own city and you are done. Nothing else is
 required: no account, no API key, no environment variables.
+
+### Upgrading
+
+**A new widget will not appear in a config you already have.** mirador never
+rewrites your config — that is what makes it safe to hand-edit and keep in git
+— so a config written by an earlier version lays out exactly the panels that
+existed when it was written, and nothing since. Leaving a panel out is a
+legitimate choice, so this cannot be an error and cannot be fixed for you.
+
+What you get instead is a notice on the right of the status bar naming what
+your layout does not place:
+
+```
+ mirador   Tab focus   ? keys   q quit          1 unused: pomodoro   ? for help
+```
+
+It retires on your first keypress, because a dashboard you leave open all day
+must not nag; `?` keeps it in the help overlay. To take a widget up, add it to
+a row in `[layout]` and give the row's other panels room for it:
+
+```toml
+  { height = 42, panels = [
+    { widget = "todo",     width = 44 },
+    { widget = "notes",    width = 30 },
+    { widget = "pomodoro", width = 26 },   # the new one
+  ] },
+```
+
+`mirador --print-config` prints the current default in full if you would rather
+copy a whole row, and `mirador --migrate-config` rewrites keys that were
+renamed between versions, leaving a backup beside the original.
 
 ## The panels
 


### PR DESCRIPTION
Julian added the pomodoro panel, ran `cargo run`, and went looking for a missing setting. That is the right conclusion from the evidence and the wrong answer — and the docs were what failed, not the code.

## The behaviour is correct and deliberate

A new widget does not appear in a config you already have. mirador never rewrites your config, which is exactly the property that makes it safe to hand-edit and keep in git, so a config written by an earlier version lays out the panels that existed then and nothing since. Leaving a panel out is a legitimate choice, so this cannot be an error and cannot be silently fixed for you.

## The machinery already worked

The status bar has named unplaced widgets since that hint landed, and it read correctly the whole time:

```
 mirador   Tab focus   ? keys   q quit          1 unused: pomodoro   ? for help
```

I verified this against a copy of Julian's actual config. It sits on the right, retires on the first keypress so the dashboard does not nag, and is easy to miss if you do not know to look for it.

So the fix is documentation. A new **Upgrading** section shows the notice as it actually appears, explains why it cannot be automatic, gives the layout row to paste, and points at `--print-config` and `--migrate-config` (both verified to exist, rather than remembered).

## Two claims went stale with the new panel

- The screenshot caption said **"All eight panels"** of an image that now predates the timer.
- Quick start said first run **"lays out all eight panels"**.

The caption now says what the image is and links to the panel it does not contain. This file claims every screen in it is a real capture, and that only stays true if the captions are honest about what was captured. Retaking the shot needs a real screenshot, so that is Julian's to do if he wants it.

## CLAUDE.md: why the pomodoro exists at all

It answers none of the four questions the dashboard is filtered on, and `CLAUDE.md` says a panel that answers none of them needs a better reason than "it would be easy". The reason is that the owner asked for it — worth stating outright rather than leaving the next reader to wonder whether the filter was forgotten.

It is also the only panel *about the time you spend at the dashboard* rather than about something outside it, which is the sharpest argument for why its chime defaults off and its paused state greys out instead of blinking.

## Verified

`cargo fmt --check`, `cargo test` (361 pass), `cargo doc` with `-D warnings`, and the new `#pomodoro` anchor resolves to the heading it names.