### PR TITLE
Add a panel picker, and write layout changes back to the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A panel picker.** `w` opens a dialog listing every widget with whether it is
+  on; `space` toggles, and the panel appears or disappears immediately.
+  Switching a widget on used to mean finding your config file and editing
+  `[layout]` by hand — which is what the first person to meet the pomodoro
+  panel actually had to do, after pressing `?` and not finding the answer there
+  either. The status bar notice and the help overlay both name the key now.
+
+  Panel sizes are remembered too: `Ctrl+arrow` no longer lasts only for the
+  session.
+
 ### Changed
 
+- **Layout changes are written back into your config**, reversing an earlier
+  decision to keep them out of it. The rule was never really "do not write to
+  the config" — it was "do not *reserialise* it", because a round trip through
+  `toml` discards every comment in the file, including the ~145 mirador wrote to
+  explain its own options. `--migrate-config` had already established the
+  alternative: edit the lines that need editing and leave the rest alone.
+
+  So `[layout]` is edited surgically. Adding a panel is a one-line diff; a width
+  change rewrites one number and keeps its column alignment; comments inside the
+  layout block survive.
+
+  The safety property is a check rather than care: the edited text is parsed and
+  compared against the layout that was asked for, and a mismatch throws the edit
+  away. An unusually formatted config fails as "that did not stick", said in the
+  picker, rather than as a broken file.
+
+  Preferences that are not layout stay in the state file. The split is by what
+  the setting *is*: `[layout]` is the part of the config people read and curate,
+  so a change made in the UI has to show up there, while nobody keeps their
+  preferred sort order under version control.
 - Windows is described as working rather than as untried. The binary shipped in
   0.2.0 was built and packaged but had never been started on the platform, and
   the docs said so; it has now been run and works, installed with the PowerShell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ glyphs.rs    block numerals, bold-uppercase labels, weather art
 theme.rs     colours and gradient stops
 config.rs    TOML config, validation, default file
 migrate.rs   textual in-place upgrade of configs written by older versions
+layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
 state.rs     UI-changed preferences, remembered across restarts
 task.rs      task model + atomic TOML store
 note.rs      note model + atomic TOML store
@@ -186,7 +187,23 @@ Adding a widget: implement `Panel`, add a config struct, add the name to
     while a list next door runs out. Return `None` for anything that scrolls or
     scales; return a figure only when more space genuinely buys the reader
     nothing. Both are whole-panel measurements, frame and padding included.
-16. **A panel remembers only what the user changed.** `Panel::remember` writes
+16. **The config is edited, never reserialised.** This is the real form of the
+    "never rewrites the config" rule, which was always about comments: a round
+    trip through `toml` discards all ~145 of them, including the ones mirador
+    wrote to explain its own options. `migrate.rs` established the alternative
+    and `layout_edit.rs` follows it — find the line, change that line, leave
+    everything else alone. Adding a panel is a one-line diff.
+
+    What makes it safe to do at all is the check at the end of
+    `layout_edit::apply`: the edited text is parsed and compared against the
+    layout that was requested, and a mismatch throws the edit away. So an
+    unusually formatted config fails as "your change did not stick", reported
+    in the picker, rather than as a mangled file.
+
+    The split is by *what*, not by convenience: `[layout]` goes to the config
+    because people read and curate it, and everything else goes to `state.rs`
+    because nobody keeps their preferred sort order under version control.
+17. **A panel remembers only what the user changed.** `Panel::remember` writes
     a preference only when it differs from the value the panel was *built*
     with, which is why every such panel keeps a `seeded_*` copy. Reporting the
     current value unconditionally looks identical in a unit test and is wrong
@@ -198,7 +215,7 @@ Adding a widget: implement `Panel`, add a config struct, add the name to
     The app merges into what it loaded rather than starting from nothing, so a
     preference set last session and untouched this one is not dropped by a
     panel that has nothing new to say about it.
-17. **First run must not be blank, and the defaults must agree.** The task and
+18. **First run must not be blank, and the defaults must agree.** The task and
     notes stores seed examples via `load_or_seed`, keyed on the file being
     *absent* — never on it being empty, or deleting the examples would not
     stick. The seeded titles are instructions, so they have to fit the task

--- a/README.md
+++ b/README.md
@@ -155,55 +155,75 @@ Some settings you change with a keystroke are remembered across restarts:
 | Seconds on the clock | `s` | Clock |
 | Pomodoro durations | `+` / `-` | Pomodoro |
 | Watchlist symbols | `a` / `d` | Markets |
+| Which panels are shown | `w` | — |
+| Panel sizes | `Ctrl+arrow` | — |
 
-**mirador never rewrites your config.** That is what makes it safe to
-hand-edit and keep in git, so these live in a small state file beside your
-tasks instead. The config *seeds* a setting; the state file records where you
-moved it since.
+They go to two different places, and the split is deliberate.
 
-Only what you actually changed is written. Pressing `u` records the units and
-nothing else, so editing any other value in your config still takes effect —
-if mirador wrote everything, the first keystroke would silently freeze the
-rest of your config in place. Delete the state file and every remembered
-setting falls back to what the config says; it is listed at the top of the
-file itself, because a preference you cannot remember setting needs an obvious
-way back.
+**Anything to do with `[layout]` is written back into your config** — which
+panels exist, and how wide they are. That is the part of the file you actually
+read and curate, so a change you make with `w` has to show up there or your
+config would end up describing a dashboard nobody is looking at.
 
-Panel sizes are the deliberate exception. `Ctrl+arrow` resizing lasts for the
-session only: it is geometry rather than preference, in the same vocabulary as
-`[layout]`, and remembering it would mean a saved width quietly overruling a
-layout you had since edited by hand.
+The edit is surgical, never a reserialise: mirador rewrites the one line it has
+to and leaves your comments, spacing and ordering exactly as they were. Adding
+a panel is a one-line diff. If your `[layout]` is formatted in a way it cannot
+edit confidently, it says so in the picker and changes nothing rather than
+guessing — the failure mode is "that did not stick", not a mangled config.
+
+**Everything else goes to a small state file** beside your tasks, and only what
+you actually changed is written. Pressing `u` records the units and nothing
+else, so editing any other value in your config still takes effect. Delete that
+file and every remembered setting falls back to what the config says; it says
+so at the top of itself, because a preference you cannot remember setting needs
+an obvious way back.
 
 ### Upgrading
 
-**A new widget will not appear in a config you already have.** mirador never
-rewrites your config — that is what makes it safe to hand-edit and keep in git
-— so a config written by an earlier version lays out exactly the panels that
-existed when it was written, and nothing since. Leaving a panel out is a
-legitimate choice, so this cannot be an error and cannot be fixed for you.
+**A new widget will not appear in a config you already have.** A config written
+by an earlier version lays out exactly the panels that existed when it was
+written, and nothing since. Leaving a panel out is a legitimate choice, so this
+cannot be an error and cannot be decided for you.
 
-What you get instead is a notice on the right of the status bar naming what
-your layout does not place:
+You get a notice on the right of the status bar naming what your layout does
+not place, and telling you which key fixes it:
 
 ```
- mirador   Tab focus   ? keys   q quit          1 unused: pomodoro   ? for help
+ mirador   Tab focus   ? keys   q quit   w panels        1 unused: pomodoro   press w
 ```
 
 It retires on your first keypress, because a dashboard you leave open all day
-must not nag; `?` keeps it in the help overlay. To take a widget up, add it to
-a row in `[layout]` and give the row's other panels room for it:
+must not nag; `?` keeps it in the help overlay. Press `w` and you get the
+picker:
 
-```toml
-  { height = 42, panels = [
-    { widget = "todo",     width = 48 },
-    { widget = "notes",    width = 30 },
-    { widget = "pomodoro", width = 22 },   # the new one
-  ] },
+```
+╭PANELS────────────────────────────────╮
+│    ■ clocks                          │
+│    ■ weather                         │
+│    ■ todo                            │
+│    ■ notes                           │
+│    ■ stocks                          │
+│    ■ calendar                        │
+│  ▸ □ pomodoro                        │
+│    ■ cpu                             │
+│    ■ network                         │
+│                                      │
+│   written to your config on close    │
+│   space toggle   esc close           │
+╰──────────────────────────────────────╯
 ```
 
-`mirador --print-config` prints the current default in full if you would rather
-copy a whole row, and `mirador --migrate-config` rewrites keys that were
-renamed between versions, leaving a backup beside the original.
+`space` toggles, `↑`/`↓` or `j`/`k` move, `esc` closes. A panel appears or
+disappears the moment you toggle it, and the change is written to your config
+when you close the dialog — as a one-line edit, with your comments untouched.
+A new panel joins the row carrying the fewest panels; `Ctrl+arrow` moves the
+space around afterwards, and that is written too.
+
+The last panel cannot be switched off, because a layout with nothing in it is
+rejected at startup and would leave you with a config that will not open.
+
+`mirador --migrate-config` is still there for keys renamed between versions,
+and leaves a backup beside the original.
 
 ## The panels
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -3,11 +3,15 @@
 # This file was created automatically on first run. Every value below is a
 # default, so you can delete anything you do not want to override.
 #
-# mirador never rewrites this file, so it is safe to hand-edit and to keep in
-# version control. Settings you change with a keystroke — weather units, the
-# task sort, seconds on the clock, pomodoro durations — are remembered in a
-# separate state file beside your tasks, which records only what you actually
-# changed. Delete that file and everything falls back to what is written here.
+# mirador edits this file surgically and never reserialises it: switching a
+# panel on with `w`, or resizing one with Ctrl+arrow, rewrites the one line it
+# has to and leaves your comments, spacing and ordering exactly as they were.
+# So it stays safe to hand-edit and to keep in version control.
+#
+# Preferences that are not layout — weather units, the task sort, seconds on
+# the clock, pomodoro durations — live in a separate state file beside your
+# tasks, which records only what you actually changed. Delete it and they fall
+# back to what is written here.
 #
 # Docs: https://github.com/jchultarsky/mirador#configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,11 @@ const GLOBAL: &[Binding] = &[
     Binding::primary("Tab", "focus"),
     Binding::primary("?", "keys"),
     Binding::primary("q", "quit"),
+    // After `quit` deliberately. The status bar shows as many primary bindings
+    // as fit, in order, and on a narrow terminal knowing how to get out beats
+    // knowing how to add a panel. The unused-widget notice names this key
+    // anyway, which is where someone actually needs to be told about it.
+    Binding::primary("w", "panels"),
     Binding::extra("Shift+Tab", "focus back"),
     Binding::extra("1-9", "jump to panel"),
     Binding::extra("Ctrl+←/→", "resize width"),
@@ -147,6 +152,9 @@ fn neighbour_of(index: usize, len: usize) -> Option<usize> {
     }
 }
 
+/// The panels of a layout, with the `(row, column)` each came from.
+type Built = (Vec<Slot>, Vec<(usize, usize)>);
+
 /// A panel plus its tick bookkeeping.
 struct Slot {
     panel: Box<dyn Panel>,
@@ -158,6 +166,11 @@ struct Slot {
 }
 
 /// The running dashboard.
+///
+/// The flags are genuinely independent — an overlay being open says nothing
+/// about whether the layout needs writing — so grouping them into a struct to
+/// satisfy the lint would add a name without adding a meaning.
+#[allow(clippy::struct_excessive_bools)]
 pub struct App {
     config: Config,
     gradients: Gradients,
@@ -180,6 +193,16 @@ pub struct App {
     /// of any kind: a dashboard you leave open all day must not nag, and a
     /// notice that will not go away is a nag.
     show_widget_hint: bool,
+    /// Open panel picker, and which row it is on.
+    picker: Option<usize>,
+    /// The config file, so layout changes can be written back to it. `None` in
+    /// tests, which is what keeps them off a real user's config.
+    config_path: Option<PathBuf>,
+    /// Whether the layout has been changed since it was last written.
+    layout_dirty: bool,
+    /// Why the last layout write failed, if it did. Shown in the picker: a
+    /// change you made that silently did not persist is the worst outcome here.
+    layout_error: Option<String>,
     /// Where to write remembered preferences, once someone asks for that.
     /// `None` in tests, which is what keeps them off a real user's file.
     state_path: Option<PathBuf>,
@@ -200,17 +223,42 @@ impl std::fmt::Debug for App {
 impl App {
     /// Build every panel named in the layout, in row-major order.
     pub fn new(config: Config) -> Result<Self> {
-        let mut slots = Vec::new();
+        let (slots, positions) = Self::build_slots(&config)?;
+
+        let gradients = config.theme.gradients();
+        let unused_widgets = crate::widgets::unused_widgets(&config);
+        Ok(Self {
+            config,
+            gradients,
+            slots,
+            positions,
+            focus: 0,
+            show_help: false,
+            should_quit: false,
+            show_widget_hint: !unused_widgets.is_empty(),
+            unused_widgets,
+            picker: None,
+            config_path: None,
+            layout_dirty: false,
+            layout_error: None,
+            state_path: None,
+            saved_state: UiState::default(),
+        })
+    }
+
+    /// Build one panel per entry in the layout, in row-major order.
+    fn build_slots(config: &Config) -> Result<Built> {
         // Start each panel far enough in the past that its first tick fires
         // immediately rather than one interval from now.
         let epoch = Instant::now()
             .checked_sub(Duration::from_hours(24))
             .unwrap();
 
+        let mut slots = Vec::new();
         let mut positions = Vec::new();
         for (row_index, row) in config.layout.rows.iter().enumerate() {
             for (column_index, entry) in row.panels.iter().enumerate() {
-                let panel = crate::widgets::build(&entry.widget, &config)
+                let panel = crate::widgets::build(&entry.widget, config)
                     .with_context(|| format!("building the `{}` panel", entry.widget))?;
                 if let Some(panel) = panel {
                     slots.push(Slot {
@@ -227,22 +275,28 @@ impl App {
             !slots.is_empty(),
             "no panels were built; check the `[layout]` table in your config"
         );
+        Ok((slots, positions))
+    }
 
-        let gradients = config.theme.gradients();
-        let unused_widgets = crate::widgets::unused_widgets(&config);
-        Ok(Self {
-            config,
-            gradients,
-            slots,
-            positions,
-            focus: 0,
-            show_help: false,
-            should_quit: false,
-            show_widget_hint: !unused_widgets.is_empty(),
-            unused_widgets,
-            state_path: None,
-            saved_state: UiState::default(),
-        })
+    /// Rebuild every panel after the layout changed.
+    ///
+    /// Panels are thrown away and remade rather than moved, which costs a fresh
+    /// weather fetch and an empty CPU history for the panels that survived. The
+    /// alternative is matching old panels to new positions by widget name and
+    /// carrying them across, which is a good deal more machinery for something
+    /// that happens when a person deliberately opens a dialog and toggles
+    /// something — a moment where a beat of re-fetching reads as the dashboard
+    /// responding rather than as a stall.
+    ///
+    /// A failure leaves the previous panels in place: a layout that will not
+    /// build is a reason to refuse the change, not to end up with nothing.
+    fn rebuild_panels(&mut self) -> Result<()> {
+        let (slots, positions) = Self::build_slots(&self.config)?;
+        self.slots = slots;
+        self.positions = positions;
+        self.focus = self.focus.min(self.slots.len().saturating_sub(1));
+        self.unused_widgets = crate::widgets::unused_widgets(&self.config);
+        Ok(())
     }
 
     /// Run until the user quits.
@@ -291,6 +345,9 @@ impl App {
         // Once more on the way out, in case the last thing changed was not a
         // key — and because Ctrl+C reaches here too.
         self.persist_preferences();
+        // Resizes batch to here rather than writing per keystroke: Ctrl+arrow
+        // repeats, and a config rewritten on every repeat would be absurd.
+        self.write_layout();
         Ok(())
     }
 
@@ -387,6 +444,13 @@ impl App {
             return;
         }
 
+        // The picker is a real dialog rather than a notice, so it reads keys
+        // instead of dismissing on any of them.
+        if self.picker.is_some() {
+            self.handle_picker_key(key);
+            return;
+        }
+
         // Resizing is a shell-level concern, the way it is in tmux, so it is
         // claimed before panels get a look. It has to be: the calendar binds
         // the bare arrow keys and does not inspect modifiers, so offering the
@@ -402,13 +466,108 @@ impl App {
                 KeyCode::Up => self.resize_height(false),
                 _ => return self.dispatch_key(key),
             };
+            // Only a resize that actually moved something needs writing. Held
+            // against a minimum, the key repeats without changing anything, and
+            // marking those dirty would write the config on shutdown after a
+            // session that changed nothing.
+            self.layout_dirty |= resized;
             // Swallowed either way: a resize that hit the minimum is still a
             // resize key, and must not fall through to a panel binding.
-            let _ = resized;
             return;
         }
 
         self.dispatch_key(key);
+    }
+
+    /// Drive the panel picker.
+    fn handle_picker_key(&mut self, key: KeyEvent) {
+        let names = crate::widgets::WIDGET_NAMES;
+        let Some(selected) = self.picker else { return };
+        let last = names.len().saturating_sub(1);
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q' | 'w') | KeyCode::Enter => {
+                self.picker = None;
+                // Written on close rather than on every toggle: someone trying
+                // three arrangements should cost one write, not three, and the
+                // dialog is a natural commit point.
+                self.write_layout();
+            }
+            KeyCode::Down | KeyCode::Char('j') => self.picker = Some((selected + 1).min(last)),
+            KeyCode::Up | KeyCode::Char('k') => self.picker = Some(selected.saturating_sub(1)),
+            KeyCode::Home | KeyCode::Char('g') => self.picker = Some(0),
+            KeyCode::End | KeyCode::Char('G') => self.picker = Some(last),
+            KeyCode::Char(' ') => {
+                if let Some(name) = names.get(selected) {
+                    self.toggle_widget(name);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Turn a widget on or off, rebuilding the dashboard around it.
+    fn toggle_widget(&mut self, widget: &str) {
+        let before = self.config.layout.clone();
+
+        if self.config.layout.places(widget) {
+            if !self.config.layout.remove_widget(widget) {
+                // The last panel. An empty layout is rejected at startup, so
+                // allowing this would write a config that cannot be opened.
+                self.layout_error = Some("at least one panel has to stay".into());
+                return;
+            }
+        } else {
+            self.config.layout.add_widget(widget);
+        }
+
+        if let Err(e) = self.rebuild_panels() {
+            // Put it back. A layout that will not build is a reason to refuse
+            // the toggle, not to leave the dashboard in pieces.
+            self.config.layout = before;
+            let _ = self.rebuild_panels();
+            self.layout_error = Some(format!("{e:#}"));
+            return;
+        }
+
+        self.layout_error = None;
+        self.layout_dirty = true;
+    }
+
+    /// Write the layout back into the config file, if it changed.
+    ///
+    /// Textual, so comments and formatting survive; see [`crate::layout_edit`].
+    /// A failure is kept and shown rather than swallowed — a panel you switched
+    /// on that quietly fails to persist is worse than one that never appeared,
+    /// because you will not find out until the next start.
+    fn write_layout(&mut self) {
+        if !self.layout_dirty {
+            return;
+        }
+        let Some(path) = self.config_path.clone() else {
+            return;
+        };
+
+        let result = std::fs::read_to_string(&path)
+            .map_err(anyhow::Error::from)
+            .and_then(|source| crate::layout_edit::apply(&source, &self.config.layout))
+            .and_then(|updated| std::fs::write(&path, updated).map_err(anyhow::Error::from));
+
+        match result {
+            Ok(()) => {
+                self.layout_dirty = false;
+                self.layout_error = None;
+            }
+            Err(e) => self.layout_error = Some(format!("{e:#}")),
+        }
+    }
+
+    /// Write layout changes to `path` from now on.
+    ///
+    /// Separate from [`App::new`] for the same reason the state path is: tests
+    /// build apps constantly and must not be able to touch a real config.
+    pub fn write_layout_to(&mut self, path: PathBuf) {
+        self.config_path = Some(path);
     }
 
     /// Offer a key to the focused panel, then to the global bindings.
@@ -431,6 +590,7 @@ impl App {
             KeyCode::Tab => self.cycle_focus(true),
             KeyCode::BackTab => self.cycle_focus(false),
             KeyCode::Char('?') => self.show_help = true,
+            KeyCode::Char('w') => self.picker = Some(0),
             KeyCode::Char(c @ '1'..='9') => {
                 let index = c as usize - '1' as usize;
                 if index < self.slots.len() {
@@ -733,6 +893,9 @@ impl App {
         if self.show_help {
             self.render_help(frame, area);
         }
+        if let Some(selected) = self.picker {
+            self.render_picker(frame, area, selected);
+        }
     }
 
     /// The status bar carries *global* bindings only.
@@ -786,11 +949,101 @@ impl App {
         if !self.show_widget_hint || self.unused_widgets.is_empty() {
             return None;
         }
+        // Names the key rather than only the widgets. Saying what is missing
+        // without saying what to do about it is how someone ends up reading the
+        // help, not finding the answer there either, and going to look for a
+        // config file.
         Some(format!(
-            "{} unused: {}   ? for help ",
+            "{} unused: {}   press w ",
             self.unused_widgets.len(),
             self.unused_widgets.join(", ")
         ))
+    }
+
+    /// The panel picker: every widget mirador has, and whether it is on.
+    fn render_picker(&self, frame: &mut ratatui::Frame, area: Rect, selected: usize) {
+        let theme = &self.config.theme;
+        let names = crate::widgets::WIDGET_NAMES;
+
+        let mut lines: Vec<Line> = Vec::new();
+        for (index, name) in names.iter().enumerate() {
+            let on = self.config.layout.places(name);
+            let here = index == selected;
+            // A filled mark and an empty one in the track colour, the same
+            // vocabulary the meters use, so "on" is legible without relying on
+            // the word beside it.
+            let mark = if on { "■" } else { "□" };
+            let mark_style = Style::default().fg(if on { theme.accent } else { theme.track });
+            let name_style = if here {
+                Style::default()
+                    .fg(theme.text)
+                    .add_modifier(Modifier::REVERSED)
+            } else if on {
+                Style::default().fg(theme.text)
+            } else {
+                Style::default().fg(theme.muted)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    if here { " ▸ " } else { "   " },
+                    Style::default().fg(theme.accent),
+                ),
+                Span::styled(format!("{mark} "), mark_style),
+                Span::styled(format!("{name:<10}"), name_style),
+            ]));
+        }
+
+        lines.push(Line::from(""));
+        if let Some(error) = &self.layout_error {
+            lines.push(Line::from(Span::styled(
+                format!("  {error}"),
+                Style::default().fg(theme.error),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "  written to your config on close",
+                Style::default().fg(theme.muted),
+            )));
+        }
+        lines.push(Line::from(vec![
+            Span::styled(
+                "  space",
+                Style::default().fg(theme.key).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" toggle   ", Style::default().fg(theme.muted)),
+            Span::styled(
+                "esc",
+                Style::default().fg(theme.key).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" close", Style::default().fg(theme.muted)),
+        ]));
+
+        let width = 40.min(area.width);
+        let height = (u16::try_from(lines.len()).unwrap_or(u16::MAX) + 2).min(area.height);
+        let popup = Rect {
+            x: area.x + area.width.saturating_sub(width) / 2,
+            y: area.y + area.height.saturating_sub(height) / 2,
+            width,
+            height,
+        };
+
+        frame.render_widget(Clear, popup);
+        frame.render_widget(
+            Paragraph::new(lines).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(theme.border_focused))
+                    .title(Span::styled(
+                        crate::glyphs::utility(" panels "),
+                        Style::default()
+                            .fg(theme.title)
+                            .add_modifier(Modifier::BOLD),
+                    ))
+                    .padding(Padding::horizontal(1)),
+            ),
+            popup,
+        );
     }
 
     fn render_help(&self, frame: &mut ratatui::Frame, area: Rect) {
@@ -838,10 +1091,11 @@ impl App {
             // still leaves you able to act, losing the instruction does not.
             // The names go on one wrapped line for the same reason — one line
             // per widget cost eight rows on a stale config.
-            lines.push(Line::from(Span::styled(
-                "  add to [layout]; --print-config shows how",
-                muted,
-            )));
+            lines.push(Line::from(vec![
+                Span::styled("  press ", muted),
+                Span::styled("w", key_style),
+                Span::styled(" to switch them on", muted),
+            ]));
             lines.push(Line::from(Span::styled(
                 format!("  {}", self.unused_widgets.join(", ")),
                 Style::default().fg(theme.text),
@@ -1483,6 +1737,110 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
         assert!(!app.show_help);
         assert!(!app.should_quit, "closing help must not also quit");
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn the_picker_opens_and_toggles_a_panel_on_and_off() {
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        let before = app.slots.len();
+
+        app.handle_key(key(KeyCode::Char('w')));
+        assert_eq!(app.picker, Some(0), "opens on the first widget");
+
+        // WIDGET_NAMES starts with clocks, which this layout already places.
+        app.handle_key(key(KeyCode::Char(' ')));
+        assert!(!app.config.layout.places("clocks"), "space turned it off");
+        assert_eq!(app.slots.len(), before - 1, "and the panel actually went");
+        assert!(app.layout_dirty);
+
+        app.handle_key(key(KeyCode::Char(' ')));
+        assert!(
+            app.config.layout.places("clocks"),
+            "space turned it back on"
+        );
+        assert_eq!(app.slots.len(), before);
+    }
+
+    #[test]
+    fn the_picker_moves_and_closes_without_quitting() {
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        app.handle_key(key(KeyCode::Char('w')));
+
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(app.picker, Some(1));
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.picker, Some(0));
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.picker, Some(0), "clamps at the top");
+
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(app.picker, None);
+        assert!(
+            !app.should_quit,
+            "Esc closes the dialog rather than falling through to quit"
+        );
+    }
+
+    #[test]
+    fn the_last_panel_cannot_be_switched_off() {
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        app.handle_key(key(KeyCode::Char('w')));
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        assert!(
+            app.config.layout.places("clocks"),
+            "an empty layout is rejected at startup, so this would write a \
+             config that cannot be opened again"
+        );
+        assert_eq!(app.slots.len(), 1);
+        assert!(app.layout_error.is_some(), "and it says why");
+    }
+
+    #[test]
+    fn a_toggle_updates_the_unused_list_the_hint_reads_from() {
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        assert!(app.unused_widgets.contains(&"pomodoro"));
+
+        app.handle_key(key(KeyCode::Char('w')));
+        let index = crate::widgets::WIDGET_NAMES
+            .iter()
+            .position(|n| *n == "pomodoro")
+            .unwrap();
+        app.picker = Some(index);
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        assert!(
+            !app.unused_widgets.contains(&"pomodoro"),
+            "switching a widget on must stop it being advertised as missing"
+        );
+    }
+
+    #[test]
+    fn nothing_is_written_when_no_config_path_was_given() {
+        // The guard that keeps the whole test suite off a real user's config.
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        app.handle_key(key(KeyCode::Char('w')));
+        app.handle_key(key(KeyCode::Char(' ')));
+        assert!(app.layout_dirty);
+        app.handle_key(key(KeyCode::Esc));
+        assert!(
+            app.layout_dirty,
+            "still pending, because there was nowhere to write it"
+        );
+        assert_eq!(app.layout_error, None, "and that is not an error");
+    }
+
+    #[test]
+    fn a_resize_that_changed_nothing_does_not_mark_the_layout_dirty() {
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        // One panel in its row: there is no neighbour to trade with, so the
+        // key does nothing and must not queue a config write.
+        app.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL));
+        assert!(!app.layout_dirty);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,89 @@ impl Default for Layout {
     }
 }
 
+impl Layout {
+    /// Every widget this layout places, in row-major order.
+    pub fn widgets(&self) -> Vec<&str> {
+        self.rows
+            .iter()
+            .flat_map(|row| row.panels.iter())
+            .map(|panel| panel.widget.as_str())
+            .collect()
+    }
+
+    /// Whether `widget` appears anywhere.
+    pub fn places(&self, widget: &str) -> bool {
+        self.widgets().contains(&widget)
+    }
+
+    /// Place `widget`, appending it to the row carrying the fewest panels.
+    ///
+    /// A dashboard has no obvious "end" to add to, so the rule is the one that
+    /// keeps the grid even: the emptiest row, and the last of those on a tie so
+    /// repeated additions walk downward rather than piling into row one. The
+    /// new panel takes the average weight of that row's existing panels, which
+    /// leaves the others in proportion to each other instead of squeezing one.
+    ///
+    /// Deliberately crude, because it has to be undoable by hand: this only
+    /// ever *adds*, and `Ctrl+arrow` or the config can put it where you want.
+    /// Guessing more cleverly would be harder to predict, not easier.
+    pub fn add_widget(&mut self, widget: &str) {
+        if self.places(widget) {
+            return;
+        }
+
+        let target = self
+            .rows
+            .iter()
+            .enumerate()
+            .min_by_key(|(index, row)| (row.panels.len(), usize::MAX - index))
+            .map(|(index, _)| index);
+
+        let Some(index) = target else {
+            // No rows at all: give the widget one of its own rather than
+            // dropping it silently.
+            self.rows.push(LayoutRow {
+                height: 100,
+                panels: vec![LayoutPanel {
+                    widget: widget.to_string(),
+                    width: 100,
+                }],
+            });
+            return;
+        };
+
+        let row = &mut self.rows[index];
+        let width = if row.panels.is_empty() {
+            100
+        } else {
+            let total: u32 = row.panels.iter().map(|p| u32::from(p.width)).sum();
+            u16::try_from(total / row.panels.len() as u32)
+                .unwrap_or(25)
+                .max(1)
+        };
+        row.panels.push(LayoutPanel {
+            widget: widget.to_string(),
+            width,
+        });
+    }
+
+    /// Remove every placement of `widget`, and any row left empty by it.
+    ///
+    /// Refuses to remove the last panel on the dashboard and says so, because
+    /// an empty layout is rejected at startup — turning off the final panel
+    /// would produce a config that cannot be loaded next time.
+    pub fn remove_widget(&mut self, widget: &str) -> bool {
+        if self.widgets().iter().all(|placed| *placed == widget) {
+            return false;
+        }
+        for row in &mut self.rows {
+            row.panels.retain(|panel| panel.widget != widget);
+        }
+        self.rows.retain(|row| !row.panels.is_empty());
+        true
+    }
+}
+
 /// One horizontal band of the dashboard.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -342,7 +425,7 @@ impl Default for CalendarConfig {
 /// Pomodoro timer settings.
 ///
 /// These are the *starting* values. `+` and `-` change the timer in the panel,
-/// and those changes last for the session — mirador never rewrites this file.
+/// and those changes are remembered in the state file beside your tasks.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields)]
 pub struct PomodoroConfig {

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1,0 +1,484 @@
+//! Writing `[layout]` changes back into the config file.
+//!
+//! Which panels exist and how wide they are can be changed from the dashboard,
+//! and those changes have to land somewhere the user will find them. That is
+//! the config: `[layout]` is the part people actually read and curate, and
+//! recording it anywhere else would leave the file describing a dashboard
+//! nobody is looking at.
+//!
+//! Rewriting is **textual**, for the reason [`crate::migrate`] gives at
+//! length: a parse-and-reserialise round trip through `toml` discards every
+//! comment in the file, including the two hundred lines mirador itself wrote to
+//! explain the options. Lines are edited, inserted and deleted in place;
+//! everything else — spacing, ordering, comments, even a comment *inside* the
+//! layout block — is left exactly as the user left it.
+//!
+//! The safety property that makes this defensible is at the bottom of
+//! [`apply`]: the edited text is parsed before it is returned, and the layout it
+//! produces is compared against the one that was asked for. A mismatch means
+//! the surgery went wrong, and the edit is thrown away rather than written. So
+//! the failure mode of an unusual config is "your change did not stick",
+//! reported, rather than "your config is now broken".
+
+use anyhow::{Result, bail};
+
+use crate::config::{Config, Layout};
+
+/// Rewrite the `[layout]` block of `source` so it describes `desired`.
+///
+/// Returns the new file text. Fails rather than guessing if the block cannot be
+/// edited confidently, leaving the caller to report that and change nothing.
+pub fn apply(source: &str, desired: &Layout) -> Result<String> {
+    let current: Config = toml::from_str(source)?;
+    let lines: Vec<&str> = source.lines().collect();
+    let map = map_layout(&lines)?;
+
+    if map.rows.len() != current.layout.rows.len() {
+        bail!(
+            "found {} layout rows in the text but {} when parsed; the `[layout]` \
+             block is formatted in a way this cannot edit safely",
+            map.rows.len(),
+            current.layout.rows.len()
+        );
+    }
+
+    // Work back to front so an insertion or deletion cannot shift the line
+    // numbers of an edit that has not happened yet.
+    let mut out: Vec<String> = lines.iter().map(|line| (*line).to_string()).collect();
+    let mut edits: Vec<Edit> = Vec::new();
+
+    for (row_index, row) in map.rows.iter().enumerate() {
+        let Some(want_row) = desired.rows.get(row_index) else {
+            // The row is gone entirely. Deleting a whole row textually means
+            // removing its opening and closing lines too, which is beyond what
+            // this does; the caller keeps the row and empties it instead.
+            bail!("removing a whole layout row is not supported");
+        };
+
+        if current.layout.rows[row_index].height != want_row.height {
+            edits.push(Edit::Number {
+                line: row.header_line,
+                key: "height",
+                value: want_row.height,
+            });
+        }
+
+        for panel in &row.panels {
+            match want_row
+                .panels
+                .iter()
+                .find(|wanted| wanted.widget == panel.widget)
+            {
+                Some(wanted) if wanted.width != panel.width => edits.push(Edit::Number {
+                    line: panel.line,
+                    key: "width",
+                    value: wanted.width,
+                }),
+                Some(_) => {}
+                None => edits.push(Edit::Delete { line: panel.line }),
+            }
+        }
+
+        for wanted in &want_row.panels {
+            if !row.panels.iter().any(|p| p.widget == wanted.widget) {
+                let after = row.panels.last().map_or(row.header_line, |p| p.line);
+                edits.push(Edit::Insert {
+                    after,
+                    text: panel_line(&lines, after, &wanted.widget, wanted.width),
+                });
+            }
+        }
+    }
+
+    // Deletions and insertions both key off original line numbers, so applying
+    // from the bottom up keeps every unapplied edit's index valid.
+    edits.sort_by_key(Edit::anchor);
+    for edit in edits.iter().rev() {
+        match edit {
+            Edit::Number { line, key, value } => {
+                out[*line] = set_number(&out[*line], key, *value);
+            }
+            Edit::Delete { line } => {
+                out.remove(*line);
+            }
+            Edit::Insert { after, text } => {
+                out.insert(after + 1, text.clone());
+            }
+        }
+    }
+
+    let mut result = out.join("\n");
+    if source.ends_with('\n') {
+        result.push('\n');
+    }
+
+    // The whole reason this is safe to do at all. If the text no longer says
+    // what it was meant to say, the edit is wrong and is thrown away.
+    let reparsed: Config = toml::from_str(&result)
+        .map_err(|e| anyhow::anyhow!("the edited config no longer parses: {e}"))?;
+    if shape(&reparsed.layout) != shape(desired) {
+        bail!("the edited config does not describe the requested layout");
+    }
+
+    Ok(result)
+}
+
+/// A layout reduced to what this module promises to reproduce.
+fn shape(layout: &Layout) -> Vec<(u16, Vec<(String, u16)>)> {
+    layout
+        .rows
+        .iter()
+        .map(|row| {
+            (
+                row.height,
+                row.panels
+                    .iter()
+                    .map(|p| (p.widget.clone(), p.width))
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+enum Edit {
+    Number {
+        line: usize,
+        key: &'static str,
+        value: u16,
+    },
+    Delete {
+        line: usize,
+    },
+    Insert {
+        after: usize,
+        text: String,
+    },
+}
+
+impl Edit {
+    fn anchor(&self) -> usize {
+        match self {
+            Self::Number { line, .. } | Self::Delete { line } => *line,
+            Self::Insert { after, .. } => *after,
+        }
+    }
+}
+
+struct PanelSite {
+    widget: String,
+    width: u16,
+    line: usize,
+}
+
+struct RowSite {
+    /// The line carrying `height = …`, which is also where a row with no panels
+    /// gets its first one inserted after.
+    header_line: usize,
+    panels: Vec<PanelSite>,
+}
+
+struct LayoutMap {
+    rows: Vec<RowSite>,
+}
+
+/// Find every row and panel in the `[layout]` block, by line.
+///
+/// Deliberately literal: a row starts at a line containing `panels = [`, and a
+/// panel is a line containing `widget = "…"`. That is the shape mirador writes
+/// and the shape anyone editing it by hand will have copied. A file that does
+/// not match — everything on one line, say — produces a map that disagrees with
+/// the parsed config, which [`apply`] treats as a refusal rather than guessing.
+fn map_layout(lines: &[&str]) -> Result<LayoutMap> {
+    let mut rows: Vec<RowSite> = Vec::new();
+    let mut in_layout = false;
+
+    for (index, raw) in lines.iter().enumerate() {
+        let line = strip_comment(raw);
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') && !trimmed.starts_with("[[") {
+            in_layout = trimmed == "[layout]";
+            continue;
+        }
+        if !in_layout {
+            continue;
+        }
+
+        if line.contains("panels") && line.contains('[') {
+            rows.push(RowSite {
+                header_line: index,
+                panels: Vec::new(),
+            });
+        }
+        if let Some(widget) = quoted_value(line, "widget")
+            && let Some(width) = number_value(line, "width")
+            && let Some(row) = rows.last_mut()
+        {
+            row.panels.push(PanelSite {
+                widget,
+                width,
+                line: index,
+            });
+        }
+    }
+
+    if rows.is_empty() {
+        bail!("no `[layout]` rows found in the config text");
+    }
+    Ok(LayoutMap { rows })
+}
+
+/// Everything before an unquoted `#`.
+fn strip_comment(line: &str) -> &str {
+    let mut in_string = false;
+    for (index, ch) in line.char_indices() {
+        match ch {
+            '"' => in_string = !in_string,
+            '#' if !in_string => return &line[..index],
+            _ => {}
+        }
+    }
+    line
+}
+
+/// `key = "value"` on this line.
+fn quoted_value(line: &str, key: &str) -> Option<String> {
+    let rest = after_key(line, key)?;
+    let rest = rest.trim_start().strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// `key = 123` on this line.
+fn number_value(line: &str, key: &str) -> Option<u16> {
+    let rest = after_key(line, key)?;
+    let digits: String = rest
+        .trim_start()
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits.parse().ok()
+}
+
+/// The text just past `key =`, ignoring keys that are only a suffix of a longer
+/// one — `width` must not match inside `max_width`.
+fn after_key<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let mut from = 0;
+    while let Some(found) = line[from..].find(key) {
+        let at = from + found;
+        let before_ok = at == 0
+            || !line[..at]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        let rest = &line[at + key.len()..];
+        let after = rest.trim_start();
+        if before_ok && let Some(value) = after.strip_prefix('=') {
+            return Some(value);
+        }
+        from = at + key.len();
+    }
+    None
+}
+
+/// Replace `key = N` on a line, leaving the rest of it untouched.
+fn set_number(line: &str, key: &str, value: u16) -> String {
+    let Some(rest) = after_key(line, key) else {
+        return line.to_string();
+    };
+    let start = line.len() - rest.len();
+    let spaces = rest.len() - rest.trim_start().len();
+    let digits = rest
+        .trim_start()
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .count();
+    let new = value.to_string();
+    // Keep the column the value started in when it is not getting longer, so a
+    // hand-aligned block stays aligned.
+    let padding = spaces + digits.saturating_sub(new.len());
+    format!(
+        "{}{}{}{}",
+        &line[..start],
+        " ".repeat(padding.max(1)),
+        new,
+        &line[start + spaces + digits..]
+    )
+}
+
+/// A new panel line, indented and spaced to match the one it follows.
+fn panel_line(lines: &[&str], after: usize, widget: &str, width: u16) -> String {
+    let template = lines.get(after).copied().unwrap_or("");
+    let indent: String = template
+        .chars()
+        .take_while(|c| c.is_whitespace())
+        .collect::<String>();
+    // Rows nest one level deeper than their header, so a panel inserted into an
+    // empty row needs the extra step in.
+    let indent = if quoted_value(strip_comment(template), "widget").is_some() {
+        indent
+    } else {
+        format!("{indent}  ")
+    };
+    format!("{indent}{{ widget = \"{widget}\", width = {width} }},")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"# a comment at the top
+[general]
+mouse = true
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+[layout]
+rows = [
+  { height = 34, panels = [
+    { widget = "clocks",   width = 26 },
+    # Wide enough for two months side by side.
+    { widget = "calendar", width = 34 },
+  ] },
+  { height = 42, panels = [
+    { widget = "todo",     width = 48 },
+    { widget = "notes",    width = 30 },
+  ] },
+]
+
+[weather]
+units = "imperial"
+"#;
+
+    fn layout_of(text: &str) -> Layout {
+        toml::from_str::<Config>(text).expect("parses").layout
+    }
+
+    #[test]
+    fn no_change_produces_an_identical_file() {
+        let desired = layout_of(SAMPLE);
+        assert_eq!(apply(SAMPLE, &desired).unwrap(), SAMPLE);
+    }
+
+    #[test]
+    fn a_width_change_touches_only_that_number() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows[1].panels[0].width = 60;
+        let out = apply(SAMPLE, &desired).unwrap();
+
+        assert!(out.contains(r#"{ widget = "todo",     width = 60 },"#));
+        assert!(
+            out.contains("# Wide enough for two months side by side."),
+            "a comment inside the layout block must survive"
+        );
+        assert!(out.contains("# a comment at the top"));
+        assert!(out.contains(r#"units = "imperial""#));
+        assert_eq!(layout_of(&out).rows[1].panels[0].width, 60);
+    }
+
+    #[test]
+    fn a_height_change_edits_the_row_header() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows[0].height = 50;
+        let out = apply(SAMPLE, &desired).unwrap();
+        assert!(out.contains("{ height = 50, panels = ["));
+        assert_eq!(layout_of(&out).rows[0].height, 50);
+    }
+
+    #[test]
+    fn adding_a_panel_inserts_one_line_after_the_last_of_its_row() {
+        let mut desired = layout_of(SAMPLE);
+        desired.add_widget("pomodoro");
+        let out = apply(SAMPLE, &desired).unwrap();
+
+        assert!(out.contains(r#"{ widget = "pomodoro", width = "#));
+        assert_eq!(
+            out.lines().count(),
+            SAMPLE.lines().count() + 1,
+            "exactly one line added"
+        );
+        assert!(layout_of(&out).places("pomodoro"));
+        assert!(out.contains("# Wide enough for two months side by side."));
+    }
+
+    #[test]
+    fn removing_a_panel_deletes_only_its_line() {
+        let mut desired = layout_of(SAMPLE);
+        assert!(desired.remove_widget("notes"));
+        let out = apply(SAMPLE, &desired).unwrap();
+
+        assert!(!out.contains(r#"widget = "notes""#));
+        assert!(out.contains(r#"widget = "todo""#));
+        assert_eq!(out.lines().count(), SAMPLE.lines().count() - 1);
+        assert!(!layout_of(&out).places("notes"));
+    }
+
+    #[test]
+    fn several_changes_at_once_do_not_disturb_each_others_line_numbers() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows[0].panels[0].width = 20;
+        desired.remove_widget("calendar");
+        desired.add_widget("cpu");
+        desired.rows[1].height = 55;
+
+        let out = apply(SAMPLE, &desired).unwrap();
+        let got = layout_of(&out);
+
+        assert_eq!(got.rows[0].panels[0].width, 20);
+        assert!(!got.places("calendar"));
+        assert!(got.places("cpu"));
+        assert_eq!(got.rows[1].height, 55);
+    }
+
+    #[test]
+    fn a_layout_this_cannot_map_is_refused_rather_than_mangled() {
+        // Everything on one line: legal TOML, and not the shape the line-based
+        // map understands.
+        let flat = "[layout]\nrows = [ { height = 100, panels = [ { widget = \"todo\", width = 100 } ] } ]\n";
+        let mut desired = layout_of(flat);
+        desired.add_widget("notes");
+
+        // Either it maps it correctly or it refuses; what it must never do is
+        // write something that does not say what was asked.
+        if let Ok(out) = apply(flat, &desired) {
+            assert_eq!(shape(&layout_of(&out)), shape(&desired));
+        }
+    }
+
+    #[test]
+    fn a_file_without_a_layout_block_is_refused() {
+        let text = "[general]\nmouse = true\n";
+        let desired = layout_of(SAMPLE);
+        assert!(apply(text, &desired).is_err());
+    }
+
+    #[test]
+    fn width_is_not_confused_by_a_key_that_ends_in_the_same_word() {
+        assert_eq!(number_value("max_width = 7, width = 42", "width"), Some(42));
+        assert_eq!(after_key("max_width = 7", "width"), None);
+    }
+
+    #[test]
+    fn a_commented_out_panel_is_not_treated_as_a_real_one() {
+        let text = SAMPLE.replace(
+            r#"    { widget = "notes",    width = 30 },"#,
+            r#"    # { widget = "notes",    width = 30 },"#,
+        );
+        let desired = layout_of(&text);
+        assert!(!desired.places("notes"));
+        // Round-trips without resurrecting the commented line.
+        let out = apply(&text, &desired).unwrap();
+        assert!(out.contains(r#"# { widget = "notes""#));
+        assert!(!layout_of(&out).places("notes"));
+    }
+
+    #[test]
+    fn trailing_newline_is_preserved_either_way() {
+        let desired = layout_of(SAMPLE);
+        assert!(apply(SAMPLE, &desired).unwrap().ends_with('\n'));
+
+        let without = SAMPLE.trim_end_matches('\n');
+        assert!(!apply(without, &desired).unwrap().ends_with('\n'));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod dateinput;
 mod frame;
 mod glyphs;
 mod grid;
+mod layout_edit;
 mod migrate;
 mod note;
 mod panel;
@@ -152,7 +153,7 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
-    let (mut config, _path) = Config::load(args.config)?;
+    let (mut config, config_path) = Config::load(args.config)?;
 
     // Preferences changed from the keyboard on a previous run are applied over
     // the config *before* any panel exists, so every panel is constructed with
@@ -167,6 +168,7 @@ fn run() -> Result<()> {
 
     let mouse = config.general.mouse;
     let mut app = App::new(config)?;
+    app.write_layout_to(config_path);
     if let Some(path) = state_path {
         app.remember_preferences_at(path, saved);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,9 @@
 //! Preferences changed from the UI, remembered across restarts.
 //!
-//! mirador never rewrites its config. That is what makes the config safe to
-//! hand-edit and keep in git, and it is the reason a setting you change with a
-//! keystroke has nowhere obvious to go. The watchlist answered this first by
+//! mirador never *reserialises* its config — a round trip through `toml` would
+//! discard every comment in it — so a setting changed with a keystroke has
+//! nowhere obvious to go unless it is worth the surgery [`crate::layout_edit`]
+//! does for `[layout]`. The watchlist answered this first by
 //! keeping symbols in a data file of their own; this is the same answer
 //! generalised, and the config's role is unchanged — it *seeds*, and this file
 //! records where you have moved since.
@@ -13,11 +14,12 @@
 //! says. That last property is the point: there must be an obvious way to undo
 //! a preference you cannot remember setting.
 //!
-//! Deliberately *not* here: panel sizes. `Ctrl+arrow` resizing is geometry
-//! rather than preference — it belongs to the same vocabulary as `[layout]`,
-//! and remembering it would mean a saved width silently overruling a layout you
-//! had since edited by hand. Sizes stay session-only until that conflict has an
-//! answer.
+//! Deliberately *not* here: anything that belongs to `[layout]` — which panels
+//! exist and how wide they are. Those are written back to the config itself by
+//! [`crate::layout_edit`], because `[layout]` is the part of the config people
+//! actually read and curate, and a state file shadowing it would leave the
+//! config describing a dashboard nobody is looking at. Preferences have no such
+//! problem: nobody keeps their preferred sort order under version control.
 
 use std::path::{Path, PathBuf};
 

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -7,7 +7,7 @@
 //!
 //! Durations are adjustable from the panel and outlive the session: `[pomodoro]`
 //! seeds them and [`crate::state`] records where you moved since, so mirador
-//! still never rewrites the config. Only a phase you actually adjusted is
+//! never reserialises the config. Only a phase you actually adjusted is
 //! remembered — see [`Panel::remember`].
 
 use std::time::{Duration, Instant};


### PR DESCRIPTION
Switching a widget on meant finding your config file and editing `[layout]` by hand. Julian met the new pomodoro panel, was told by the status bar that it existed, pressed `?` to find out how — and did not find the answer there either. That is the bug. The dialog is the fix.

```
╭PANELS────────────────────────────────╮
│    ■ clocks                          │
│    ■ weather                         │
│    ■ todo                            │
│    ■ notes                           │
│    ■ stocks                          │
│    ■ calendar                        │
│  ▸ □ pomodoro                        │
│    ■ cpu                             │
│    ■ network                         │
│                                      │
│   written to your config on close    │
│   space toggle   esc close           │
╰──────────────────────────────────────╯
```

`w` opens it, `space` toggles, and the panel appears or disappears at once. The last panel cannot be switched off — an empty layout is rejected at startup and would leave a config that will not open. The status bar notice now names the key rather than only naming what is missing, and so does the help overlay.

## The harder half: this reverses an earlier decision

Layout was being kept *out* of the config on the grounds that mirador never rewrites it. But that rule was never about writing — it was about **comments**. A round trip through `toml` discards all ~145 of them, including the ones mirador wrote to explain its own options. `migrate.rs` had already worked this out and built the alternative: find the line, change that line, leave the rest alone.

So `[layout]` is edited surgically. Against a real config with the pomodoro entry removed:

```diff
$ diff before.toml after.toml
47a48
>     { widget = "pomodoro", width = 39 },
```

One line. Comment count 145 before, 145 after. A width change rewrites one number and keeps its column alignment:

```diff
-    { widget = "todo",     width = 48 },
-    { widget = "notes",    width = 30 },
+    { widget = "todo",     width = 54 },
+    { widget = "notes",    width = 24 },
```

## What makes that safe is a check, not care

At the end of `layout_edit::apply` the edited text is **parsed**, and the layout it produces is compared against the one that was requested. A mismatch throws the edit away. So a config formatted in a way the line-based map does not understand fails as *"that did not stick"*, reported in the picker, rather than as a mangled file. That property is what the whole approach rests on, and it is tested directly rather than assumed.

## Panel sizes ride along

`Ctrl+arrow` now persists. Batched to one write on exit rather than per keypress — the key repeats — and only when a resize actually moved something, since held against a minimum it changes nothing and would otherwise queue a pointless write.

## The split, stated once

`[layout]` goes to the config because that is the part people read and curate; a change made in the UI has to show up there or the file ends up describing a dashboard nobody is looking at. Everything else stays in the state file, because nobody keeps their preferred sort order under version control.

## Verified

11 tests on the text surgery alone, including comment preservation, a commented-out panel not being resurrected, multiple simultaneous edits not disturbing each other's line numbers, and the refuse-rather-than-mangle path. Plus 6 on the picker itself, one of which asserts the whole suite cannot touch a real config.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (392 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`, and driven end to end under tmux.