### PR TITLE
Ship an updater beside the binary for people who installed without a package manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mirador-update`, installed beside the binary by the shell and PowerShell
+  installers. It asks GitHub for the newest release and installs it if that is
+  newer, so upgrading no longer means going back to the releases page. It runs
+  only when invoked: mirador itself never checks for updates and does not know
+  the program exists, which keeps the "no telemetry" line in the README exactly
+  as true as it was. Anyone who installed with `cargo install` or from source
+  upgrades the way they installed.
 - **Settings changed from the keyboard are remembered across restarts.**
   Weather units, the task sort order, whether completed tasks show, seconds on
   the clock, and the pomodoro durations. The watchlist already did this for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,10 @@ installers = ["shell", "powershell"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Checksums to generate for each App
 checksum = "sha256"
-# Whether to install an updater program
-install-updater = false
+# Ship the standalone updater alongside the shell and PowerShell installers, so
+# someone who installed without a package manager can run `mirador-update`
+# rather than going back to the releases page. It only ever runs when invoked.
+install-updater = true
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # The archive format to use for windows builds (defaults .zip)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Both fetch the right archive for your platform, check it against its published
 checksum, and unpack the binary. If you would rather read the script before
 running it, it is an ordinary file at that URL, and the manual route is below.
 
+They also install `mirador-update` beside it, so a later upgrade is:
+
+```sh
+mirador-update
+```
+
+It asks GitHub what the newest release is and installs it if that is newer than
+what you have. It runs **only when you run it** — mirador itself never checks
+for updates, never phones home, and does not know this program exists. If you
+installed with `cargo install` or from source, upgrade the same way you
+installed; the updater is only for the two installers above.
+
 From source:
 
 ```sh


### PR DESCRIPTION
`dist`'s `install-updater` puts **`mirador-update`** next to the binary when the shell or PowerShell installer is used, so upgrading is one command rather than a trip back to the releases page.

`dist plan` now produces a `mirador-<target>-update` per platform:

```
mirador-aarch64-apple-darwin-update
mirador-x86_64-apple-darwin-update
mirador-x86_64-pc-windows-msvc-update
mirador-x86_64-unknown-linux-gnu-update
```

Anyone who installed with `cargo install`, from source, or eventually through a package manager upgrades the way they installed. The updater is only for the two installers that have no other mechanism.

## Being precise about "no telemetry"

The README makes that claim, so this deserves stating rather than leaving a reader to work out:

- it is a **separate program** that runs **only when you run it**
- it asks GitHub what the newest release is, and installs it if that is newer
- **mirador itself never checks for updates**, never contacts anything it was not configured to, and does not know this program exists

The claim stays exactly as true as it was, and the README now says so explicitly next to the install command.

## `release.yml` is unchanged

Worth noting since `dist` owns that file: the updater is the *installers'* business, and those are generated at release time from the config rather than baked into the workflow. Only `Cargo.toml` changed, and `dist generate --check` is silent — the committed workflow and the manifest still agree.

## Verified

`cargo fmt --check`, `cargo test` (375 pass), `dist plan`, `dist generate --check`, and `cargo package --list` still at 42 files with nothing new leaking into the published crate.

Nothing here can be fully proven until a release actually goes out, since the installers are generated then. That is the same caveat the Windows binaries had, and it is worth an eye on the first `mirador-update` run after the next tag.