### PR TITLE
Release 0.3.1: stop the published README contradicting its own screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-25
+
+### Fixed
+
+- The README on crates.io no longer contradicts its own screenshot. The image
+  is referenced by absolute URL so that it resolves on crates.io as well as
+  GitHub — which means it tracks `main` and updated the moment a new capture
+  landed, while the caption around it stayed frozen at whatever the last
+  publish baked in. The published page ended up showing the pomodoro panel
+  above a caption explaining that the shot predates it. The alt text was stale
+  for the same reason, which matters more, since a screen reader has only that.
+
+  Worth knowing for any future image: a floating URL and fixed prose drift
+  apart by design, so a caption describing the picture has to ship in the same
+  release as the picture.
+
 ## [0.3.0] - 2026-07-25
 
 ### Added
@@ -392,7 +408,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/jchultarsky/mirador/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jchultarsky/mirador/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jchultarsky/mirador/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jchultarsky/mirador/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,16 @@ inline `[theme]` table from a `theme = "name"` string).
 
 ## Housekeeping
 
+- **The README's images float; its prose does not.** `docs/screenshot.png` is
+  referenced by absolute `raw.githubusercontent.com/.../main/...` URL, because
+  `Cargo.toml` excludes `/docs` and `*.png` and a relative path would render on
+  GitHub and 404 on crates.io. The consequence is easy to miss: replacing the
+  capture updates it on *every* published version at once, while the caption
+  and alt text around it stay frozen at whatever each release baked in. 0.3.0
+  spent an hour showing the pomodoro panel above a caption explaining that the
+  shot predated it. A caption that describes the picture has to ship in the
+  same release as the picture.
+
 - Originally built in a Linux container, where `sysinfo`'s macOS CPU and network
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows remains untested.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Patch, and docs-only — no source changed from 0.3.0.

## The problem, which only appears after publishing

The README's image is referenced by absolute URL so it resolves on crates.io as well as GitHub. That means it tracks `main` and updated the moment the new capture landed. **The prose around it did not.**

crates.io went on rendering 0.3.0's caption:

> *…This one predates the pomodoro panel, which is shown further down.*

directly beneath a picture with the pomodoro panel plainly in it. Verified against the live page rather than reasoned about:

```
$ curl -sL .../api/v1/crates/mirador/0.3.0/readme | grep -o "predates the pomodoro panel[^<]*"
predates the pomodoro panel, which is shown

$ ... | grep -o '<img[^>]*screenshot[^>]*>'
<img src="https://raw.githubusercontent.com/.../main/docs/screenshot.png" alt="...the task list and notes, and a market watchlist...">
```

The **alt text** was stale the same way, and that matters more: a sighted reader can see the contradiction and dismiss it, while a screen reader user has only the description, which omits a panel that is there.

## Recorded, not just fixed

A floating image and fixed prose drift apart *by design*, and the next capture will do this again unless whoever replaces it ships the caption in the same release. That is now in `CLAUDE.md` under Housekeeping, with the specific failure spelled out.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (375 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`, `cargo publish --dry-run`, `dist plan` announcing `v0.3.1`, `dist generate --check` silent.

Once merged: tag `v0.3.1`, then `cargo publish` — the publish is the point, since the GitHub page has been correct since the screenshot merged and only crates.io is stale.