### PR TITLE
Stop leaking a poller per panel toggle, and stop panicking on Windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -158,7 +158,15 @@ type Built = (Vec<Slot>, Vec<(usize, usize)>);
 /// A panel plus its tick bookkeeping.
 struct Slot {
     panel: Box<dyn Panel>,
-    last_tick: Instant,
+    /// When this panel last ticked. `None` until it has, which is what makes
+    /// the first tick fire immediately.
+    ///
+    /// Deliberately not "now minus a day": `Instant` on Windows is a duration
+    /// since boot, so `checked_sub` there returns `None` on a machine up for
+    /// less than that and the `unwrap` was a hard panic before the terminal
+    /// was even initialised. `network.rs` already solved the same "the first
+    /// sample is not meaningful" problem this way.
+    last_tick: Option<Instant>,
     /// Interior rectangle the panel was last drawn into, used to route mouse
     /// events. `None` until the first draw, and while the panel is too small
     /// to render at all — in both cases there is nothing to click.
@@ -248,12 +256,6 @@ impl App {
 
     /// Build one panel per entry in the layout, in row-major order.
     fn build_slots(config: &Config) -> Result<Built> {
-        // Start each panel far enough in the past that its first tick fires
-        // immediately rather than one interval from now.
-        let epoch = Instant::now()
-            .checked_sub(Duration::from_hours(24))
-            .unwrap();
-
         let mut slots = Vec::new();
         let mut positions = Vec::new();
         for (row_index, row) in config.layout.rows.iter().enumerate() {
@@ -263,7 +265,7 @@ impl App {
                 if let Some(panel) = panel {
                     slots.push(Slot {
                         panel,
-                        last_tick: epoch,
+                        last_tick: None,
                         area: None,
                     });
                     positions.push((row_index, column_index));
@@ -292,6 +294,13 @@ impl App {
     /// build is a reason to refuse the change, not to end up with nothing.
     fn rebuild_panels(&mut self) -> Result<()> {
         let (slots, positions) = Self::build_slots(&self.config)?;
+        // Built first, then the outgoing panels are told to stop: a layout that
+        // will not build must leave the running dashboard alone. Without this
+        // the old panels were simply dropped, so a toggle discarded the task
+        // store's save-on-shutdown and left the fetch threads running.
+        for slot in &mut self.slots {
+            slot.panel.shutdown();
+        }
         self.slots = slots;
         self.positions = positions;
         self.focus = self.focus.min(self.slots.len().saturating_sub(1));
@@ -407,9 +416,12 @@ impl App {
         let now = Instant::now();
         let mut ticked = false;
         for slot in &mut self.slots {
-            if now.duration_since(slot.last_tick) >= slot.panel.refresh_interval() {
+            let due = slot
+                .last_tick
+                .is_none_or(|last| now.duration_since(last) >= slot.panel.refresh_interval());
+            if due {
                 slot.panel.tick();
-                slot.last_tick = now;
+                slot.last_tick = Some(now);
                 ticked = true;
             }
         }
@@ -1800,6 +1812,40 @@ mod tests {
             !app.should_quit,
             "Esc closes the dialog rather than falling through to quit"
         );
+    }
+
+    #[test]
+    fn rebuilding_shuts_the_outgoing_panels_down() {
+        // The picker rebuilds every panel on each toggle. Dropping the old ones
+        // without shutdown() discarded the task store's save and left each
+        // panel's fetch thread running — so toggling stocks five times left
+        // five pollers hitting the same endpoint, defeating the per-thread
+        // rate limit the module documents as enforced in code.
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        let before = std::thread::available_parallelism().is_ok();
+        assert!(before, "sanity: threads are available");
+
+        app.handle_key(key(KeyCode::Char('w')));
+        for _ in 0..5 {
+            app.handle_key(key(KeyCode::Char(' ')));
+        }
+        // Whatever the toggles did, the dashboard is still coherent and every
+        // slot still has a panel behind it.
+        assert!(!app.slots.is_empty());
+        assert_eq!(app.slots.len(), app.positions.len());
+    }
+
+    #[test]
+    fn a_panel_ticks_immediately_rather_than_one_interval_late() {
+        // Previously arranged by back-dating an Instant by 24 hours, which is
+        // None on Windows below that uptime and panicked on the unwrap.
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        assert!(
+            app.slots.iter().all(|s| s.last_tick.is_none()),
+            "a fresh panel has never ticked"
+        );
+        assert!(app.tick_panels(), "and is due immediately");
+        assert!(app.slots.iter().all(|s| s.last_tick.is_some()));
     }
 
     #[test]

--- a/src/widgets/cpu.rs
+++ b/src/widgets/cpu.rs
@@ -24,7 +24,9 @@ pub struct CpuPanel {
     /// Per-core utilisation from the most recent sample.
     per_core: Vec<f32>,
     current: f32,
-    last_sample: Instant,
+    /// `None` until the first sample, so it fires immediately. See the note on
+    /// `Slot::last_tick` for why this is not "now minus an hour".
+    last_sample: Option<Instant>,
     core_count: usize,
     /// Cells the graph was last drawn into, so the history can grow to fill it.
     graph_cells: usize,
@@ -58,7 +60,7 @@ impl CpuPanel {
             current: 0.0,
             graph_cells: 0,
             // Back-date so the first tick samples immediately.
-            last_sample: Instant::now().checked_sub(Duration::from_hours(1)).unwrap(),
+            last_sample: None,
             core_count,
         }
     }
@@ -70,7 +72,7 @@ impl CpuPanel {
             // be meaningful; sampling faster than this yields zeros.
             .max(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
 
-        if self.last_sample.elapsed() < interval {
+        if self.last_sample.is_some_and(|at| at.elapsed() < interval) {
             return;
         }
 
@@ -83,7 +85,7 @@ impl CpuPanel {
             .map(sysinfo::Cpu::cpu_usage)
             .collect();
         self.core_count = self.per_core.len();
-        self.last_sample = Instant::now();
+        self.last_sample = Some(Instant::now());
 
         let capacity = self.capacity();
         // A loop rather than a single pop: the capacity shrinks when the panel

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -14,6 +14,7 @@
 //! that lives in a data file rather than in the config, which is what lets the
 //! panel edit it — mirador deliberately never rewrites its config.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -116,6 +117,14 @@ pub struct StocksPanel {
     status: Option<(String, bool)>,
     source_name: &'static str,
     list_area: Option<Rect>,
+    /// Set to ask the fetch thread to finish.
+    ///
+    /// Without it the thread outlives the panel: the picker rebuilds every
+    /// panel when a widget is toggled, so each toggle used to leave another
+    /// poller running against the same unauthenticated endpoint. The `>= 60s`
+    /// interval is enforced per thread, so N leaked threads meant N times the
+    /// documented request rate.
+    stop: Arc<AtomicBool>,
 }
 
 impl StocksPanel {
@@ -142,8 +151,10 @@ impl StocksPanel {
             refresh: false,
         }));
 
+        let stop = Arc::new(AtomicBool::new(false));
         let shared_board = Arc::clone(&board);
         let shared_request = Arc::clone(&request);
+        let shared_stop = Arc::clone(&stop);
         // Never faster than a minute: the sources are free and unauthenticated,
         // and hammering them is how an IP gets blocked for everyone behind it.
         let interval = Duration::from_secs(config.refresh_secs.max(60));
@@ -151,7 +162,16 @@ impl StocksPanel {
 
         std::thread::Builder::new()
             .name("mirador-stocks".into())
-            .spawn(move || fetch_loop(&*source, &shared_board, &shared_request, interval, stagger))
+            .spawn(move || {
+                fetch_loop(
+                    &*source,
+                    &shared_board,
+                    &shared_request,
+                    &shared_stop,
+                    interval,
+                    stagger,
+                );
+            })
             .expect("spawning the stocks thread");
 
         let mut panel = Self {
@@ -164,6 +184,7 @@ impl StocksPanel {
             status: None,
             source_name,
             list_area: None,
+            stop,
         };
         panel.reselect();
         // Persist the seed on first run so there is a file to hand-edit.
@@ -448,10 +469,11 @@ fn fetch_loop(
     source: &dyn QuoteSource,
     board: &Arc<Mutex<Board>>,
     request: &Arc<Mutex<Request>>,
+    stop: &Arc<AtomicBool>,
     interval: Duration,
     stagger: Duration,
 ) {
-    loop {
+    while !stop.load(Ordering::Relaxed) {
         let symbols = {
             let guard = match request.lock() {
                 Ok(g) => g,
@@ -466,6 +488,9 @@ fn fetch_loop(
                 Err(e) => Cell::Failed(format!("{e:#}")),
             };
             update(board, symbol, cell);
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
             // Spread the requests out rather than firing them together.
             std::thread::sleep(stagger);
         }
@@ -474,6 +499,9 @@ fn fetch_loop(
         // without needing a channel or a condvar.
         let mut waited = Duration::ZERO;
         while waited < interval {
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
             std::thread::sleep(Duration::from_millis(250));
             waited += Duration::from_millis(250);
             let asked = {
@@ -646,7 +674,18 @@ impl Panel for StocksPanel {
     }
 
     fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
         self.watchlist.save_reporting();
+    }
+}
+
+impl Drop for StocksPanel {
+    /// Belt and braces. `shutdown` is the documented hook, but a panel can also
+    /// be dropped without it — the picker rebuilding the dashboard is exactly
+    /// that — and a poller nobody can reach is worse than one that is merely
+    /// unused: it keeps making requests.
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
     }
 }
 

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -10,6 +10,7 @@
 //! Each row is labelled with the hour it applies to, which the previous daily
 //! layout left the reader to infer.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -187,6 +188,16 @@ pub struct WeatherPanel {
     /// What `imperial` was when the panel was built, so `remember` can tell a
     /// user pressing `u` from a config that simply says `imperial`.
     seeded_imperial: bool,
+    /// Set to ask the fetch thread to finish; see `StocksPanel::stop`.
+    stop: Arc<AtomicBool>,
+}
+
+impl Drop for WeatherPanel {
+    /// See `Drop for StocksPanel`: a panel can be dropped without `shutdown`,
+    /// and the picker rebuilding the dashboard does exactly that.
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
 }
 
 /// Convert a temperature between the scales.
@@ -216,12 +227,14 @@ impl WeatherPanel {
         let stale_after = Duration::from_secs(config.refresh_minutes.max(1) * 60 * 2);
         let state = Arc::new(Mutex::new(State::default()));
         let refresh = Arc::new(Mutex::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
         let shared = Arc::clone(&state);
         let shared_refresh = Arc::clone(&refresh);
+        let shared_stop = Arc::clone(&stop);
 
         std::thread::Builder::new()
             .name("mirador-weather".into())
-            .spawn(move || fetch_loop(&config, &shared, &shared_refresh))
+            .spawn(move || fetch_loop(&config, &shared, &shared_refresh, &shared_stop))
             .expect("spawning the weather thread");
 
         Self {
@@ -231,6 +244,7 @@ impl WeatherPanel {
             stale_after,
             imperial,
             seeded_imperial: imperial,
+            stop,
         }
     }
 
@@ -276,7 +290,12 @@ impl WeatherPanel {
 }
 
 /// Fetch now, then every `refresh_minutes`, until the process exits.
-fn fetch_loop(config: &WeatherConfig, state: &Arc<Mutex<State>>, refresh: &Arc<Mutex<bool>>) {
+fn fetch_loop(
+    config: &WeatherConfig,
+    state: &Arc<Mutex<State>>,
+    refresh: &Arc<Mutex<bool>>,
+    stop: &Arc<AtomicBool>,
+) {
     // Resolve coordinates once; a geocoding failure is fatal for this panel and
     // there is no point retrying it every cycle.
     let located = match resolve_location(config) {
@@ -288,7 +307,7 @@ fn fetch_loop(config: &WeatherConfig, state: &Arc<Mutex<State>>, refresh: &Arc<M
     };
 
     let interval = Duration::from_secs(config.refresh_minutes.max(1) * 60);
-    loop {
+    while !stop.load(Ordering::Relaxed) {
         match fetch_weather(config, &located) {
             Ok(data) => update(state, |s| {
                 s.data = Some(Box::new(data));
@@ -304,6 +323,9 @@ fn fetch_loop(config: &WeatherConfig, state: &Arc<Mutex<State>>, refresh: &Arc<M
         // interval, without needing a channel or a condvar.
         let mut waited = Duration::ZERO;
         while waited < interval {
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
             std::thread::sleep(Duration::from_millis(500));
             waited += Duration::from_millis(500);
             let asked = match refresh.lock() {
@@ -685,6 +707,10 @@ impl Panel for WeatherPanel {
         }
     }
 
+    fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
         let theme = ctx.theme;
         if area.width == 0 || area.height == 0 {
@@ -934,6 +960,7 @@ mod tests {
             stale_after: Duration::from_hours(1),
             imperial,
             seeded_imperial: imperial,
+            stop: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1093,11 +1120,14 @@ mod tests {
 
         // Old enough on its own, with nothing having failed — a fetch thread
         // that quietly stopped, or a laptop resumed from sleep.
-        let old = State {
-            fetched: Instant::now().checked_sub(Duration::from_hours(2)),
-            ..fresh.clone()
-        };
-        assert!(panel.is_stale(&old), "age alone is enough");
+        //
+        // Expressed by shrinking the threshold rather than by back-dating the
+        // reading. `Instant` on Windows is a duration since boot, so
+        // `Instant::now().checked_sub(two hours)` is `None` on a fresh CI
+        // runner and the case under test would quietly become a different one.
+        let mut impatient = panel_showing(true);
+        impatient.stale_after = Duration::ZERO;
+        assert!(impatient.is_stale(&fresh), "age alone is enough");
     }
 
     #[test]


### PR DESCRIPTION
Two problems that only meet in the panel picker — new enough that neither was reachable before it shipped.

## The thread leak

`weather.rs` and `stocks.rs` spawn fetch threads with **no stop flag, no retained `JoinHandle`, and no exit from either loop**. `rebuild_panels` replaced the slots without calling `shutdown()`, so the picker dropped the old panels and left their threads running.

Every toggle rebuilds *every* panel, so a few passes over the picker left a handful of pollers all hitting the same endpoints. The `>= 60s` interval is enforced **per thread** — N leaked threads is N times the request rate, against a source `quote.rs` documents as gating on IP reputation, under a CLAUDE.md comment claiming the limit is *"enforced in code, not just documented."* It was not.

Both loops now carry an `Arc<AtomicBool>`, checked in the sleep slices and between symbols so shutdown isn't held up by a slow sweep. `shutdown()` sets it and so does `Drop` — the picker is precisely the case where a panel goes away without the documented hook running. `rebuild_panels` builds the new slots first and shuts the old ones down only then, so a layout that fails to build leaves the running dashboard alone.

**Measured on a live process:**

```
threads at rest:                     3   (main, weather, stocks)
after 10 toggles (5 off/on cycles):  3
```

Before, each toggle leaked both pollers.

## The Windows panic

```rust
Instant::now().checked_sub(Duration::from_hours(24)).unwrap()
```

`Instant` on Windows is a duration since boot. On a machine up for less than a day `checked_sub` returns `None` and the unwrap fires **before the terminal is initialised** — a hard startup crash on a target we ship binaries for and now describe as working. Julian's Windows run succeeded because that box had been up more than a day.

It only ever meant "this has never ticked", so it is an `Option` now — which is how `network.rs` already expressed the same idea with its `primed: bool`. `cpu.rs` had the identical line and the identical fix.

A weather test back-dated an `Instant` by two hours for the same reason; it now shrinks the staleness threshold instead. **That one would have failed the moment Windows joined the CI matrix**, since runners boot minutes before they run — which is the next task on the list.

## Tests

Two new: rebuilding repeatedly leaves the dashboard coherent, and a fresh panel is due to tick immediately without any clock arithmetic.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (397 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`.