### PR TITLE
Release 0.4.0: the panel picker, and layout changes that reach the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-07-26
 
 ### Added
 
@@ -453,7 +453,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/jchultarsky/mirador/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/jchultarsky/mirador/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jchultarsky/mirador/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jchultarsky/mirador/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Minor. A new dialog, and a reversal of where layout changes are stored — the second is the one worth reading the notes for, since it is a change of principle rather than only of code.

- `Cargo.toml` and `Cargo.lock` to `0.4.0`
- `[Unreleased]` stamped as `[0.4.0] - 2026-07-26`, with compare links

## What ships

**A panel picker.** `w` opens a list of every widget with whether it is on; `space` toggles and the panel appears or disappears at once. Switching a widget on used to mean finding the config file and editing `[layout]` by hand — which is exactly what happened to the first person to meet the pomodoro panel, after `?` failed to tell them how.

**Layout changes are written back into the config.** The old rule was never "do not write to the config", it was "do not *reserialise* it" — a `toml` round trip discards all ~145 comments. `[layout]` is now edited surgically, the way `--migrate-config` already edited keys: adding a panel is a one-line diff, a resize rewrites one number and keeps its alignment, and comments inside the block survive. The edit is re-parsed and compared against what was asked for, so an unusual config fails as "that did not stick" rather than as a broken file.

**Panel sizes persist.** `Ctrl+arrow` no longer lasts only for the session.

**Windows is documented as working**, confirmed via the PowerShell installer in the default Windows terminal.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (392 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`, `cargo publish --dry-run`, `dist plan` announcing `v0.4.0`, `dist generate --check` silent.

Once merged: tag `v0.4.0`, verify the artifacts and the updater, then `cargo publish`.