### PR TITLE
Stop the pomodoro panel claiming a hundred columns for a five-character clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The pomodoro panel stops claiming space it cannot use. It declared a maximum
+  of 102 columns and 21 rows — the width of the numerals at the largest scale
+  the clock allows — and on a wide terminal it took them, from the task list.
+  The numerals are now capped at the scale where `MM:SS` is 38 columns by 5
+  rows, which is already a chunky readout; scale 2 is 68 columns and scale 3 is
+  98, and a timer occupying half a dashboard reads as an alarm rather than an
+  instrument. The panel now declares 42 by 10 and hands everything past that to
+  a neighbour, and the figures are pinned by a test so they cannot drift back.
 - The README says what happens when you upgrade. A new widget does not appear
   in a config you already have — mirador never rewrites your config, which is
   what makes it safe to hand-edit, so a config written by an earlier version

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ a row in `[layout]` and give the row's other panels room for it:
 
 ```toml
   { height = 42, panels = [
-    { widget = "todo",     width = 44 },
+    { widget = "todo",     width = 48 },
     { widget = "notes",    width = 30 },
-    { widget = "pomodoro", width = 26 },   # the new one
+    { widget = "pomodoro", width = 22 },   # the new one
   ] },
 ```
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -43,12 +43,12 @@ rows = [
     { widget = "weather",  width = 40 },
   ] },
   { height = 42, panels = [
-    { widget = "todo",     width = 44 },
+    { widget = "todo",     width = 48 },
     { widget = "notes",    width = 30 },
     # The timer draws block numerals when it has the width for them and falls
     # back to plain text when it does not, so a narrow terminal loses the
     # spectacle rather than the time.
-    { widget = "pomodoro", width = 26 },
+    { widget = "pomodoro", width = 22 },
   ] },
   { height = 24, panels = [
     { widget = "stocks",  width = 40 },

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,7 +97,7 @@ impl Default for Layout {
         Self {
             rows: vec![
                 row(34, &[("clocks", 26), ("calendar", 34), ("weather", 40)]),
-                row(42, &[("todo", 44), ("notes", 30), ("pomodoro", 26)]),
+                row(42, &[("todo", 48), ("notes", 30), ("pomodoro", 22)]),
                 row(24, &[("stocks", 40), ("cpu", 30), ("network", 30)]),
             ],
         }

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -24,9 +24,15 @@ use crate::frame::Binding;
 use crate::glyphs::{self, BigText};
 use crate::panel::{KeyOutcome, Panel, RenderContext};
 
-/// The numerals stop being easier to read past this, and a timer that fills the
-/// panel edge to edge reads as an alarm rather than as an instrument.
-const MAX_SCALE: u16 = 3;
+/// The numerals are never drawn larger than this.
+///
+/// One, deliberately. `MM:SS` at scale 1 is 38 columns by 5 rows, which is
+/// already a chunky readout and is as much as this panel is worth — scale 2 is
+/// 68 columns and scale 3 is 98, and a timer occupying half a dashboard reads
+/// as an alarm rather than as an instrument. Capping the scale is also what
+/// makes `max_width` small enough to matter: without it the panel claims 102
+/// columns it cannot use, and takes them from the task list next door.
+const MAX_SCALE: u16 = 1;
 /// Left and right border plus one column of padding each side.
 const FRAME_WIDTH: u16 = 4;
 /// Top and bottom border.
@@ -365,14 +371,18 @@ impl Panel for PomodoroPanel {
     }
 
     fn max_width(&self) -> Option<u16> {
-        // Past the width the numerals need at full scale, more columns only
-        // pad the sides. The status line under them is shorter than this.
+        // 42 columns: the numerals plus the frame. Everything else the panel
+        // draws is narrower, so past this the extra only pads the sides — and
+        // a timer is a small fact. The surplus goes to the task list, which
+        // can always use another column.
         Some(glyphs::width_of("00:00", MAX_SCALE) + FRAME_WIDTH)
     }
 
     fn max_height(&self) -> Option<u16> {
-        // Label, numerals, meter, pips, and one blank line holding them apart.
-        Some(5 * MAX_SCALE + 4 + FRAME_HEIGHT)
+        // Label, numerals, meter, pip line, and the frame. Nothing here scrolls
+        // or scales, so a taller panel is pure empty space; declaring the
+        // ceiling lets a row hand it downward instead.
+        Some(1 + 5 * MAX_SCALE + 2 + FRAME_HEIGHT)
     }
 
     fn refresh_interval(&self) -> Duration {
@@ -924,6 +934,33 @@ mod tests {
                 binding.key
             );
         }
+    }
+
+    #[test]
+    fn the_panel_claims_only_the_space_it_can_actually_use() {
+        use crate::panel::Panel as _;
+        let p = panel();
+
+        // Pinned as figures rather than as a formula, so a change to either has
+        // to be deliberate. A timer is a small fact and should not be sized like
+        // the thing you are working on: at scale 3 this declared 102 columns and
+        // 21 rows, and took them from the task list.
+        assert_eq!(p.max_width(), Some(42));
+        assert_eq!(p.max_height(), Some(10));
+
+        // And what it declares must be enough to draw what it draws.
+        let time = "88:88";
+        let scale = clock_scale(time, 42 - FRAME_WIDTH, 10 - FRAME_HEIGHT - LABEL_AND_FOOTER);
+        assert!(
+            scale.is_some(),
+            "the declared width must fit the numerals, or the panel caps itself \
+             into its own plain-text fallback"
+        );
+        assert_eq!(
+            LABEL_AND_FOOTER + clock_rows(time, scale) + FRAME_HEIGHT,
+            10,
+            "the declared height must be exactly what the rows add up to"
+        );
     }
 
     #[test]


### PR DESCRIPTION
It declared a maximum of **102 columns and 21 rows** — what `MM:SS` needs at the largest scale the clock uses — and on a wide terminal the layout gave it them, out of the task list's share.

| Scale | Numerals |
| --- | --- |
| 1 | 38 × 5 |
| 2 | 68 × 10 |
| 3 | 98 × 15 |

Scale 1 is already a chunky readout. A timer is a small fact and should not be sized like the thing you are working on, so the scale is capped there and the panel now declares **42 × 10** — the numerals plus the frame, and the rows it actually draws. Everything past that goes to a neighbour that can use it.

## Two figures doing different jobs

The **cap** stops the panel growing on a wide screen. The **layout weight** decides what it gets on a narrow one, and comes down 26 → 22.

18 was tried first and was too far: at 200 columns it left the panel below the 42 the numerals need, so it fell back to plain text and lost the thing worth looking at. 22 lands just above the cap.

Before and after at 200 columns — the task list is the visible winner:

```
before:  ╭┤4 Tasks├────────── 86 ──────────╮╭┤5 Notes├── 60 ──╮╭┤6 Pomodoro├── 52 ──╮
after:   ╭┤4 Tasks├────────── 95 ──────────╮╭┤5 Notes├── 58 ──╮╭┤6 Pomodoro├─ 42 ─╮
```

## Pinned, not derived

Both figures are asserted as numbers rather than recomputed from the same formula the code uses, so a change has to be deliberate. The test also checks the declared width can actually seat the numerals — a cap one column too low would quietly trap the panel in its own plain-text fallback, which reads fine in a diff and looks broken on screen.

## Verified

Rendered under tmux at 200×44 before and after. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (375 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`.