### PR TITLE
Record how Windows was actually installed and run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Windows is described as working rather than as untried. The binary shipped in
   0.2.0 was built and packaged but had never been started on the platform, and
-  the docs said so; it has now been run and works. All three shipped targets
-  have been started rather than merely compiled. It is still the
-  least-travelled of the three, which the README says instead of claiming a
-  parity nobody has earned.
+  the docs said so; it has now been run and works, installed with the PowerShell
+  one-liner in the default Windows terminal. All three shipped targets have been
+  started rather than merely compiled, and that is also the first real-world use
+  of the PowerShell installer — the rest had only been checked from macOS. It is
+  still the least-travelled of the three, which the README says instead of
+  claiming a parity nobody has earned.
 
 ## [0.3.1] - 2026-07-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,12 @@ inline `[theme]` table from a `theme = "name"` string).
   least-travelled of the three rather than as unknown: macOS and Linux are used
   daily and Windows has been checked once.
 
+  That run also came through the **PowerShell installer** (`irm … | iex`) in
+  the default Windows terminal, which is the first real-world exercise of that
+  path — everything else about the installers had only been checked from macOS.
+  `mirador-update` is installed alongside by the same installer but has not been
+  run on Windows; the macOS one has.
+
   `aarch64-pc-windows-msvc` is deliberately absent because `ring`, reached
   through `ureq`'s TLS, does not build for it. musl is absent for the same
   C-toolchain reason. `ring` is also why the Windows target cannot be

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ Get-Content .\mirador-x86_64-pc-windows-msvc.zip.sha256
 
 Requires Rust 1.95 or newer to build from source.
 
-**Windows** has been run and works. It is still the least-travelled of the
-three — macOS and Linux are used daily and Windows has been checked rather
-than lived in — so a report of something off there is genuinely useful.
-Windows on ARM is deliberately absent: `ring`, reached through `ureq`'s TLS,
-does not build for it.
+**Windows** has been run and works — installed with the PowerShell one-liner
+above, in the default Windows terminal. It is still the least-travelled of the
+three: macOS and Linux are used daily and Windows has been checked rather than
+lived in, so a report of something off there is genuinely useful. Windows on
+ARM is deliberately absent: `ring`, reached through `ureq`'s TLS, does not
+build for it.
 
 ## Quick start
 


### PR DESCRIPTION
"Works on Windows" was the useful half of the report. The other half is that it arrived through the **PowerShell installer**, in the default Windows terminal.

That is the first real-world use of `irm … | iex`. Every other check of the installers was run from macOS against the shell script, so the PowerShell path had never been exercised by anyone — and an install path nobody has used is the one most likely to be broken.

Both facts are worth pinning rather than summarising away. A terminal emulator is where a TUI's differences actually show, and the installer is the only part of a release that cannot be verified before the release exists.

## Also noted, because it is the obvious next question

`mirador-update` is installed alongside by the same installer but **has not been run on Windows**. The macOS one has. Recorded as a known gap rather than left to be assumed either way.

`cargo fmt --check`, `cargo test` (375 pass). Docs only; no release needed, same reasoning as [#25](https://github.com/jchultarsky/mirador/pull/25).