### PR TITLE
Close the release-security gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    permissions:
+      "attestations": "write"
+      "contents": "read"
+      "id-token": "write"
     steps:
       - name: enable windows longpaths
         run: |
@@ -144,6 +148,10 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+      - name: Attest
+        uses: actions/attest@v4
+        with:
+          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Findings from an adversarial review of the whole project, fixed in order of how
+much they could cost someone.
+
+### Fixed
+
+- **`Esc` no longer quits the dashboard.** It was in the global quit arm, so the
+  reflex that closes a dialog closed the program — and any unsaved note went
+  with it.
+- **A long note can be scrolled to its end.** The body scrolled against its
+  unwrapped line count, so wrapping hid the tail.
+- **`Ctrl+S` and `Enter` save from either field of a form**, not just the one
+  the cursor happened to be in.
+- **Removing a symbol from the watchlist reports a failed save** instead of
+  dropping the error.
+- **The weather and stocks pollers stop when their panel goes away.** Neither
+  loop had an exit, and the panel picker rebuilds every panel on every toggle,
+  so a few passes over it left several threads polling the same endpoints —
+  multiplying a request rate that `CLAUDE.md` claimed was enforced in code.
+  Measured: 3 threads at rest, 3 after ten toggles.
+- **mirador no longer panics at startup on Windows** on a machine up for less
+  than a day. `Instant` there counts from boot, so back-dating one by 24 hours
+  returned `None` and the `unwrap` fired before the terminal existed.
+- **A preference can be un-set again.** Switching temperature units to metric
+  and back left the state file insisting on metric, permanently. The comparison
+  that decides what to record now happens once, against the config as it was
+  read, rather than in each panel against the value it was built with.
+
+### Security
+
+- **Every release artifact now carries a GitHub build provenance attestation**,
+  so a download can be proved to have come from this repository's workflow:
+  `gh attestation verify --repo jchultarsky/mirador <file>`.
+- **Documented what the one-line installers actually verify**, which is less
+  than the README claimed: the shell installer checks the archive's sha256, the
+  PowerShell installer checks nothing, and neither checks the updater binary.
+  See [SECURITY.md](SECURITY.md#verifying-a-download).
+- Private vulnerability reporting is enabled, which the security policy already
+  pointed people at. `main` now requires the full CI suite to pass and refuses
+  force-pushes and deletion.
+
 ## [0.4.0] - 2026-07-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,16 @@ installers = ["shell", "powershell"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Checksums to generate for each App
 checksum = "sha256"
+# Have GitHub sign a provenance attestation for every artifact, so anyone can
+# prove a download was built by this repository's workflow from this commit:
+#
+#   gh attestation verify --repo jchultarsky/mirador mirador-<triple>.tar.gz
+#
+# This is the only integrity check that covers *all* the artifacts. The shell
+# installer verifies sha256 for the archive but not for the updater binary, and
+# the PowerShell installer verifies nothing at all — both are dist's behaviour,
+# not ours. See SECURITY.md for what is and is not checked.
+github-attestations = true
 # Ship the standalone updater alongside the shell and PowerShell installers, so
 # someone who installed without a package manager can run `mirador-update`
 # rather than going back to the releases page. It only ever runs when invoked.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,20 @@ and on Windows:
 irm https://github.com/jchultarsky/mirador/releases/latest/download/mirador-installer.ps1 | iex
 ```
 
-Both fetch the right archive for your platform, check it against its published
-checksum, and unpack the binary. If you would rather read the script before
-running it, it is an ordinary file at that URL, and the manual route is below.
+Both fetch the right archive for your platform and unpack the binary. If you
+would rather read the script before running it, it is an ordinary file at that
+URL, and the manual route is below.
+
+The shell installer checks the archive against its published sha256; the
+PowerShell one does no verification, and neither verifies the updater binary.
+That is [dist](https://opensource.axo.dev/cargo-dist/)'s behaviour rather than
+ours, and [SECURITY.md](SECURITY.md#verifying-a-download) says what it does and
+does not buy you. Every artifact carries a GitHub provenance attestation, which
+is the stronger check and the one to run if you care:
+
+```sh
+gh attestation verify --repo jchultarsky/mirador mirador-aarch64-apple-darwin.tar.gz
+```
 
 They also install `mirador-update` beside it, so a later upgrade is:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,14 @@
 
 ## Supported versions
 
-mirador is pre-1.0. Only the latest released version receives fixes.
+mirador is pre-1.0. Only the latest released minor version receives fixes;
+there are no backports. In practice that means whatever is on the
+[releases page](https://github.com/jchultarsky/mirador/releases) right now.
 
 | Version | Supported |
 | --- | --- |
-| 0.1.x | Yes |
+| 0.4.x | Yes |
+| < 0.4 | No — upgrade |
 
 ## Reporting a vulnerability
 
@@ -25,18 +28,34 @@ either way, and credited in the advisory unless you prefer otherwise.
 
 ## Scope
 
-mirador is a local terminal application. It reads its own configuration and
-task files, samples system metrics, and makes outbound HTTPS requests to
-[Open-Meteo](https://open-meteo.com) for weather. It opens no listening ports
-and requires no credentials.
+mirador is a local terminal application. It opens no listening ports, requires
+no credentials, and stores no secrets.
+
+It reads its own configuration, task, note and watchlist files, samples system
+metrics through [sysinfo](https://crates.io/crates/sysinfo), and makes outbound
+HTTPS requests to exactly two hosts, both only when the corresponding widget is
+enabled:
+
+- `api.open-meteo.com` and `geocoding-api.open-meteo.com` —
+  [Open-Meteo](https://open-meteo.com), for the weather panel. It sends the
+  configured location, or the configured coordinates.
+- `query1.finance.yahoo.com` — for the stocks panel. It sends the ticker
+  symbols on your watchlist. This is Yahoo's undocumented chart endpoint; see
+  [Market data](README.md#market-data) for what that means for you.
+
+Neither request carries an identifier, a credential, or anything else about the
+machine.
 
 Things worth reporting:
 
-- Anything that lets a crafted config or task file cause code execution, or
-  write outside the configured paths
-- Anything that causes mirador to send data it should not, to Open-Meteo or
-  anywhere else
+- Anything that lets a crafted config, task, note or watchlist file cause code
+  execution, or write outside the configured paths
+- Anything that causes mirador to send data it should not, to either host above
+  or anywhere else
+- Anything that lets a hostile HTTP response from either host affect the machine
+  beyond a wrong reading on screen
 - A dependency advisory that materially affects mirador as it is used here
+- A gap in the release pipeline beyond the ones already disclosed below
 
 Things that are out of scope:
 
@@ -45,4 +64,46 @@ Things that are out of scope:
   you.
 - Denial of service through absurd config values, such as a several-million
   sample history buffer
-- Vulnerabilities in Open-Meteo itself
+- Vulnerabilities in Open-Meteo or Yahoo themselves
+
+## Verifying a download
+
+Every release artifact carries a [GitHub build
+provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+attestation, signed by GitHub's Sigstore instance. This is the check worth
+running, because it proves more than a checksum does — not just that the bytes
+are intact, but that they were built by this repository's release workflow from
+a specific commit:
+
+```
+gh attestation verify --repo jchultarsky/mirador mirador-aarch64-apple-darwin.tar.gz
+```
+
+Each archive also has a `.sha256` sibling, and the release carries a combined
+`sha256.sum`.
+
+### What the installers do not check
+
+The one-line installers come from [dist](https://opensource.axo.dev/cargo-dist/)
+and their verification is dist's, not ours. As of dist 0.32.0:
+
+- The shell installer verifies the sha256 of the archive it downloads, but
+  **not** of the `mirador-<triple>-update` updater binary it fetches alongside
+  it. `sha256.sum` does not list the updater either.
+- The PowerShell installer verifies **nothing**. It contains no hash check at
+  all.
+
+In both cases the only thing standing between you and a substituted binary is
+TLS to `github.com` — which is also true of the archive's checksum, since the
+checksum is served from the same release over the same connection. So this is a
+defence-in-depth gap rather than an open door, and it is the reason attestations
+are the recommended check above.
+
+If that trade is not one you want to make, install from source instead:
+
+```
+cargo install mirador --locked
+```
+
+This is disclosed rather than fixed because the installers are generated, and
+patching generated files by hand is worse than documenting them accurately.


### PR DESCRIPTION
Task #4 of the adversarial-review plan. Four gaps, one of which turned out to be a false claim in the README rather than a missing feature.

## The installers verify less than we said

`README.md` claimed both one-line installers "check it against its published checksum". Verified against the shipped v0.4.0 assets:

- `mirador-installer.ps1` — 645 lines, **zero** occurrences of `sha256`, `checksum` or `Get-FileHash`. It verifies nothing.
- `mirador-installer.sh` — `verify_checksum` appears twice: the definition at line 1487, and one call at line 319 on the archive. The updater binary it downloads at line 331 is not checked.
- `sha256.sum` lists five files. None is a `-update` binary.

This is [dist](https://opensource.axo.dev/cargo-dist/) behaviour, and 0.32.0 is the latest release, so there is nothing to upgrade to. Hand-patching generated installers would be worse than the gap. So the README and `SECURITY.md` now say what is actually checked, and point at the check that covers everything.

Worth being precise about the severity: the archive checksum is served from the same release over the same TLS connection as the archive, so it never protected against a tampered release either — only against corruption. TLS to `github.com` was always the trust anchor. This is a defence-in-depth inconsistency, not an open door.

## Attestations

`github-attestations = true`, regenerated with `dist generate`. The workflow attests `target/distrib/*<triple>*`, so the updater is covered too:

\`\`\`
gh attestation verify --repo jchultarsky/mirador mirador-aarch64-apple-darwin.tar.gz
\`\`\`

That proves provenance, not just integrity — built by this repo's workflow from a known commit — and it is the first check here that does not reduce to trusting TLS.

## Repository settings (already applied)

- **Private vulnerability reporting** was `{"enabled": false}` while `SECURITY.md` led with the advisory form, so the documented private channel did not work. Enabled.
- **`main` had no protection at all** — `/branches/main/protection` returned 404 and `/rulesets` returned `[]`. There is now an active ruleset requiring all six CI checks, requiring a pull request at zero approvals (a solo repo cannot approve its own), and blocking force-pushes and deletion, with no bypass actors.

The six contexts were taken from the checks GitHub actually reported on #31, not inferred from job names — a required check that never reports hangs every PR permanently. **This PR is the first test of that ruleset.**

> Note for #9: adding `windows-latest` to the test matrix creates a seventh check name, which has to be added to the ruleset or it will not be required.

## SECURITY.md

Supported version said `0.1.x`, three releases stale. Network scope named Open-Meteo only; the stocks panel has talked to `query1.finance.yahoo.com` since 0.2.0. Both hosts are now named, with what each request carries and what it does not.

## Changelog

Adds the `[Unreleased]` heading that the link definition at the bottom of the file has been pointing at since 0.4.0, and records the first four review fixes under it.

---

No `src/` changes, so behaviour is unaffected; `cargo publish --dry-run` and `dist plan` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)