### PR TITLE
Remember settings changed from the keyboard across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Settings changed from the keyboard are remembered across restarts.**
+  Weather units, the task sort order, whether completed tasks show, seconds on
+  the clock, and the pomodoro durations. The watchlist already did this for
+  symbols; this is the same answer generalised.
+
+  mirador still never rewrites your config — the property that makes it safe to
+  hand-edit and keep in git. The config *seeds* a setting and a small state
+  file beside your tasks records where you moved it since. Deleting that file
+  puts everything back, which the file's own header says, because a preference
+  you cannot remember setting needs an obvious way out.
+
+  **Only what you actually changed is written.** Pressing `u` records the units
+  and nothing else. The first version reported every panel's current value,
+  which pins the config's own settings into the state file the moment any one
+  preference moves — after which editing the config silently stops working.
+  That passed its tests and was caught by running it.
+
+  Panel sizes are deliberately excluded: `Ctrl+arrow` resizing is geometry
+  rather than preference, and remembering it would mean a saved width quietly
+  overruling a `[layout]` edited by hand.
 - **Pomodoro panel.** A focus timer in the same block numerals the clock uses:
   `space` starts and pauses, `n` skips a phase, `r` restores the current one,
   and `+`/`-` change the length of the phase you are in. Focus is brass and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ glyphs.rs    block numerals, bold-uppercase labels, weather art
 theme.rs     colours and gradient stops
 config.rs    TOML config, validation, default file
 migrate.rs   textual in-place upgrade of configs written by older versions
+state.rs     UI-changed preferences, remembered across restarts
 task.rs      task model + atomic TOML store
 note.rs      note model + atomic TOML store
 quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
@@ -185,7 +186,19 @@ Adding a widget: implement `Panel`, add a config struct, add the name to
     while a list next door runs out. Return `None` for anything that scrolls or
     scales; return a figure only when more space genuinely buys the reader
     nothing. Both are whole-panel measurements, frame and padding included.
-16. **First run must not be blank, and the defaults must agree.** The task and
+16. **A panel remembers only what the user changed.** `Panel::remember` writes
+    a preference only when it differs from the value the panel was *built*
+    with, which is why every such panel keeps a `seeded_*` copy. Reporting the
+    current value unconditionally looks identical in a unit test and is wrong
+    in practice: the first keystroke on any panel pins every other panel's
+    config values into the state file, and editing the config silently stops
+    working from then on. This was written the wrong way first and caught by
+    running it, not by the tests.
+
+    The app merges into what it loaded rather than starting from nothing, so a
+    preference set last session and untouched this one is not dropped by a
+    panel that has nothing new to say about it.
+17. **First run must not be blank, and the defaults must agree.** The task and
     notes stores seed examples via `load_or_seed`, keyed on the file being
     *absent* — never on it being empty, or deleting the examples would not
     stick. The seeded titles are instructions, so they have to fit the task
@@ -331,11 +344,15 @@ inline `[theme]` table from a `theme = "name"` string).
 
 ## Open work, in priority order
 
-1. **Settings editable from the UI**, starting with `[weather].location`.
-   Blocked on a decision: mirador deliberately *never rewrites the config*, so
-   either that stance changes or edited settings go to a separate state file.
-   The watchlist took the second route and it worked well — that is the
-   precedent, but applying it to *all* settings is still the owner's call.
+1. **Settings editable from the UI — decided and built.** The owner's call was
+   the state file, following the watchlist: config seeds, `state.rs` records
+   where the user moved since, and the config is still never rewritten. Live
+   for weather units, task sort and completed-visibility, clock seconds and
+   pomodoro durations.
+
+   What is *not* covered: `[weather].location`, which was the original example.
+   Editing it needs text entry in the panel rather than a toggle, and that is a
+   UI question rather than a persistence one now that the storage exists.
 2. Calendar panel reading a local `.ics` — the shipped `calendar` widget is a
    date grid only, deliberately offline; events are a separate, larger panel.
 3. Theme system per above.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,37 @@ mirador --config-path
 Edit `[weather].location` to your own city and you are done. Nothing else is
 required: no account, no API key, no environment variables.
 
+### Remembered settings
+
+Some settings you change with a keystroke are remembered across restarts:
+
+| Setting | Key | Panel |
+| --- | --- | --- |
+| Weather units | `u` | Weather |
+| Task sort order | `s` | Tasks |
+| Whether completed tasks show | `c` | Tasks |
+| Seconds on the clock | `s` | Clock |
+| Pomodoro durations | `+` / `-` | Pomodoro |
+| Watchlist symbols | `a` / `d` | Markets |
+
+**mirador never rewrites your config.** That is what makes it safe to
+hand-edit and keep in git, so these live in a small state file beside your
+tasks instead. The config *seeds* a setting; the state file records where you
+moved it since.
+
+Only what you actually changed is written. Pressing `u` records the units and
+nothing else, so editing any other value in your config still takes effect —
+if mirador wrote everything, the first keystroke would silently freeze the
+rest of your config in place. Delete the state file and every remembered
+setting falls back to what the config says; it is listed at the top of the
+file itself, because a preference you cannot remember setting needs an obvious
+way back.
+
+Panel sizes are the deliberate exception. `Ctrl+arrow` resizing lasts for the
+session only: it is geometry rather than preference, in the same vocabulary as
+`[layout]`, and remembering it would mean a saved width quietly overruling a
+layout you had since edited by hand.
+
 ### Upgrading
 
 **A new widget will not appear in a config you already have.** mirador never

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -3,6 +3,12 @@
 # This file was created automatically on first run. Every value below is a
 # default, so you can delete anything you do not want to override.
 #
+# mirador never rewrites this file, so it is safe to hand-edit and to keep in
+# version control. Settings you change with a keystroke — weather units, the
+# task sort, seconds on the clock, pomodoro durations — are remembered in a
+# separate state file beside your tasks, which records only what you actually
+# changed. Delete that file and everything falls back to what is written here.
+#
 # Docs: https://github.com/jchultarsky/mirador#configuration
 
 [general]
@@ -217,8 +223,9 @@ week_starts = "sunday"   # sunday | monday
 # whichever phase you are in by a minute.
 #
 # The values below are where the timer *starts*. Changes made with `+` and `-`
-# last for the session; mirador never rewrites this file, so edit here for a
-# lasting change.
+# are remembered across restarts in mirador's own state file — this file is
+# never rewritten. Only a phase you actually adjusted is remembered, so editing
+# a duration here still works. Delete the state file to go back to these.
 #
 # `chime` is off by default, because a dashboard you leave open all day has no
 # business making noise you did not ask for. With no `chime_command` it rings

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@
 //! focus ring, the frames and the tick schedule, and forwards everything else
 //! through the [`Panel`] trait.
 
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -19,6 +20,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wr
 use crate::config::Config;
 use crate::frame::{Binding, FrameSpec};
 use crate::panel::{KeyOutcome, Panel, RenderContext};
+use crate::state::UiState;
 use crate::theme::Gradients;
 
 /// Global bindings, used for both the status bar and the help overlay.
@@ -178,6 +180,12 @@ pub struct App {
     /// of any kind: a dashboard you leave open all day must not nag, and a
     /// notice that will not go away is a nag.
     show_widget_hint: bool,
+    /// Where to write remembered preferences, once someone asks for that.
+    /// `None` in tests, which is what keeps them off a real user's file.
+    state_path: Option<PathBuf>,
+    /// The last state written, so a keypress that changed nothing writes
+    /// nothing.
+    saved_state: UiState,
 }
 
 impl std::fmt::Debug for App {
@@ -232,6 +240,8 @@ impl App {
             should_quit: false,
             show_widget_hint: !unused_widgets.is_empty(),
             unused_widgets,
+            state_path: None,
+            saved_state: UiState::default(),
         })
     }
 
@@ -257,6 +267,11 @@ impl App {
                     // release event, which would otherwise double every action.
                     Event::Key(key) if key.kind == KeyEventKind::Press => {
                         self.handle_key(key);
+                        // Only keys can move a preference, and only after one
+                        // has been handled can it have moved. Cheap because it
+                        // compares before writing: an arrow key costs a struct
+                        // comparison, not a file.
+                        self.persist_preferences();
                         dirty = true;
                     }
                     Event::Mouse(mouse) => dirty |= self.handle_mouse(mouse),
@@ -273,7 +288,58 @@ impl App {
         for slot in &mut self.slots {
             slot.panel.shutdown();
         }
+        // Once more on the way out, in case the last thing changed was not a
+        // key — and because Ctrl+C reaches here too.
+        self.persist_preferences();
         Ok(())
+    }
+
+    /// Remember preferences to `path` from now on.
+    ///
+    /// Separate from [`App::new`] so that tests, which build apps constantly,
+    /// cannot write to a real user's state file by forgetting to opt out. An
+    /// app with no path set simply never persists.
+    ///
+    /// `loaded` is what was read from that file, and becomes the base every
+    /// later write merges into — so starting up does not rewrite a file it has
+    /// just read, and a preference from an earlier session is not dropped by a
+    /// panel that has nothing new to say about it.
+    pub fn remember_preferences_at(&mut self, path: PathBuf, loaded: UiState) {
+        self.saved_state = loaded;
+        self.state_path = Some(path);
+    }
+
+    /// What every panel currently wants remembered.
+    ///
+    /// Starts from what is already on disk rather than from nothing, so a
+    /// preference set last session and left alone this one survives instead of
+    /// being dropped by the panel that is no longer calling it a change.
+    fn collect_preferences(&self) -> UiState {
+        let mut state = self.saved_state.clone();
+        for slot in &self.slots {
+            slot.panel.remember(&mut state);
+        }
+        state
+    }
+
+    /// Write preferences if any of them moved.
+    ///
+    /// A failed write is deliberately not surfaced. There is no panel that owns
+    /// this to show an error in, and the failure costs a sort order that one
+    /// keystroke restores — putting a warning on a dashboard designed to be
+    /// left open, over that, would be the wrong trade. Task and note saves,
+    /// which can lose something you cannot retype, do surface theirs.
+    fn persist_preferences(&mut self) {
+        let Some(path) = self.state_path.clone() else {
+            return;
+        };
+        let current = self.collect_preferences();
+        if current == self.saved_state {
+            return;
+        }
+        if current.save(&path).is_ok() {
+            self.saved_state = current;
+        }
     }
 
     /// Tick any panel whose refresh interval has elapsed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -484,7 +484,10 @@ impl Config {
 
     /// Reject configs that would produce an unusable dashboard, with a message
     /// that says how to fix it rather than just what is wrong.
-    fn validate(&self) -> Result<()> {
+    /// `pub(crate)` so the state tests can assert that no remembered preference,
+    /// however mangled, can produce a config that would have been rejected had
+    /// it come from the file.
+    pub(crate) fn validate(&self) -> Result<()> {
         if self.layout.rows.is_empty() {
             anyhow::bail!(
                 "`[layout]` has no rows, so there is nothing to draw. \
@@ -559,6 +562,63 @@ impl Config {
         match &self.stocks.file {
             Some(p) => Ok(expand_tilde(p)),
             None => Ok(Self::default_data_dir()?.join("watchlist.toml")),
+        }
+    }
+
+    /// Where remembered UI preferences live. Not configurable: it is mirador's
+    /// own bookkeeping rather than something you curate, and a config key
+    /// pointing at it would invite exactly the confusion this file avoids.
+    pub fn state_path() -> Result<PathBuf> {
+        Ok(crate::state::default_path(&Self::default_data_dir()?))
+    }
+
+    /// Apply remembered preferences over the config.
+    ///
+    /// Runs before any panel is built, so panels see a config that already
+    /// reflects where the user left things and need no loading code of their
+    /// own. An absent field means the config keeps its say.
+    ///
+    /// Values are *validated* rather than trusted: a sort mode or unit string
+    /// that no longer parses is dropped and the config's value stands. The file
+    /// outlives the version that wrote it, and a preference from a build where
+    /// `smart` meant something else should not take a dashboard down.
+    pub fn apply_state(&mut self, state: &crate::state::UiState) {
+        if let Some(units) = &state.weather_units
+            && matches!(units.as_str(), "metric" | "imperial")
+        {
+            self.weather.units.clone_from(units);
+        }
+        if let Some(sort) = &state.todo_sort
+            && sort.parse::<crate::task::SortMode>().is_ok()
+        {
+            self.todo.sort.clone_from(sort);
+        }
+        if let Some(show) = state.todo_show_completed {
+            self.todo.show_completed = show;
+        }
+        if let Some(show) = state.clocks_show_seconds {
+            self.clocks.show_seconds = show;
+        }
+        // Durations are clamped rather than dropped: the panel already bounds
+        // them, so an out-of-range figure means a hand-edited file and the
+        // nearest legal value is what was meant.
+        for (slot, saved) in [
+            (
+                &mut self.pomodoro.focus_minutes,
+                state.pomodoro_focus_minutes,
+            ),
+            (
+                &mut self.pomodoro.short_break_minutes,
+                state.pomodoro_short_break_minutes,
+            ),
+            (
+                &mut self.pomodoro.long_break_minutes,
+                state.pomodoro_long_break_minutes,
+            ),
+        ] {
+            if let Some(minutes) = saved {
+                *slot = minutes.clamp(1, crate::widgets::pomodoro::MAX_MINUTES);
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod migrate;
 mod note;
 mod panel;
 mod quote;
+mod state;
 mod task;
 mod textarea;
 mod textfield;
@@ -151,9 +152,24 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
-    let (config, _path) = Config::load(args.config)?;
+    let (mut config, _path) = Config::load(args.config)?;
+
+    // Preferences changed from the keyboard on a previous run are applied over
+    // the config *before* any panel exists, so every panel is constructed with
+    // the values the user last chose and none of them needs restoring code.
+    // The config still seeds; this only records where things moved since.
+    let state_path = Config::state_path().ok();
+    let saved = state_path
+        .as_deref()
+        .map(crate::state::UiState::load)
+        .unwrap_or_default();
+    config.apply_state(&saved);
+
     let mouse = config.general.mouse;
     let mut app = App::new(config)?;
+    if let Some(path) = state_path {
+        app.remember_preferences_at(path, saved);
+    }
 
     // `ratatui::init` installs a panic hook that restores the terminal, so a
     // panic leaves the user with a working shell rather than a broken one.

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -123,6 +123,20 @@ pub trait Panel {
         false
     }
 
+    /// Contribute any preference this panel wants remembered across restarts.
+    ///
+    /// Write a setting only when it differs from the value the panel was built
+    /// with. A panel that reports everything pins the config's own values into
+    /// the state file the first time any *other* preference moves, and editing
+    /// the config then silently stops working — which is the failure this whole
+    /// mechanism exists to avoid. Comparing against the seed is what keeps
+    /// "changed by the user" and "merely configured" apart.
+    ///
+    /// There is no matching load hook on purpose. Remembered preferences are
+    /// applied to the config before any panel is built, so a panel sees the
+    /// right values in its constructor and needs no restoring code at all.
+    fn remember(&self, _state: &mut crate::state::UiState) {}
+
     /// Called once before the terminal is torn down, so panels can flush state.
     fn shutdown(&mut self) {}
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,294 @@
+//! Preferences changed from the UI, remembered across restarts.
+//!
+//! mirador never rewrites its config. That is what makes the config safe to
+//! hand-edit and keep in git, and it is the reason a setting you change with a
+//! keystroke has nowhere obvious to go. The watchlist answered this first by
+//! keeping symbols in a data file of their own; this is the same answer
+//! generalised, and the config's role is unchanged — it *seeds*, and this file
+//! records where you have moved since.
+//!
+//! Every field is optional and absent means "no opinion, use the config". So a
+//! state file listing one preference overrides exactly one, an empty one
+//! overrides nothing, and deleting it puts everything back to what the config
+//! says. That last property is the point: there must be an obvious way to undo
+//! a preference you cannot remember setting.
+//!
+//! Deliberately *not* here: panel sizes. `Ctrl+arrow` resizing is geometry
+//! rather than preference — it belongs to the same vocabulary as `[layout]`,
+//! and remembering it would mean a saved width silently overruling a layout you
+//! had since edited by hand. Sizes stay session-only until that conflict has an
+//! answer.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// The persisted preferences, all optional.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UiState {
+    /// `u` in the weather panel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weather_units: Option<String>,
+    /// `s` in the task panel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub todo_sort: Option<String>,
+    /// `c` in the task panel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub todo_show_completed: Option<bool>,
+    /// `s` in the clock panel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clocks_show_seconds: Option<bool>,
+    /// `+` and `-` in the pomodoro panel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pomodoro_focus_minutes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pomodoro_short_break_minutes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pomodoro_long_break_minutes: Option<u64>,
+}
+
+impl UiState {
+    /// Read the state file, treating a missing one as no preferences.
+    ///
+    /// A *corrupt* one is also treated as no preferences rather than as a
+    /// startup failure. This file is written by the program, not by a person,
+    /// so a parse error here is mirador's fault or a half-written file — and
+    /// refusing to start a dashboard over a remembered sort order would be a
+    /// wildly disproportionate response. The config, which a person does edit,
+    /// keeps its strict parsing precisely because that error *is* actionable.
+    pub fn load(path: &Path) -> Self {
+        let Ok(raw) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        toml::from_str(&raw).unwrap_or_default()
+    }
+
+    /// Write atomically, the same temp-file-and-rename the task store uses, so
+    /// an interrupted save cannot leave a truncated file behind.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating data directory {}", parent.display()))?;
+        }
+
+        let body = toml::to_string_pretty(self).context("serialising ui state")?;
+        let contents = format!(
+            "# mirador remembers preferences you changed from the keyboard here.\n\
+             # Config seeds these; this file records where you moved since.\n\
+             # Safe to delete: everything falls back to your config.\n\n{body}"
+        );
+
+        let tmp = path.with_extension("toml.tmp");
+        std::fs::write(&tmp, &contents).with_context(|| format!("writing {}", tmp.display()))?;
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("replacing {} with {}", path.display(), tmp.display()))?;
+        Ok(())
+    }
+}
+
+/// Where the state file lives, beside the tasks and notes.
+pub fn default_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("state.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempDir(PathBuf);
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn dir(name: &str) -> (PathBuf, TempDir) {
+        let dir = std::env::temp_dir().join(format!("mirador-state-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        (dir.join("state.toml"), TempDir(dir))
+    }
+
+    #[test]
+    fn a_missing_file_means_no_preferences() {
+        let (path, _g) = dir("missing");
+        assert_eq!(UiState::load(&path), UiState::default());
+    }
+
+    #[test]
+    fn preferences_survive_a_save_and_reload() {
+        let (path, _g) = dir("roundtrip");
+        let state = UiState {
+            weather_units: Some("metric".into()),
+            todo_sort: Some("due".into()),
+            todo_show_completed: Some(true),
+            clocks_show_seconds: Some(false),
+            pomodoro_focus_minutes: Some(30),
+            pomodoro_short_break_minutes: Some(7),
+            pomodoro_long_break_minutes: Some(20),
+        };
+        state.save(&path).unwrap();
+        assert_eq!(UiState::load(&path), state);
+    }
+
+    #[test]
+    fn only_what_was_set_is_written() {
+        let (path, _g) = dir("sparse");
+        let state = UiState {
+            weather_units: Some("metric".into()),
+            ..UiState::default()
+        };
+        state.save(&path).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("weather_units"));
+        assert!(
+            !raw.contains("todo_sort"),
+            "an untouched preference must not be written, or deleting the file \
+             would be the only way to go back to the config:\n{raw}"
+        );
+    }
+
+    #[test]
+    fn a_corrupt_file_is_ignored_rather_than_refusing_to_start() {
+        let (path, _g) = dir("corrupt");
+        std::fs::write(&path, "this is not toml =").unwrap();
+        assert_eq!(
+            UiState::load(&path),
+            UiState::default(),
+            "mirador writes this file; a parse error is its own fault and no \
+             reason to refuse to open a dashboard"
+        );
+    }
+
+    #[test]
+    fn a_file_from_a_newer_version_does_not_wedge_an_older_one() {
+        let (path, _g) = dir("unknown-key");
+        std::fs::write(&path, "weather_units = \"metric\"\nfuture_thing = 3\n").unwrap();
+        // `deny_unknown_fields` means the whole file is rejected, which drops
+        // the preferences but still starts. Recorded as a test because the
+        // alternative — silently keeping half a file — is worse, and because
+        // the next person to add a field should know the older binary's
+        // behaviour rather than discover it.
+        assert_eq!(UiState::load(&path), UiState::default());
+    }
+
+    #[test]
+    fn saving_creates_the_directory_if_it_is_not_there_yet() {
+        let (path, _g) = dir("mkdir");
+        let nested = path.parent().unwrap().join("deeper").join("state.toml");
+        UiState {
+            todo_show_completed: Some(true),
+            ..UiState::default()
+        }
+        .save(&nested)
+        .unwrap();
+        assert!(nested.exists());
+    }
+
+    #[test]
+    fn a_save_leaves_no_temp_file_behind() {
+        let (path, _g) = dir("tmp");
+        UiState {
+            todo_sort: Some("title".into()),
+            ..UiState::default()
+        }
+        .save(&path)
+        .unwrap();
+        assert!(!path.with_extension("toml.tmp").exists());
+    }
+
+    #[test]
+    fn a_remembered_preference_reaches_the_config_a_panel_is_built_from() {
+        // The whole point, end to end: what a panel wrote must come back as the
+        // value the next run's panels are constructed with.
+        let mut config = crate::config::Config::default();
+        config.weather.units = "imperial".into();
+        config.todo.sort = "smart".into();
+        config.pomodoro.focus_minutes = 25;
+
+        config.apply_state(&UiState {
+            weather_units: Some("metric".into()),
+            todo_sort: Some("due".into()),
+            pomodoro_focus_minutes: Some(40),
+            ..UiState::default()
+        });
+
+        assert_eq!(config.weather.units, "metric");
+        assert_eq!(config.todo.sort, "due");
+        assert_eq!(config.pomodoro.focus_minutes, 40);
+    }
+
+    #[test]
+    fn an_absent_preference_leaves_the_config_alone() {
+        let mut config = crate::config::Config::default();
+        config.weather.units = "imperial".into();
+        config.apply_state(&UiState::default());
+        assert_eq!(
+            config.weather.units, "imperial",
+            "an empty state file must change nothing, or deleting it would not \
+             be a way back to the config"
+        );
+    }
+
+    #[test]
+    fn a_preference_that_no_longer_parses_is_dropped_rather_than_applied() {
+        let mut config = crate::config::Config::default();
+        config.weather.units = "imperial".into();
+        config.todo.sort = "smart".into();
+
+        // Both plausible in a file written by a future or a broken build.
+        config.apply_state(&UiState {
+            weather_units: Some("kelvin".into()),
+            todo_sort: Some("by-vibes".into()),
+            ..UiState::default()
+        });
+
+        assert_eq!(config.weather.units, "imperial");
+        assert_eq!(config.todo.sort, "smart");
+        config
+            .validate()
+            .expect("a junk state file must not produce a config that fails validation");
+    }
+
+    #[test]
+    fn a_hand_edited_duration_is_clamped_into_range() {
+        let mut config = crate::config::Config::default();
+        config.apply_state(&UiState {
+            pomodoro_focus_minutes: Some(0),
+            pomodoro_long_break_minutes: Some(99_999),
+            ..UiState::default()
+        });
+
+        assert_eq!(
+            config.pomodoro.focus_minutes, 1,
+            "zero would spin the timer"
+        );
+        assert_eq!(
+            config.pomodoro.long_break_minutes,
+            crate::widgets::pomodoro::MAX_MINUTES
+        );
+        config
+            .validate()
+            .expect("clamped durations must still satisfy validation");
+    }
+
+    #[test]
+    fn the_written_file_says_how_to_get_rid_of_it() {
+        let (path, _g) = dir("comment");
+        UiState {
+            todo_sort: Some("due".into()),
+            ..UiState::default()
+        }
+        .save(&path)
+        .unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains("Safe to delete"),
+            "someone finding this file must be told how to undo it:\n{raw}"
+        );
+    }
+}

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -59,6 +59,9 @@ pub struct ClocksPanel {
     /// Everything else, rendered as a labelled list.
     secondary: Vec<Clock>,
     show_seconds: bool,
+    /// What `show_seconds` was at construction, so `remember` can tell a user
+    /// pressing `s` from a config that merely asks for seconds.
+    seeded_show_seconds: bool,
 }
 
 impl ClocksPanel {
@@ -94,6 +97,7 @@ impl ClocksPanel {
             primary,
             secondary: clocks,
             show_seconds,
+            seeded_show_seconds: show_seconds,
         }
     }
 }
@@ -189,6 +193,12 @@ impl Panel for ClocksPanel {
             return KeyOutcome::Consumed;
         }
         KeyOutcome::Ignored
+    }
+
+    fn remember(&self, state: &mut crate::state::UiState) {
+        if self.show_seconds != self.seeded_show_seconds {
+            state.clocks_show_seconds = Some(self.show_seconds);
+        }
     }
 
     #[allow(clippy::too_many_lines)] // One panel, drawn top to bottom; the

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -5,10 +5,10 @@
 //! persisted: a timer that survived a restart would be lying about how long you
 //! have been sitting there.
 //!
-//! Durations are adjustable from the panel and last for the session, the same
-//! bargain panel resizing makes. mirador never rewrites its config, so `+` and
-//! `-` change the timer in front of you and `[pomodoro]` decides where it
-//! starts.
+//! Durations are adjustable from the panel and outlive the session: `[pomodoro]`
+//! seeds them and [`crate::state`] records where you moved since, so mirador
+//! still never rewrites the config. Only a phase you actually adjusted is
+//! remembered — see [`Panel::remember`].
 
 use std::time::{Duration, Instant};
 
@@ -35,7 +35,7 @@ const FRAME_HEIGHT: u16 = 2;
 /// Longest interval the panel will let you dial in, in minutes. Well past any
 /// real pomodoro, but a bound stops `+` held down from producing a timer that
 /// no longer fits its own display.
-const MAX_MINUTES: u64 = 180;
+pub const MAX_MINUTES: u64 = 180;
 
 /// Rows the panel needs besides the numerals: the phase label above, and the
 /// meter and pip line below.
@@ -101,6 +101,10 @@ impl Phase {
 /// A pomodoro timer panel.
 pub struct PomodoroPanel {
     config: PomodoroConfig,
+    /// The durations the panel was built with. `remember` compares against
+    /// these per phase, so lengthening a focus interval does not also pin the
+    /// break lengths you never touched into the state file.
+    seeded: PomodoroConfig,
     phase: Phase,
     /// When the current phase ends. `None` whenever the timer is not running.
     ends_at: Option<Instant>,
@@ -124,6 +128,7 @@ impl PomodoroPanel {
     pub fn new(config: PomodoroConfig) -> Self {
         let first = Duration::from_secs(config.focus_minutes * 60);
         Self {
+            seeded: config.clone(),
             config,
             phase: Phase::Focus,
             ends_at: None,
@@ -496,6 +501,18 @@ impl Panel for PomodoroPanel {
                 Paragraph::new(Line::from(spans)),
                 Rect::new(area.x, cursor, area.width, 1),
             );
+        }
+    }
+
+    fn remember(&self, state: &mut crate::state::UiState) {
+        if self.config.focus_minutes != self.seeded.focus_minutes {
+            state.pomodoro_focus_minutes = Some(self.config.focus_minutes);
+        }
+        if self.config.short_break_minutes != self.seeded.short_break_minutes {
+            state.pomodoro_short_break_minutes = Some(self.config.short_break_minutes);
+        }
+        if self.config.long_break_minutes != self.seeded.long_break_minutes {
+            state.pomodoro_long_break_minutes = Some(self.config.long_break_minutes);
         }
     }
 
@@ -907,6 +924,31 @@ mod tests {
                 binding.key
             );
         }
+    }
+
+    #[test]
+    fn only_a_duration_you_changed_is_remembered() {
+        use crate::panel::Panel as _;
+
+        let mut p = panel();
+        let mut state = crate::state::UiState::default();
+        p.remember(&mut state);
+        assert_eq!(
+            state,
+            crate::state::UiState::default(),
+            "an untouched timer must write nothing, or the config's own values \
+             get pinned into the state file and editing the config stops working"
+        );
+
+        p.adjust(1); // focus only
+        let mut state = crate::state::UiState::default();
+        p.remember(&mut state);
+        assert_eq!(state.pomodoro_focus_minutes, Some(26));
+        assert_eq!(
+            state.pomodoro_short_break_minutes, None,
+            "a break you never touched must not be pinned by adjusting focus"
+        );
+        assert_eq!(state.pomodoro_long_break_minutes, None);
     }
 
     #[test]

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -192,6 +192,10 @@ pub struct TodoPanel {
     config: TodoConfig,
     sort: SortMode,
     show_completed: bool,
+    /// What the two above were when the panel was built, so `remember` can tell
+    /// a user pressing `s` or `c` from a config that merely says so.
+    seeded_sort: SortMode,
+    seeded_show_completed: bool,
     filter: String,
     mode: Mode,
     /// Task ids in display order, recomputed whenever the list changes.
@@ -219,6 +223,8 @@ impl TodoPanel {
             config,
             sort,
             show_completed,
+            seeded_sort: sort,
+            seeded_show_completed: show_completed,
             filter: String::new(),
             mode: Mode::List,
             view: Vec::new(),
@@ -869,6 +875,15 @@ impl Panel for TodoPanel {
         if today != self.today {
             self.today = today;
             self.refresh_view();
+        }
+    }
+
+    fn remember(&self, state: &mut crate::state::UiState) {
+        if self.sort != self.seeded_sort {
+            state.todo_sort = Some(self.sort.label().to_string());
+        }
+        if self.show_completed != self.seeded_show_completed {
+            state.todo_show_completed = Some(self.show_completed);
         }
     }
 

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -184,6 +184,9 @@ pub struct WeatherPanel {
     /// round trip behind a keypress, and leave the panel showing the old unit
     /// — or nothing — until it came back.
     imperial: bool,
+    /// What `imperial` was when the panel was built, so `remember` can tell a
+    /// user pressing `u` from a config that simply says `imperial`.
+    seeded_imperial: bool,
 }
 
 /// Convert a temperature between the scales.
@@ -227,6 +230,7 @@ impl WeatherPanel {
             forecast_hours,
             stale_after,
             imperial,
+            seeded_imperial: imperial,
         }
     }
 
@@ -675,6 +679,12 @@ impl Panel for WeatherPanel {
         }
     }
 
+    fn remember(&self, state: &mut crate::state::UiState) {
+        if self.imperial != self.seeded_imperial {
+            state.weather_units = Some(if self.imperial { "imperial" } else { "metric" }.into());
+        }
+    }
+
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
         let theme = ctx.theme;
         if area.width == 0 || area.height == 0 {
@@ -923,6 +933,7 @@ mod tests {
             forecast_hours: 8,
             stale_after: Duration::from_hours(1),
             imperial,
+            seeded_imperial: imperial,
         }
     }
 


### PR DESCRIPTION
Weather units, the task sort, whether completed tasks show, seconds on the clock, and the pomodoro durations. The watchlist already did this for symbols; this generalises it, and settles the decision `CLAUDE.md` has carried as open-work item 1 since the beginning.

**The config is still never rewritten.** It seeds a setting; a small state file beside the tasks records where you moved it since. Preferences are applied over the config *before* any panel is built, so panels are constructed with the right values and none of them needs restoring code of its own.

## The hard part, and I got it wrong first

Each panel initially reported its current value. That passes a unit test and is wrong in practice: the moment any *one* preference moves, every other panel's config values get pinned into the state file — and editing the config silently stops working from then on.

Running it is what caught it. One keypress produced this:

```toml
weather_units = "metric"
todo_sort = "smart"           # never touched
todo_show_completed = false   # never touched
clocks_show_seconds = true    # never touched
pomodoro_focus_minutes = 25   # never touched
...
```

Panels now compare against the value they were **built** with — hence the `seeded_*` fields — and the app merges into what it loaded rather than starting from nothing, so a preference set last session and untouched this one is not dropped by a panel with nothing new to say. After the fix, the same keypress writes one line.

The irony is that `Panel::remember`'s own doc comment warned against exactly this before the code did it. Recorded as invariant 16.

## Trust boundaries

Values are validated on the way in, not assumed:

- a unit or sort mode that no longer parses is **discarded** and the config's value stands
- a hand-edited duration is **clamped** into range
- a state file cannot produce a config that would have been rejected coming from disk — asserted, not assumed
- a **corrupt** file is ignored rather than refusing to start: mirador writes this file, so a parse error is its own fault, and refusing to open a dashboard over a remembered sort order is wildly disproportionate. The config keeps strict parsing precisely because *that* error is a person's to fix.

The written file says `Safe to delete` in its own header, because a preference you cannot remember setting needs an obvious way out.

## Deliberately excluded

**Panel sizes.** `Ctrl+arrow` resizing is geometry rather than preference — same vocabulary as `[layout]` — and remembering it would mean a saved width quietly overruling a layout you had since edited by hand. Session-only until that conflict has an answer, and the reasoning is in `state.rs` rather than left to be rediscovered.

## Verified in a real terminal

With `HOME` redirected so nothing touched a real state file:

1. config says `imperial`, press `u` → state file contains exactly `weather_units = "metric"`
2. quit and relaunch → weather shows **24°C**, while the untouched task sort still reads `by smart` from the config

Plus 12 new tests in `state.rs` and one in `pomodoro.rs` pinning the seeded-comparison behaviour.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (374 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`.

## Still queued

Julian has asked for two more, which are separate diffs: shrinking the pomodoro panel's footprint, and turning on `dist`'s updater scripts.