### PR TITLE
Windows works: say so, and stop listing it as open work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Windows is described as working rather than as untried. The binary shipped in
+  0.2.0 was built and packaged but had never been started on the platform, and
+  the docs said so; it has now been run and works. All three shipped targets
+  have been started rather than merely compiled. It is still the
+  least-travelled of the three, which the README says instead of claiming a
+  parity nobody has earned.
+
 ## [0.3.1] - 2026-07-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,11 +357,6 @@ inline `[theme]` table from a `theme = "name"` string).
    date grid only, deliberately offline; events are a separate, larger panel.
 3. Theme system per above.
 4. "What changed since I last looked" markers.
-5. **Run mirador on Windows.** It is built for `x86_64-pc-windows-msvc` now,
-   but nobody has started it there. Nothing in this crate is Unix-specific and
-   the dependencies are cross-platform, so the risk is behavioural rather than
-   structural: terminal resize, the alternate screen, and whether the mouse
-   capture trade-off reads the same in Windows Terminal.
 
 ## Housekeeping
 
@@ -377,7 +372,8 @@ inline `[theme]` table from a `theme = "name"` string).
 
 - Originally built in a Linux container, where `sysinfo`'s macOS CPU and network
   paths went unexercised. Both have since been run on macOS against a real
-  terminal under `tmux` and report sensible figures. Windows remains untested.
+  terminal under `tmux` and report sensible figures. Windows has since been run
+  too — see the platform note below.
 - **`0.1.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64 and Linux x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
@@ -409,12 +405,17 @@ inline `[theme]` table from a `theme = "name"` string).
   255) and its own prerelease detection from the semver hyphen, which is why
   the hand-written versions of both were dropped when it took the file over.
 
-- **Windows is built but unexercised**; `aarch64-pc-windows-msvc` is
-  deliberately absent because `ring`, reached through `ureq`'s TLS, does not
-  build for it. musl is absent for the same C-toolchain reason. `ring` is also
-  why the Windows target cannot be cross-checked from macOS — `cargo check
-  --target x86_64-pc-windows-msvc` fails locally on `cc`, and that is the host
-  missing MSVC rather than anything wrong with the code.
+- **Windows runs**, confirmed by the owner on 25 July 2026 — so all three
+  shipped targets have now been started, not merely built. Treat it as the
+  least-travelled of the three rather than as unknown: macOS and Linux are used
+  daily and Windows has been checked once.
+
+  `aarch64-pc-windows-msvc` is deliberately absent because `ring`, reached
+  through `ureq`'s TLS, does not build for it. musl is absent for the same
+  C-toolchain reason. `ring` is also why the Windows target cannot be
+  cross-checked from macOS — `cargo check --target x86_64-pc-windows-msvc`
+  fails locally on `cc`, and that is the host missing MSVC rather than anything
+  wrong with the code.
 
 - macOS notarization is unsupported by `dist` and does not matter here:
   Gatekeeper's quarantine flag comes from browsers, not `curl`, so

--- a/README.md
+++ b/README.md
@@ -115,10 +115,9 @@ Get-Content .\mirador-x86_64-pc-windows-msvc.zip.sha256
 
 Requires Rust 1.95 or newer to build from source.
 
-**On Windows**, the binary is built but not yet exercised — everything under
-it is cross-platform (`crossterm` for the terminal, `sysinfo` for the
-metrics), and nothing in mirador is Unix-specific, but "compiles" and "behaves"
-are different claims and only the first has been checked. Reports welcome.
+**Windows** has been run and works. It is still the least-travelled of the
+three — macOS and Linux are used daily and Windows has been checked rather
+than lived in — so a report of something off there is genuinely useful.
 Windows on ARM is deliberately absent: `ring`, reached through `ureq`'s TLS,
 does not build for it.
 


### PR DESCRIPTION
The binary shipped in 0.2.0 was built and packaged but had never been *started* on the platform, and the docs were deliberately careful to claim only the first. Julian has now run it on Windows and it works, so all three shipped targets have been started rather than merely compiled.

## Described as least-travelled, not as equal

macOS and Linux are used daily; Windows has been checked once. Claiming parity nobody has earned is how the previous overstatement would have happened in the other direction, so the README says exactly that and keeps the invitation to report something off.

## Removed and rewritten, not deleted

- Open-work item 5 ("Run mirador on Windows") is gone.
- The housekeeping note that called it unexercised is **rewritten rather than removed**, because the surrounding facts it carried are still true and still worth having: why `aarch64-pc-windows-msvc` and musl are absent (`ring`, reached through `ureq`'s TLS, does not build for either), and why the Windows target cannot be cross-checked from a Mac (`cargo check --target x86_64-pc-windows-msvc` dies in `cc` — the host missing MSVC, not a code problem).
- The older "Windows remains untested" line further up now points at that note instead of contradicting it.

## No release needed

Docs only, and unlike [#24](https://github.com/jchultarsky/mirador/pull/24) this does not leave the published page self-contradicting — crates.io will carry a caveat that is *over*-cautious rather than wrong, which costs a Windows reader some confidence and nothing else. It can ride along with the next release that has a reason of its own.

`cargo fmt --check`, `cargo test` (375 pass), `cargo doc` with `-D warnings`.