### PR TITLE
Release 0.3.0: pomodoro panel, remembered preferences, an updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-07-25
 
 ### Added
 
@@ -392,6 +392,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jchultarsky/mirador/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jchultarsky/mirador/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jchultarsky/mirador/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Minor rather than patch — a new panel, a new persistence mechanism, and a new program installed beside the binary. Any one of them would have earned it.

- `Cargo.toml` and `Cargo.lock` to `0.3.0`
- `[Unreleased]` stamped as `[0.3.0] - 2026-07-25`, with compare links

## What ships

**Pomodoro panel** — a focus timer in the clock's block numerals, with an optional chime that is off by default and rings the terminal bell rather than dragging in an audio stack.

**Remembered preferences** — weather units, task sort, completed-visibility, clock seconds and pomodoro durations survive a restart, in a state file that the config seeds and never gets rewritten by. This settles `CLAUDE.md` open-work item 1.

**`mirador-update`** — installed by the shell and PowerShell installers, run only when invoked.

Plus a first-run that is no longer blank, Windows binaries, and the pomodoro panel no longer claiming 102 columns for a five-character clock.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (375 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`, `cargo publish --dry-run`, `dist plan` announcing `v0.3.0`, and `dist generate --check` silent.

Once merged: tag `v0.3.0`, let the workflow build all four targets, verify the artifacts and the updater, then `cargo publish`.

This is the first release where the installers and `mirador-update` actually get generated, so those are worth checking rather than assuming.