### PR TITLE
Make a preference retractable, by comparing against the config in one place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,18 +203,28 @@ Adding a widget: implement `Panel`, add a config struct, add the name to
     The split is by *what*, not by convenience: `[layout]` goes to the config
     because people read and curate it, and everything else goes to `state.rs`
     because nobody keeps their preferred sort order under version control.
-17. **A panel remembers only what the user changed.** `Panel::remember` writes
-    a preference only when it differs from the value the panel was *built*
-    with, which is why every such panel keeps a `seeded_*` copy. Reporting the
-    current value unconditionally looks identical in a unit test and is wrong
-    in practice: the first keystroke on any panel pins every other panel's
-    config values into the state file, and editing the config silently stops
-    working from then on. This was written the wrong way first and caught by
-    running it, not by the tests.
+17. **A remembered preference is the difference between the panels and the
+    config.** `Panel::remember` reports current values unconditionally;
+    `UiState::only_changes_from` drops whatever matches
+    `UiState::from_config(config_as_loaded)`. The baseline has to be taken
+    *before* `apply_state`, or it already contains last session's changes and
+    nothing can be seen to differ from it.
 
-    The app merges into what it loaded rather than starting from nothing, so a
-    preference set last session and untouched this one is not dropped by a
-    panel that has nothing new to say about it.
+    Two wrong versions were shipped before this one, and both looked right:
+
+    - Reporting current values with no comparison pinned every panel's config
+      values into the state file on the first keystroke anywhere, after which
+      editing the config silently stopped working.
+    - Having each panel compare against the value it was *built* with fixed
+      that, and made a preference impossible to *un*-set: after `apply_state`
+      the panel is built from the remembered value, so a setting toggled back
+      to what the config says looked unchanged, wrote nothing, and left the
+      earlier entry standing for ever.
+
+    Both passed their unit tests. The first was caught by running it; the second
+    by an adversarial review reading the data flow. Keep the comparison in one
+    place, against the config, and it is symmetric by construction.
+
 18. **First run must not be blank, and the defaults must agree.** The task and
     notes stores seed examples via `load_or_seed`, keyed on the file being
     *absent* — never on it being empty, or deleting the examples would not

--- a/src/app.rs
+++ b/src/app.rs
@@ -217,6 +217,9 @@ pub struct App {
     /// The last state written, so a keypress that changed nothing writes
     /// nothing.
     saved_state: UiState,
+    /// What the config file itself says. Preferences are recorded as the
+    /// difference from this, which is what lets one be un-set.
+    baseline: UiState,
 }
 
 impl std::fmt::Debug for App {
@@ -251,6 +254,7 @@ impl App {
             layout_error: None,
             state_path: None,
             saved_state: UiState::default(),
+            baseline: UiState::default(),
         })
     }
 
@@ -366,26 +370,28 @@ impl App {
     /// cannot write to a real user's state file by forgetting to opt out. An
     /// app with no path set simply never persists.
     ///
-    /// `loaded` is what was read from that file, and becomes the base every
-    /// later write merges into — so starting up does not rewrite a file it has
-    /// just read, and a preference from an earlier session is not dropped by a
-    /// panel that has nothing new to say about it.
-    pub fn remember_preferences_at(&mut self, path: PathBuf, loaded: UiState) {
+    /// `loaded` is what was read from that file, so startup does not rewrite a
+    /// file it has just read. `baseline` is what the *config* says, taken before
+    /// the loaded values were folded in — every write is the difference between
+    /// the panels and that.
+    pub fn remember_preferences_at(&mut self, path: PathBuf, loaded: UiState, baseline: UiState) {
         self.saved_state = loaded;
+        self.baseline = baseline;
         self.state_path = Some(path);
     }
 
-    /// What every panel currently wants remembered.
+    /// The preferences that differ from the config, which is all that is worth
+    /// recording.
     ///
-    /// Starts from what is already on disk rather than from nothing, so a
-    /// preference set last session and left alone this one survives instead of
-    /// being dropped by the panel that is no longer calling it a change.
+    /// Panels report their current values unconditionally; the comparison is
+    /// here, once, so a value set back to what the config says drops out of the
+    /// file instead of leaving the earlier change asserted for ever.
     fn collect_preferences(&self) -> UiState {
-        let mut state = self.saved_state.clone();
+        let mut current = UiState::default();
         for slot in &self.slots {
-            slot.panel.remember(&mut state);
+            slot.panel.remember(&mut current);
         }
-        state
+        current.only_changes_from(&self.baseline)
     }
 
     /// Write preferences if any of them moved.

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,13 +164,17 @@ fn run() -> Result<()> {
         .as_deref()
         .map(crate::state::UiState::load)
         .unwrap_or_default();
+    // Taken before `apply_state`, so it is what the *file* says rather than what
+    // the file plus last session's changes say. Everything written later is the
+    // difference from this, which is what makes a preference retractable.
+    let baseline = crate::state::UiState::from_config(&config);
     config.apply_state(&saved);
 
     let mouse = config.general.mouse;
     let mut app = App::new(config)?;
     app.write_layout_to(config_path);
     if let Some(path) = state_path {
-        app.remember_preferences_at(path, saved);
+        app.remember_preferences_at(path, saved, baseline);
     }
 
     // `ratatui::init` installs a panic hook that restores the terminal, so a

--- a/src/state.rs
+++ b/src/state.rs
@@ -52,6 +52,71 @@ pub struct UiState {
 }
 
 impl UiState {
+    /// The preferences a config expresses, used as the baseline to compare
+    /// against.
+    ///
+    /// Must be taken from the config **as loaded from disk**, before
+    /// [`crate::config::Config::apply_state`] has folded any remembered values
+    /// into it —
+    /// otherwise the baseline already contains last session's changes and
+    /// nothing can ever be seen to differ from it.
+    ///
+    /// Values are normalised the way the panels normalise them, so a config
+    /// holding a sort mode in some other spelling does not read as a change the
+    /// user made.
+    pub fn from_config(config: &crate::config::Config) -> Self {
+        let sort = config
+            .todo
+            .sort
+            .parse::<crate::task::SortMode>()
+            .unwrap_or_default();
+        Self {
+            weather_units: Some(if config.weather.units == "metric" {
+                "metric".into()
+            } else {
+                "imperial".into()
+            }),
+            todo_sort: Some(sort.label().to_string()),
+            todo_show_completed: Some(config.todo.show_completed),
+            clocks_show_seconds: Some(config.clocks.show_seconds),
+            pomodoro_focus_minutes: Some(config.pomodoro.focus_minutes),
+            pomodoro_short_break_minutes: Some(config.pomodoro.short_break_minutes),
+            pomodoro_long_break_minutes: Some(config.pomodoro.long_break_minutes),
+        }
+    }
+
+    /// Drop every field that matches `baseline`, keeping only real changes.
+    ///
+    /// This is what makes a preference retractable. Panels report their current
+    /// values unconditionally and the comparison happens here, in one place, so
+    /// setting a value back to what the config says *removes* it from the file
+    /// rather than leaving the old change asserted forever.
+    ///
+    /// Panels used to do the comparison themselves against the value they were
+    /// constructed with. That is subtly different and wrong: after
+    /// `apply_state`, a panel is built from the *remembered* value, so once a
+    /// preference had been changed the panel could never again see it as equal
+    /// to the config's — and writing nothing left the previous entry standing.
+    #[must_use]
+    pub fn only_changes_from(mut self, baseline: &Self) -> Self {
+        macro_rules! keep_if_changed {
+            ($($field:ident),+ $(,)?) => {
+                $(if self.$field == baseline.$field {
+                    self.$field = None;
+                })+
+            };
+        }
+        keep_if_changed!(
+            weather_units,
+            todo_sort,
+            todo_show_completed,
+            clocks_show_seconds,
+            pomodoro_focus_minutes,
+            pomodoro_short_break_minutes,
+            pomodoro_long_break_minutes,
+        );
+        self
+    }
     /// Read the state file, treating a missing one as no preferences.
     ///
     /// A *corrupt* one is also treated as no preferences rather than as a
@@ -201,6 +266,82 @@ mod tests {
         .save(&path)
         .unwrap();
         assert!(!path.with_extension("toml.tmp").exists());
+    }
+
+    /// A config with known preference values to diff against.
+    fn baseline_config() -> crate::config::Config {
+        let mut config = crate::config::Config::default();
+        config.weather.units = "imperial".into();
+        config.todo.sort = "smart".into();
+        config.todo.show_completed = false;
+        config.clocks.show_seconds = true;
+        config.pomodoro.focus_minutes = 25;
+        config
+    }
+
+    #[test]
+    fn a_preference_toggled_back_is_forgotten() {
+        // The bug this whole mechanism was rebuilt around. Panels used to
+        // compare against the value they were *built* with — but after
+        // `apply_state` that is the remembered value, so once a preference had
+        // been changed the panel could never see it as equal to the config's
+        // again. Writing nothing then left the old entry standing, and the
+        // state file went on asserting a change the user had undone.
+        let baseline = UiState::from_config(&baseline_config());
+
+        // Changed: recorded.
+        let changed = UiState {
+            weather_units: Some("metric".into()),
+            ..baseline.clone()
+        }
+        .only_changes_from(&baseline);
+        assert_eq!(changed.weather_units.as_deref(), Some("metric"));
+
+        // Changed back: not recorded, which is what lets the file shrink again.
+        let reverted = baseline.clone().only_changes_from(&baseline);
+        assert_eq!(reverted, UiState::default());
+        assert_eq!(
+            reverted.weather_units, None,
+            "pressing `u` twice must leave nothing behind"
+        );
+    }
+
+    #[test]
+    fn the_baseline_ignores_how_the_config_spelled_a_sort_mode() {
+        // A config holding an unparsable sort falls back to the default, and the
+        // panel reports the default's label — so the baseline has to normalise
+        // the same way or an untouched panel reads as a change on every start.
+        let mut config = baseline_config();
+        config.todo.sort = "nonsense".into();
+        let baseline = UiState::from_config(&config);
+
+        let reported = UiState {
+            todo_sort: Some(crate::task::SortMode::default().label().to_string()),
+            ..baseline.clone()
+        };
+        assert_eq!(
+            reported.only_changes_from(&baseline).todo_sort,
+            None,
+            "the default sort must not look like a user choice"
+        );
+    }
+
+    #[test]
+    fn only_the_field_that_moved_is_kept() {
+        let baseline = UiState::from_config(&baseline_config());
+        let current = UiState {
+            pomodoro_focus_minutes: Some(40),
+            ..baseline.clone()
+        };
+        let kept = current.only_changes_from(&baseline);
+
+        assert_eq!(kept.pomodoro_focus_minutes, Some(40));
+        assert_eq!(
+            kept.pomodoro_short_break_minutes, None,
+            "an untouched field must not be pinned by a neighbour changing"
+        );
+        assert_eq!(kept.weather_units, None);
+        assert_eq!(kept.todo_sort, None);
     }
 
     #[test]

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -59,9 +59,6 @@ pub struct ClocksPanel {
     /// Everything else, rendered as a labelled list.
     secondary: Vec<Clock>,
     show_seconds: bool,
-    /// What `show_seconds` was at construction, so `remember` can tell a user
-    /// pressing `s` from a config that merely asks for seconds.
-    seeded_show_seconds: bool,
 }
 
 impl ClocksPanel {
@@ -97,7 +94,6 @@ impl ClocksPanel {
             primary,
             secondary: clocks,
             show_seconds,
-            seeded_show_seconds: show_seconds,
         }
     }
 }
@@ -196,9 +192,7 @@ impl Panel for ClocksPanel {
     }
 
     fn remember(&self, state: &mut crate::state::UiState) {
-        if self.show_seconds != self.seeded_show_seconds {
-            state.clocks_show_seconds = Some(self.show_seconds);
-        }
+        state.clocks_show_seconds = Some(self.show_seconds);
     }
 
     #[allow(clippy::too_many_lines)] // One panel, drawn top to bottom; the

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -107,10 +107,6 @@ impl Phase {
 /// A pomodoro timer panel.
 pub struct PomodoroPanel {
     config: PomodoroConfig,
-    /// The durations the panel was built with. `remember` compares against
-    /// these per phase, so lengthening a focus interval does not also pin the
-    /// break lengths you never touched into the state file.
-    seeded: PomodoroConfig,
     phase: Phase,
     /// When the current phase ends. `None` whenever the timer is not running.
     ends_at: Option<Instant>,
@@ -134,7 +130,6 @@ impl PomodoroPanel {
     pub fn new(config: PomodoroConfig) -> Self {
         let first = Duration::from_secs(config.focus_minutes * 60);
         Self {
-            seeded: config.clone(),
             config,
             phase: Phase::Focus,
             ends_at: None,
@@ -515,15 +510,9 @@ impl Panel for PomodoroPanel {
     }
 
     fn remember(&self, state: &mut crate::state::UiState) {
-        if self.config.focus_minutes != self.seeded.focus_minutes {
-            state.pomodoro_focus_minutes = Some(self.config.focus_minutes);
-        }
-        if self.config.short_break_minutes != self.seeded.short_break_minutes {
-            state.pomodoro_short_break_minutes = Some(self.config.short_break_minutes);
-        }
-        if self.config.long_break_minutes != self.seeded.long_break_minutes {
-            state.pomodoro_long_break_minutes = Some(self.config.long_break_minutes);
-        }
+        state.pomodoro_focus_minutes = Some(self.config.focus_minutes);
+        state.pomodoro_short_break_minutes = Some(self.config.short_break_minutes);
+        state.pomodoro_long_break_minutes = Some(self.config.long_break_minutes);
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
@@ -964,28 +953,28 @@ mod tests {
     }
 
     #[test]
-    fn only_a_duration_you_changed_is_remembered() {
+    fn the_panel_reports_its_current_durations() {
         use crate::panel::Panel as _;
 
+        // Reported unconditionally, on purpose. Deciding what counts as a
+        // *change* is `UiState::only_changes_from`'s job, because a panel built
+        // from an already-remembered value cannot tell the difference — which is
+        // how a preference used to become impossible to retract. See
+        // `a_preference_toggled_back_is_forgotten` in `state.rs`.
         let mut p = panel();
         let mut state = crate::state::UiState::default();
         p.remember(&mut state);
-        assert_eq!(
-            state,
-            crate::state::UiState::default(),
-            "an untouched timer must write nothing, or the config's own values \
-             get pinned into the state file and editing the config stops working"
-        );
+        assert_eq!(state.pomodoro_focus_minutes, Some(25));
 
-        p.adjust(1); // focus only
+        p.adjust(1);
         let mut state = crate::state::UiState::default();
         p.remember(&mut state);
         assert_eq!(state.pomodoro_focus_minutes, Some(26));
         assert_eq!(
-            state.pomodoro_short_break_minutes, None,
-            "a break you never touched must not be pinned by adjusting focus"
+            state.pomodoro_short_break_minutes,
+            Some(5),
+            "the untouched break is still reported; the diff drops it"
         );
-        assert_eq!(state.pomodoro_long_break_minutes, None);
     }
 
     #[test]

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -192,10 +192,6 @@ pub struct TodoPanel {
     config: TodoConfig,
     sort: SortMode,
     show_completed: bool,
-    /// What the two above were when the panel was built, so `remember` can tell
-    /// a user pressing `s` or `c` from a config that merely says so.
-    seeded_sort: SortMode,
-    seeded_show_completed: bool,
     filter: String,
     mode: Mode,
     /// Task ids in display order, recomputed whenever the list changes.
@@ -223,8 +219,6 @@ impl TodoPanel {
             config,
             sort,
             show_completed,
-            seeded_sort: sort,
-            seeded_show_completed: show_completed,
             filter: String::new(),
             mode: Mode::List,
             view: Vec::new(),
@@ -890,12 +884,8 @@ impl Panel for TodoPanel {
     }
 
     fn remember(&self, state: &mut crate::state::UiState) {
-        if self.sort != self.seeded_sort {
-            state.todo_sort = Some(self.sort.label().to_string());
-        }
-        if self.show_completed != self.seeded_show_completed {
-            state.todo_show_completed = Some(self.show_completed);
-        }
+        state.todo_sort = Some(self.sort.label().to_string());
+        state.todo_show_completed = Some(self.show_completed);
     }
 
     fn captures_input(&self) -> bool {

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -185,9 +185,6 @@ pub struct WeatherPanel {
     /// round trip behind a keypress, and leave the panel showing the old unit
     /// — or nothing — until it came back.
     imperial: bool,
-    /// What `imperial` was when the panel was built, so `remember` can tell a
-    /// user pressing `u` from a config that simply says `imperial`.
-    seeded_imperial: bool,
     /// Set to ask the fetch thread to finish; see `StocksPanel::stop`.
     stop: Arc<AtomicBool>,
 }
@@ -243,7 +240,6 @@ impl WeatherPanel {
             forecast_hours,
             stale_after,
             imperial,
-            seeded_imperial: imperial,
             stop,
         }
     }
@@ -702,9 +698,7 @@ impl Panel for WeatherPanel {
     }
 
     fn remember(&self, state: &mut crate::state::UiState) {
-        if self.imperial != self.seeded_imperial {
-            state.weather_units = Some(if self.imperial { "imperial" } else { "metric" }.into());
-        }
+        state.weather_units = Some(if self.imperial { "imperial" } else { "metric" }.into());
     }
 
     fn shutdown(&mut self) {
@@ -959,7 +953,6 @@ mod tests {
             forecast_hours: 8,
             stale_after: Duration::from_hours(1),
             imperial,
-            seeded_imperial: imperial,
             stop: Arc::new(AtomicBool::new(false)),
         }
     }


### PR DESCRIPTION
Toggling a setting back to what the config says never un-recorded it. Press `u` for metric and the state file says metric; press it again and the screen returns to imperial while the file goes on saying metric — for ever, and across restarts. Seven fields, four panels.

## Why, and it is not where you would look

The comparison was in the wrong place. Each panel held the value it was **built** with and reported a preference only when it differed. But panels are built *after* `apply_state`, so once a setting had been remembered the panel was constructed from the remembered value and could never again see it as equal to the config's. Reporting nothing then left the earlier entry standing, because the app merged into what it had loaded.

## The fix

Panels report current values unconditionally. The comparison happens once, in `UiState::only_changes_from`, against a baseline taken from the config **before** `apply_state` folds anything in. Equal to the config means absent from the file — in both directions, by construction rather than by each panel remembering to be careful.

Every `seeded_*` field goes with it: `seeded_imperial`, `seeded_sort`, `seeded_show_completed`, `seeded_show_seconds`, `seeded: PomodoroConfig`, and the seven guards around them.

## This is the third version of this mechanism

Worth stating plainly, because two of the three look right:

1. **Report everything, no comparison.** Pinned every panel's config values into the state file on the first keystroke anywhere, after which editing the config silently stopped working. Caught by running it.
2. **Each panel compares against what it was built with.** Fixed that, introduced this bug. Caught by an adversarial review reading the data flow.
3. **One comparison, against the config.** Symmetric by construction.

Both earlier versions passed their unit tests. CLAUDE.md now records all three, because the next person will reach for one of the first two.

## Verified end to end

```
press u, quit    → state.toml:  weather_units = "metric"
restart          → dashboard shows 20°C
press u, quit    → state.toml:  (empty)
```

Plus three new tests in `state.rs` pinning the retraction, the untouched-neighbour case, and sort-mode normalisation — a config holding an unparsable sort must not make the default look like a user choice. The pomodoro test that asserted the old panel-level filtering was relocated rather than deleted.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (400 pass), `cargo doc` with `-D warnings`, `cargo +1.95.0 check --all-targets`.