### PR TITLE
Fix six correctness bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,30 @@ much they could cost someone.
   and back left the state file insisting on metric, permanently. The comparison
   that decides what to record now happens once, against the config as it was
   read, rather than in each panel against the value it was built with.
+- **`?` scrolls.** With the tasks panel focused on an 80x24 terminal the overlay
+  had 29 rows of content and 22 rows to draw it in, so nine of that panel's
+  seventeen key bindings — including `/`, `e`, `p`, `s` and `c` — were invisible,
+  with nothing on screen to say so. Arrow keys, `PgUp`/`PgDn`, `Home` and `End`
+  scroll it, and the footer shows where you are. On a terminal with room to spare
+  nothing changes: any key still closes it.
+- **A long task title no longer draws over the panel border.** Titles were
+  truncated by counting characters against a budget measured in terminal cells,
+  so every CJK character or emoji overflowed by one cell.
+- **A misspelled key under `[theme]` is now reported** rather than accepted and
+  ignored. This also un-blocked the `--migrate-config` hint for the pre-0.1.0
+  `rx` and `tx` theme keys, which could never fire because those keys parsed
+  cleanly.
+- **The weather panel recovers from a failure to look up your location.** It used
+  to end its fetch thread, then go on offering "r to retry" with nothing left to
+  act on the key — most often after a laptop resumed before its Wi-Fi did.
+- **A failed price fetch keeps the last price and labels it with its age.** One
+  timed-out request used to blank the price, the change, the percentage and the
+  sparkline together for a whole refresh interval; a fetch thread that stopped
+  quietly showed confident numbers indefinitely. A retained price is now shown
+  muted, with how old it is.
+- Panel rectangles are indexed consistently, so a layout entry that builds no
+  panel cannot shift every later panel onto its neighbour's rectangle — which is
+  what mouse clicks are matched against.
 
 ### Security
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,24 @@ const GLOBAL: &[Binding] = &[
     Binding::extra("Ctrl+C", "quit"),
 ];
 
+/// The text of `lines` with the styling dropped, for measuring.
+///
+/// Only the characters decide how text wraps, so a measurement does not need
+/// the spans — but it does need them concatenated in order, which is why this
+/// is not simply the first span of each line.
+fn plain_text(lines: &[Line<'_>]) -> String {
+    lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Smallest weight a panel or row may be squeezed to.
 const MIN_WEIGHT: u16 = 1;
 
@@ -190,6 +208,14 @@ pub struct App {
     positions: Vec<(usize, usize)>,
     focus: usize,
     show_help: bool,
+    /// First visible line of the help overlay.
+    help_scroll: u16,
+    /// How far the help overlay can scroll, and how tall its viewport is — both
+    /// measured during the render that laid it out, because both depend on the
+    /// terminal width the text wrapped at. Zero overflow is also what tells the
+    /// key handler to leave the arrow keys alone and close on anything.
+    help_overflow: u16,
+    help_viewport: u16,
     should_quit: bool,
     /// Widgets available but not placed by this layout.
     ///
@@ -245,6 +271,9 @@ impl App {
             positions,
             focus: 0,
             show_help: false,
+            help_scroll: 0,
+            help_overflow: 0,
+            help_viewport: 0,
             should_quit: false,
             show_widget_hint: !unused_widgets.is_empty(),
             unused_widgets,
@@ -456,8 +485,28 @@ impl App {
             return;
         }
 
-        // The help overlay swallows the next key, whatever it is.
+        // The help overlay swallows the next key, whatever it is — except the
+        // ones that scroll it, because on an 80x24 terminal the focused panel's
+        // own bindings do not fit and a key that cannot be reached is a key
+        // that does not exist. Scrolling only binds when there is something
+        // below the fold, so on a tall terminal any key still closes it.
         if self.show_help {
+            if self.help_overflow > 0 {
+                let page = self.help_viewport.max(1);
+                let moved = match key.code {
+                    KeyCode::Down | KeyCode::Char('j') => Some(self.help_scroll.saturating_add(1)),
+                    KeyCode::Up | KeyCode::Char('k') => Some(self.help_scroll.saturating_sub(1)),
+                    KeyCode::PageDown => Some(self.help_scroll.saturating_add(page)),
+                    KeyCode::PageUp => Some(self.help_scroll.saturating_sub(page)),
+                    KeyCode::Home => Some(0),
+                    KeyCode::End => Some(self.help_overflow),
+                    _ => None,
+                };
+                if let Some(to) = moved {
+                    self.help_scroll = to.min(self.help_overflow);
+                    return;
+                }
+            }
             self.show_help = false;
             return;
         }
@@ -613,7 +662,12 @@ impl App {
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Tab => self.cycle_focus(true),
             KeyCode::BackTab => self.cycle_focus(false),
-            KeyCode::Char('?') => self.show_help = true,
+            KeyCode::Char('?') => {
+                self.show_help = true;
+                // Opening it always starts at the top; the bindings for the
+                // panel you just focused are the reason you pressed `?`.
+                self.help_scroll = 0;
+            }
             KeyCode::Char('w') => self.picker = Some(0),
             KeyCode::Char(c @ '1'..='9') => {
                 let index = c as usize - '1' as usize;
@@ -830,7 +884,13 @@ impl App {
 
         let heights = distribute(area.height, &row_weights, &row_maxima);
 
-        let mut rects = Vec::with_capacity(self.slots.len());
+        // Indexed by slot, not by layout column, and written through `slot_at`.
+        // Pushing one rect per column assumes every layout entry produced a
+        // panel; a single entry that did not shifts every later slot onto the
+        // previous entry's rectangle, which is what `slot.area` hit-tests, so
+        // clicks land on the wrong panel. A slot that gets no rectangle keeps
+        // the zero one and is skipped by the caller's size check.
+        let mut rects = vec![Rect::default(); self.slots.len()];
         let mut y = area.y;
         for (row_index, row) in rows.iter().enumerate() {
             let height = heights.get(row_index).copied().unwrap_or(0);
@@ -845,8 +905,10 @@ impl App {
             let columns = distribute(area.width, &widths, &maxima);
 
             let mut x = area.x;
-            for width in columns {
-                rects.push(Rect::new(x, y, width, height));
+            for (column, width) in columns.into_iter().enumerate() {
+                if let Some(slot) = self.slot_at(row_index, column) {
+                    rects[slot] = Rect::new(x, y, width, height);
+                }
                 x = x.saturating_add(width);
             }
             y = y.saturating_add(height);
@@ -1070,8 +1132,9 @@ impl App {
         );
     }
 
-    fn render_help(&self, frame: &mut ratatui::Frame, area: Rect) {
-        let theme = &self.config.theme;
+    fn render_help(&mut self, frame: &mut ratatui::Frame, area: Rect) {
+        let theme = self.config.theme.clone();
+        let theme = &theme;
         let key_style = Style::default().fg(theme.key).add_modifier(Modifier::BOLD);
         let muted = Style::default().fg(theme.muted);
 
@@ -1110,11 +1173,10 @@ impl App {
         if !self.unused_widgets.is_empty() {
             lines.push(Line::from(""));
             lines.push(section("widgets not in your layout"));
-            // The overlay clips silently when the content outgrows the screen,
-            // so the actionable line comes before the list: losing the names
-            // still leaves you able to act, losing the instruction does not.
-            // The names go on one wrapped line for the same reason — one line
-            // per widget cost eight rows on a stale config.
+            // The actionable line comes before the list because it is the more
+            // useful of the two if only one is on screen. The names go on one
+            // wrapped line because one line per widget cost eight rows on a
+            // stale config.
             lines.push(Line::from(vec![
                 Span::styled("  press ", muted),
                 Span::styled("w", key_style),
@@ -1126,16 +1188,22 @@ impl App {
             )));
         }
 
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "  any key to close",
-            Style::default()
-                .fg(theme.muted)
-                .add_modifier(Modifier::ITALIC),
-        )));
-
+        // The footer is rendered separately and pinned to the last row, rather
+        // than being the last line of the scrolling text. A hint saying how to
+        // close the overlay is no use once it has scrolled out of the overlay.
         let width = 46.min(area.width);
-        let height = (u16::try_from(lines.len()).unwrap_or(u16::MAX) + 2).min(area.height);
+        // Two borders and one cell of padding on each side.
+        let text_width = width.saturating_sub(4).max(1);
+        // Measured after wrapping, not from `lines.len()`. The two differ
+        // whenever a line is longer than the popup, which the list of unused
+        // widgets routinely is — sizing from the unwrapped count is how the
+        // overlay came to be shorter than its own contents.
+        let text_height = crate::grid::wrapped_height(&plain_text(&lines), text_width);
+        let body = Paragraph::new(lines).wrap(Wrap { trim: false });
+
+        // Borders, the blank line, and the footer.
+        let chrome = 4;
+        let height = text_height.saturating_add(chrome).min(area.height);
         let popup = Rect {
             x: area.x + area.width.saturating_sub(width) / 2,
             y: area.y + area.height.saturating_sub(height) / 2,
@@ -1161,7 +1229,72 @@ impl App {
             ]));
         let inner = block.inner(popup);
         frame.render_widget(block, popup);
-        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+
+        if inner.height == 0 {
+            self.help_overflow = 0;
+            self.help_viewport = 0;
+            return;
+        }
+
+        // Give the footer the last row and the blank line the one above it,
+        // but never at the cost of showing no text at all.
+        let footer_rows = 2.min(inner.height.saturating_sub(1));
+        let viewport = Rect {
+            height: inner.height - footer_rows,
+            ..inner
+        };
+
+        self.help_viewport = viewport.height;
+        self.help_overflow = text_height.saturating_sub(viewport.height);
+        // The terminal may have shrunk since the last frame, or the focused
+        // panel changed to one with fewer bindings.
+        self.help_scroll = self.help_scroll.min(self.help_overflow);
+
+        frame.render_widget(body.scroll((self.help_scroll, 0)), viewport);
+
+        if footer_rows > 0 {
+            let footer = Rect {
+                y: inner.y + inner.height - 1,
+                height: 1,
+                ..inner
+            };
+            frame.render_widget(Paragraph::new(self.help_footer(theme)), footer);
+        }
+    }
+
+    /// The pinned last row of the help overlay.
+    ///
+    /// It says how to close the overlay, and when there is more text than fits,
+    /// that scrolling is possible and where in the list you are. Without the
+    /// position there is no way to tell a full list from a truncated one.
+    fn help_footer(&self, theme: &crate::theme::Theme) -> Line<'static> {
+        let italic = Style::default()
+            .fg(theme.muted)
+            .add_modifier(Modifier::ITALIC);
+
+        if self.help_overflow == 0 {
+            return Line::from(Span::styled("any key to close", italic));
+        }
+
+        let key_style = Style::default().fg(theme.key).add_modifier(Modifier::BOLD);
+        let more_above = self.help_scroll > 0;
+        let more_below = self.help_scroll < self.help_overflow;
+        let arrows = match (more_above, more_below) {
+            (true, true) => "↑↓",
+            (true, false) => "↑",
+            _ => "↓",
+        };
+        Line::from(vec![
+            Span::styled(arrows, key_style),
+            Span::styled(
+                format!(
+                    " {}/{} · any other key to close",
+                    self.help_scroll + self.help_viewport,
+                    self.help_overflow + self.help_viewport,
+                ),
+                italic,
+            ),
+        ])
     }
 }
 
@@ -1409,6 +1542,74 @@ mod tests {
                 .draw(|frame| app.render_for_test(frame))
                 .unwrap_or_else(|e| panic!("help failed to draw at {width}x{height}: {e}"));
         }
+    }
+
+    #[test]
+    fn every_binding_of_the_focused_panel_is_reachable_on_an_80x24_terminal() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // The tasks panel declares 17 bindings; with the global block, the
+        // section headings and the footer that is well past the 22 rows an
+        // 80x24 terminal leaves inside the overlay. It used to clip there
+        // silently, so about a third of the keys did not exist as far as
+        // anyone reading `?` could tell.
+        let mut app = App::new(config_with(&["todo"])).unwrap();
+        let bindings = app.slots[0].panel.bindings().len();
+        assert!(bindings > 4, "this test needs a panel with many bindings");
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+        terminal.draw(|frame| app.render_for_test(frame)).unwrap();
+
+        assert!(
+            app.help_overflow > 0,
+            "the overlay fits at 80x24, so this test no longer proves anything"
+        );
+
+        // Scroll to the bottom one key at a time, redrawing as a user would.
+        let mut guard = 0;
+        while app.help_scroll < app.help_overflow {
+            app.handle_key(KeyEvent::from(KeyCode::Down));
+            terminal.draw(|frame| app.render_for_test(frame)).unwrap();
+            assert!(app.show_help, "scrolling must not dismiss the overlay");
+            guard += 1;
+            assert!(guard < 200, "scrolling made no progress");
+        }
+
+        // The last row of text is on screen, and `End` and `Home` agree.
+        app.handle_key(KeyEvent::from(KeyCode::Home));
+        assert_eq!(app.help_scroll, 0);
+        app.handle_key(KeyEvent::from(KeyCode::End));
+        assert_eq!(app.help_scroll, app.help_overflow);
+
+        // Anything that is not a scroll key still closes it.
+        app.handle_key(KeyEvent::from(KeyCode::Char('x')));
+        assert!(
+            !app.show_help,
+            "a non-scroll key must still close the overlay"
+        );
+    }
+
+    #[test]
+    fn the_overlay_closes_on_any_key_when_it_all_fits() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // Scrolling only binds the arrow keys when there is something below the
+        // fold. On a terminal with room to spare, `?` then Down must close,
+        // because that is what "any key to close" promises.
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(120, 60)).unwrap();
+        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+        terminal.draw(|frame| app.render_for_test(frame)).unwrap();
+
+        assert_eq!(
+            app.help_overflow, 0,
+            "120x60 has room for the whole overlay"
+        );
+        app.handle_key(KeyEvent::from(KeyCode::Down));
+        assert!(!app.show_help);
     }
 
     #[test]
@@ -1701,6 +1902,38 @@ mod tests {
             assert!(rect.x + rect.width <= area.x + area.width);
             assert!(rect.y + rect.height <= area.y + area.height);
         }
+    }
+
+    #[test]
+    fn a_layout_entry_that_builds_no_panel_does_not_shift_the_rest() {
+        // `geometry` used to push one rect per layout column and `render` read
+        // it back by slot index. Any entry that produced no panel made the two
+        // disagree, so every later slot drew — and hit-tested clicks — in the
+        // previous entry's box.
+        //
+        // `Config::validate` rejects an unknown widget name, but `App::new`
+        // does not re-validate and neither does `rebuild_panels`, so this is
+        // one `config.layout` mutation away from being reachable.
+        let mut config = config_with(&["nope", "clocks", "cpu"]);
+        config.layout.rows[0].panels[0].width = 25;
+        config.layout.rows[0].panels[1].width = 25;
+        config.layout.rows[0].panels[2].width = 50;
+
+        let app = App::new(config).unwrap();
+        assert_eq!(app.slots.len(), 2, "the unknown widget builds no panel");
+        assert_eq!(app.positions, vec![(0, 1), (0, 2)]);
+
+        let rects = app.geometry(Rect::new(0, 0, 80, 24));
+        assert_eq!(rects.len(), 2, "one rect per slot, not per layout column");
+
+        // Column 0 is 20 cells wide and belongs to nothing. The clock is the
+        // first *slot* but the second *column*, so it starts at x = 20.
+        assert_eq!(
+            rects[0].x, 20,
+            "the clock took the missing panel's rectangle"
+        );
+        assert_eq!(rects[1].x, rects[0].x + rects[0].width);
+        assert_eq!(rects[0].width + rects[1].width, 60);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -856,6 +856,48 @@ mod tests {
     }
 
     #[test]
+    fn a_misspelled_theme_key_is_reported_rather_than_ignored() {
+        // `deny_unknown_fields` on `Config` only guards the top level, so
+        // `[theme]` was handed to a struct that accepted anything and dropped
+        // what it did not know. A one-letter slip meant a colour that never
+        // changed and nothing on screen to say why.
+        for source in [
+            "[theme]\nacent = \"#ff0000\"",
+            "[theme.rx_gradient]\nstrat = \"green\"",
+        ] {
+            let err = toml::from_str::<Config>(source)
+                .map_err(|e| stale_config_hint(&e, Path::new("/tmp/config.toml")))
+                .unwrap_err();
+            let message = format!("{err:#}");
+            assert!(
+                message.contains("acent") || message.contains("strat"),
+                "{source} was accepted, or the error did not name the key: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_pre_0_1_0_theme_keys_reach_their_migration_hint() {
+        // These two entries sat in `RENAMED` unreachable: `[theme] rx = ...`
+        // parsed clean, so the hint telling the user to run
+        // `--migrate-config` could not fire for the very keys it names.
+        for key in ["rx", "tx"] {
+            let err = toml::from_str::<Config>(&format!("[theme]\n{key} = \"green\""))
+                .map_err(|e| stale_config_hint(&e, Path::new("/tmp/config.toml")))
+                .expect_err("an old theme key must be rejected");
+            let message = format!("{err:#}");
+            assert!(
+                message.contains("--migrate-config"),
+                "`{key}` did not reach the migration hint: {message}"
+            );
+            assert!(
+                message.contains(&format!("[theme.{key}_gradient]")),
+                "`{key}` did not name its replacement: {message}"
+            );
+        }
+    }
+
+    #[test]
     fn bad_units_are_rejected() {
         let config: Config = toml::from_str("[weather]\nunits = \"kelvin\"").expect("parses");
         assert!(config.validate().is_err());

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -27,6 +27,85 @@ pub fn display_width(text: &str) -> usize {
     UnicodeWidthStr::width(text)
 }
 
+/// Cut `text` down to `width` terminal cells, ending in `…` if anything was
+/// dropped.
+///
+/// Measured in cells for the same reason as [`display_width`]: budgeting by
+/// `chars().count()` means one CJK glyph or emoji per two cells of overflow,
+/// which is enough to push the text through the panel's own border.
+///
+/// The result never exceeds `width`, but may fall one cell short of it when a
+/// double-width character would not fit — there is no half a cell to give
+/// back. Callers that need an exact width should pad, as [`fit`] does.
+pub fn truncate(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if display_width(text) <= width {
+        return text.to_string();
+    }
+
+    // Take characters while they fit, keeping one cell back for the ellipsis.
+    let budget = width - 1;
+    let mut out = String::new();
+    let mut used = 0usize;
+    for c in text.chars() {
+        let w = char_width(c);
+        if used + w > budget {
+            break;
+        }
+        out.push(c);
+        used += w;
+    }
+    out.push('…');
+    out
+}
+
+/// Display width of a single character, treating unprintables as zero-width.
+fn char_width(c: char) -> usize {
+    unicode_width::UnicodeWidthChar::width(c).unwrap_or(0)
+}
+
+/// Rows that `text` occupies once word-wrapped to `width` cells.
+///
+/// Needed wherever something is sized to fit its own contents — a scroll
+/// clamp, or a dialog that must not be shorter than the text inside it. The
+/// unwrapped line count is not a substitute: it is right until a line is
+/// longer than the box, and then it is short by exactly the amount that
+/// matters.
+///
+/// Matches `Paragraph::new(text).wrap(Wrap { trim: false })`, whose own
+/// `line_count` is private. An empty line still occupies a row.
+pub fn wrapped_height(text: &str, width: u16) -> u16 {
+    if width == 0 {
+        return 0;
+    }
+    let width = usize::from(width);
+    let mut rows: usize = 0;
+
+    for line in text.lines() {
+        let mut used = 0usize;
+        let mut rows_here = 1usize;
+        for word in line.split_inclusive(' ') {
+            let w = display_width(word);
+            if used > 0 && used + w > width {
+                rows_here += 1;
+                used = w;
+            } else {
+                used += w;
+            }
+            // A single word longer than the line wraps within itself.
+            while used > width {
+                rows_here += 1;
+                used -= width;
+            }
+        }
+        rows += rows_here;
+    }
+
+    u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
+}
+
 /// How a column is sized.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Width {
@@ -265,21 +344,9 @@ fn fit(text: &str, width: u16, align: Align) -> String {
 
     let actual = display_width(text);
     if actual > width {
-        // Take characters while they fit, leaving one cell for the ellipsis.
-        let mut out = String::new();
-        let mut used = 0usize;
-        for c in text.chars() {
-            let w = UnicodeWidthStr::width(c.to_string().as_str());
-            if used + w > width.saturating_sub(1) {
-                break;
-            }
-            out.push(c);
-            used += w;
-        }
-        out.push('…');
-        used += 1;
+        let mut out = truncate(text, width);
         // A double-width character can leave the result a cell short.
-        out.push_str(&" ".repeat(width.saturating_sub(used)));
+        out.push_str(&" ".repeat(width.saturating_sub(display_width(&out))));
         return out;
     }
 

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -125,12 +125,18 @@ pub trait Panel {
 
     /// Contribute any preference this panel wants remembered across restarts.
     ///
-    /// Write a setting only when it differs from the value the panel was built
-    /// with. A panel that reports everything pins the config's own values into
-    /// the state file the first time any *other* preference moves, and editing
-    /// the config then silently stops working — which is the failure this whole
-    /// mechanism exists to avoid. Comparing against the seed is what keeps
-    /// "changed by the user" and "merely configured" apart.
+    /// Report the panel's *current* values, unconditionally. Deciding whether a
+    /// value is worth writing is not a panel's job: the shell compares the whole
+    /// set against the config as it was read, before any remembered preference
+    /// was folded in, and writes only the difference.
+    ///
+    /// Do not filter here by comparing against the value the panel was built
+    /// with. That was the previous design and it made a preference impossible to
+    /// retract: panels are built *after* remembered preferences are applied, so
+    /// once a setting had been recorded the panel was constructed from the
+    /// recorded value and could never see it as equal to the config's again.
+    /// Setting it back to the config's value then wrote nothing, which left the
+    /// old entry standing for ever. See `CLAUDE.md` invariant 17.
     ///
     /// There is no matching load hook on purpose. Remembered preferences are
     /// applied to the config before any panel is built, so a panel sees the
@@ -139,4 +145,20 @@ pub trait Panel {
 
     /// Called once before the terminal is torn down, so panels can flush state.
     fn shutdown(&mut self) {}
+}
+
+/// Render a duration the way a person would say it.
+///
+/// Used wherever a panel shows data it fetched rather than computed, which is
+/// the only honest way to present a reading that may have stopped updating.
+pub fn describe_age(age: Duration) -> String {
+    let minutes = age.as_secs() / 60;
+    if minutes < 60 {
+        return format!("{minutes}m old");
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        return format!("{hours}h old");
+    }
+    format!("{}d old", hours / 24)
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -47,7 +47,7 @@ fn de_opt_color<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<Col
 /// `mid` and `end` are optional: with neither, the ramp is flat; with `end`
 /// only, it is a single linear segment.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct GradientStops {
     #[serde(deserialize_with = "de_color")]
     pub start: Color,
@@ -83,8 +83,13 @@ impl GradientStops {
 }
 
 /// Every colour the dashboard draws with.
+///
+/// `deny_unknown_fields` matters more here than it looks. Without it a
+/// misspelled colour is accepted and silently ignored — and because the
+/// pre-0.1.0 theme keys `rx` and `tx` also parsed clean, the
+/// `--migrate-config` hint that names them could never fire.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Theme {
     /// Frame of an unfocused panel.
     #[serde(deserialize_with = "de_color")]

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -20,7 +20,7 @@ use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
 
 use crate::config::NotesConfig;
 use crate::frame::Binding;
-use crate::grid::{Column, Grid};
+use crate::grid::{Column, Grid, wrapped_height};
 use crate::note::{Note, NoteStore};
 use crate::panel::{KeyOutcome, Panel, RenderContext};
 use crate::textarea::TextArea;
@@ -846,46 +846,6 @@ impl Panel for NotesPanel {
     fn shutdown(&mut self) {
         self.store.save_reporting();
     }
-}
-
-/// Rows `body` occupies once wrapped to `width`.
-///
-/// Word wrapping, matching how the reader renders it, and measured in display
-/// cells rather than characters — a note full of CJK or emoji wraps at half the
-/// character count. An empty line still occupies a row.
-fn wrapped_height(body: &str, width: u16) -> u16 {
-    if width == 0 {
-        return 0;
-    }
-    let width = usize::from(width);
-    let mut rows: usize = 0;
-
-    for line in body.lines() {
-        let mut used = 0usize;
-        let mut rows_here = 1usize;
-        for word in line.split_inclusive(' ') {
-            let w = display_width(word);
-            if used > 0 && used + w > width {
-                rows_here += 1;
-                used = w;
-            } else {
-                used += w;
-            }
-            // A single word longer than the line wraps within itself.
-            while used > width {
-                rows_here += 1;
-                used -= width;
-            }
-        }
-        rows += rows_here;
-    }
-
-    u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
-}
-
-/// Width in display cells.
-fn display_width(text: &str) -> usize {
-    unicode_width::UnicodeWidthStr::width(text)
 }
 
 #[cfg(test)]

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -16,7 +16,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ratatui::Frame;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
@@ -28,7 +28,7 @@ use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 use crate::config::StocksConfig;
 use crate::frame::Binding;
 use crate::grid::{Column, Grid};
-use crate::panel::{KeyOutcome, Panel, RenderContext};
+use crate::panel::{KeyOutcome, Panel, RenderContext, describe_age};
 use crate::quote::{Quote, QuoteSource, Watchlist, source_for, sparkline};
 use crate::textfield::TextField;
 use crate::theme::Theme;
@@ -77,11 +77,36 @@ const COLUMNS: &[Column] = &[
 ];
 
 /// What the background thread has produced for one symbol.
-#[derive(Debug, Clone)]
-enum Cell {
-    Loading,
-    Ready(Quote),
-    Failed(String),
+///
+/// Shaped like the weather panel's `State` and for the same reason: a
+/// failed request keeps the last good price and shows how old it is, instead of
+/// replacing a real number with a dash for a whole refresh interval. This panel
+/// used to overwrite the quote with the error, so one timed-out request blanked
+/// the price, the change, the percentage and the sparkline together — and with
+/// no timestamp anywhere, a thread that quietly stopped went on showing
+/// confident numbers for as long as the dashboard was open.
+///
+/// The rule is the one weather follows: old data labelled old is useful, no
+/// data is not, and old data presented as current is the only unacceptable
+/// outcome.
+#[derive(Debug, Clone, Default)]
+struct Cell {
+    /// The last good quote and when it landed, if one ever did.
+    quote: Option<(Quote, Instant)>,
+    /// Why the most recent attempt failed, if it did.
+    error: Option<String>,
+}
+
+impl Cell {
+    /// How long ago the price on screen was fetched.
+    fn age(&self) -> Option<Duration> {
+        self.quote.as_ref().map(|(_, at)| at.elapsed())
+    }
+
+    /// Whether what is on screen should be presented as possibly out of date.
+    fn is_stale(&self, after: Duration) -> bool {
+        self.error.is_some() || self.age().is_some_and(|age| age > after)
+    }
 }
 
 /// The shared snapshot: one entry per symbol, in watchlist order.
@@ -117,6 +142,10 @@ pub struct StocksPanel {
     status: Option<(String, bool)>,
     source_name: &'static str,
     list_area: Option<Rect>,
+    /// Twice the refresh interval. Past this a price is shown as stale even
+    /// when nothing has failed — a fetch thread that quietly stopped and a
+    /// laptop resumed from sleep both look like success from here.
+    stale_after: Duration,
     /// Set to ask the fetch thread to finish.
     ///
     /// Without it the thread outlives the panel: the picker rebuilds every
@@ -143,7 +172,7 @@ impl StocksPanel {
         let board: Board = watchlist
             .symbols()
             .iter()
-            .map(|s| (s.clone(), Cell::Loading))
+            .map(|s| (s.clone(), Cell::default()))
             .collect();
         let board = Arc::new(Mutex::new(board));
         let request = Arc::new(Mutex::new(Request {
@@ -184,6 +213,9 @@ impl StocksPanel {
             status: None,
             source_name,
             list_area: None,
+            // Twice the interval, matching the weather panel: one missed cycle
+            // is a blip, two is a pattern.
+            stale_after: interval * 2,
             stop,
         };
         panel.reselect();
@@ -264,7 +296,7 @@ impl StocksPanel {
                     .iter()
                     .find(|(s, _)| s == symbol)
                     .map(|(_, cell)| cell.clone());
-                (symbol.clone(), previous.unwrap_or(Cell::Loading))
+                (symbol.clone(), previous.unwrap_or_default())
             })
             .collect();
     }
@@ -363,7 +395,14 @@ impl StocksPanel {
     }
 
     /// One row of the board.
-    fn row(symbol: &str, cell: &Cell, theme: &Theme, grid: &Grid, spark: u16) -> Line<'static> {
+    fn row(
+        symbol: &str,
+        cell: &Cell,
+        stale: bool,
+        theme: &Theme,
+        grid: &Grid,
+        spark: u16,
+    ) -> Line<'static> {
         let symbol_span = Span::styled(
             symbol.to_string(),
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
@@ -371,24 +410,32 @@ impl StocksPanel {
 
         // Never an empty cell: a blank column reads as a broken panel, where
         // an explicit `…` or `–` reads as a fact about the data.
-        let (last, chg, pct, spark_text, tone) = match cell {
-            Cell::Loading => (
-                "…".to_string(),
-                "…".to_string(),
-                "…".to_string(),
-                String::new(),
-                theme.muted,
-            ),
-            Cell::Failed(_) => (
+        let (last, chg, pct, spark_text, tone) = match &cell.quote {
+            // Nothing has ever landed for this symbol. Only here is the row
+            // genuinely empty — a failure with a price behind it keeps the
+            // price.
+            None if cell.error.is_some() => (
                 "–".to_string(),
                 "–".to_string(),
                 "–".to_string(),
                 String::new(),
                 theme.error,
             ),
-            Cell::Ready(q) => {
+            None => (
+                "…".to_string(),
+                "…".to_string(),
+                "…".to_string(),
+                String::new(),
+                theme.muted,
+            ),
+            Some((q, _)) => {
                 let change = q.change();
-                let tone = if change > 0.0 {
+                // A price that may have moved since must not be coloured as
+                // though the direction were current, so a stale row goes muted
+                // whichever way it last went.
+                let tone = if stale {
+                    theme.muted
+                } else if change > 0.0 {
                     theme.success
                 } else if change < 0.0 {
                     theme.error
@@ -409,9 +456,10 @@ impl StocksPanel {
             }
         };
 
-        let value_style = match cell {
-            Cell::Ready(_) => Style::default().fg(theme.text),
-            _ => Style::default().fg(tone),
+        let value_style = if cell.quote.is_some() && !stale {
+            Style::default().fg(theme.text)
+        } else {
+            Style::default().fg(tone)
         };
 
         grid.row(&[
@@ -446,9 +494,16 @@ impl StocksPanel {
             _ => {
                 // With nothing else to say, surface the first failure rather
                 // than leaving a row showing `–` with no explanation anywhere.
-                let failure = board.iter().find_map(|(symbol, cell)| match cell {
-                    Cell::Failed(why) => Some(format!("{symbol}: {why}")),
-                    _ => None,
+                let failure = board.iter().find_map(|(symbol, cell)| {
+                    cell.error.as_ref().map(|why| match cell.age() {
+                        // A price is still on screen behind the error, so
+                        // say how old it is rather than only why the last
+                        // attempt failed.
+                        Some(age) => {
+                            format!("{symbol}: {why} — showing {}", describe_age(age))
+                        }
+                        None => format!("{symbol}: {why}"),
+                    })
                 });
                 match failure {
                     // Left full length: the paragraph clips it to the panel,
@@ -483,11 +538,8 @@ fn fetch_loop(
         };
 
         for symbol in &symbols {
-            let cell = match source.fetch(symbol) {
-                Ok(quote) => Cell::Ready(quote),
-                Err(e) => Cell::Failed(format!("{e:#}")),
-            };
-            update(board, symbol, cell);
+            let result = source.fetch(symbol);
+            update(board, symbol, result);
             if stop.load(Ordering::Relaxed) {
                 return;
             }
@@ -518,15 +570,25 @@ fn fetch_loop(
     }
 }
 
-/// Write one symbol's result into the shared board, ignoring symbols that were
+/// Merge one symbol's result into the shared board, ignoring symbols that were
 /// removed while the request was in flight.
-fn update(board: &Arc<Mutex<Board>>, symbol: &str, cell: Cell) {
+///
+/// Merge rather than replace: a failure records the reason and leaves whatever
+/// price was already there, so the row keeps a real number with its age on it.
+fn update(board: &Arc<Mutex<Board>>, symbol: &str, result: anyhow::Result<Quote>) {
     let mut guard = match board.lock() {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
     };
-    if let Some(slot) = guard.iter_mut().find(|(s, _)| s == symbol) {
-        slot.1 = cell;
+    let Some(slot) = guard.iter_mut().find(|(s, _)| s == symbol) else {
+        return;
+    };
+    match result {
+        Ok(quote) => {
+            slot.1.quote = Some((quote, Instant::now()));
+            slot.1.error = None;
+        }
+        Err(e) => slot.1.error = Some(format!("{e:#}")),
     }
 }
 
@@ -657,7 +719,10 @@ impl Panel for StocksPanel {
 
         let items: Vec<ListItem> = board
             .iter()
-            .map(|(symbol, cell)| ListItem::new(Self::row(symbol, cell, theme, &grid, spark)))
+            .map(|(symbol, cell)| {
+                let stale = cell.is_stale(self.stale_after);
+                ListItem::new(Self::row(symbol, cell, stale, theme, &grid, spark))
+            })
             .collect();
 
         self.list_area = Some(rows[1]);
@@ -720,6 +785,22 @@ mod tests {
 
     fn press(p: &mut StocksPanel, code: KeyCode) {
         p.handle_key(KeyEvent::new(code, KeyModifiers::NONE));
+    }
+
+    /// A cell holding a live quote, as a successful fetch leaves it.
+    fn ready(quote: Quote) -> Cell {
+        Cell {
+            quote: Some((quote, Instant::now())),
+            error: None,
+        }
+    }
+
+    /// A cell whose only fetch failed, so there is no price behind the error.
+    fn failed(why: &str) -> Cell {
+        Cell {
+            quote: None,
+            error: Some(why.to_string()),
+        }
     }
 
     fn type_str(p: &mut StocksPanel, text: &str) {
@@ -822,7 +903,7 @@ mod tests {
         assert!(
             board
                 .iter()
-                .all(|(_, c)| matches!(c, Cell::Loading | Cell::Ready(_) | Cell::Failed(_))),
+                .all(|(_, c)| c.quote.is_some() || c.error.is_some() || c.age().is_none()),
             "every row must render as something"
         );
     }
@@ -847,19 +928,29 @@ mod tests {
         let theme = Theme::default();
         let grid = Grid::new(COLUMNS, 60);
 
-        for cell in [
-            Cell::Loading,
-            Cell::Failed("network request failed".into()),
-            Cell::Ready(Quote {
-                symbol: "AAPL".into(),
-                price: 213.5,
-                previous_close: 211.0,
-                currency: Some("USD".into()),
-                series: vec![211.0, 213.5],
-                delayed: false,
-            }),
+        let quote = Quote {
+            symbol: "AAPL".into(),
+            price: 213.5,
+            previous_close: 211.0,
+            currency: Some("USD".into()),
+            series: vec![211.0, 213.5],
+            delayed: false,
+        };
+        for (cell, stale) in [
+            // Loading, never-succeeded failure, live, and a failure with a
+            // price behind it — the state that used to render as three dashes.
+            (Cell::default(), false),
+            (failed("network request failed"), false),
+            (ready(quote.clone()), false),
+            (
+                Cell {
+                    error: Some("timed out".into()),
+                    ..ready(quote.clone())
+                },
+                true,
+            ),
         ] {
-            let line = StocksPanel::row("AAPL", &cell, &theme, &grid, 8);
+            let line = StocksPanel::row("AAPL", &cell, stale, &theme, &grid, 8);
             let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
             assert!(
                 !text.trim().is_empty(),
@@ -887,7 +978,7 @@ mod tests {
         down.price = 9.0;
 
         let text = |q: Quote| -> String {
-            StocksPanel::row("X", &Cell::Ready(q), &theme, &grid, 0)
+            StocksPanel::row("X", &ready(q), false, &theme, &grid, 0)
                 .spans
                 .iter()
                 .map(|s| s.content.as_ref())
@@ -903,7 +994,7 @@ mod tests {
         assert!(fall.contains("-10.00%"), "got `{fall}`");
 
         let colour_of = |q: Quote| {
-            StocksPanel::row("X", &Cell::Ready(q), &theme, &grid, 0).spans[4]
+            StocksPanel::row("X", &ready(q), false, &theme, &grid, 0).spans[4]
                 .style
                 .fg
         };
@@ -918,7 +1009,7 @@ mod tests {
     fn a_failure_is_surfaced_in_the_status_line_rather_than_only_as_a_dash() {
         let (p, _g) = panel("failure", &["AAPL"]);
         let theme = Theme::default();
-        let board: Board = vec![("AAPL".into(), Cell::Failed("HTTP 429".into()))];
+        let board: Board = vec![("AAPL".into(), failed("HTTP 429"))];
 
         let text: String = p
             .status_line(&theme, &board)
@@ -930,6 +1021,66 @@ mod tests {
         assert!(
             text.contains("429"),
             "the reason must reach the user: `{text}`"
+        );
+    }
+
+    #[test]
+    fn a_failed_fetch_keeps_the_last_good_price_and_says_it_is_old() {
+        let (p, _g) = panel("retain", &["AAPL"]);
+        let theme = Theme::default();
+        let grid = Grid::new(COLUMNS, 60);
+
+        let quote = Quote {
+            symbol: "AAPL".into(),
+            price: 213.5,
+            previous_close: 211.0,
+            currency: Some("USD".into()),
+            series: vec![211.0, 213.5],
+            delayed: false,
+        };
+
+        let board = Arc::new(Mutex::new(vec![("AAPL".to_string(), Cell::default())]));
+        update(&board, "AAPL", Ok(quote));
+        update(&board, "AAPL", Err(anyhow::anyhow!("HTTP 429")));
+
+        let snapshot = board.lock().unwrap().clone();
+        let cell = &snapshot[0].1;
+
+        // The whole point: the error did not take the price with it. This used
+        // to render as three dashes and an empty sparkline for a full refresh
+        // interval, because the error replaced the quote outright.
+        assert!(cell.error.is_some(), "the reason is still recorded");
+        let row: String = StocksPanel::row("AAPL", cell, true, &theme, &grid, 8)
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(row.contains("213.50"), "the price was lost: `{row}`");
+        assert!(!row.contains('–'), "a retained price must not show a dash");
+
+        // And it is not passed off as current: the status line says how old it
+        // is, and the row is muted rather than coloured by direction.
+        let status: String = p
+            .status_line(&theme, &snapshot)
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(status.contains("429"), "got `{status}`");
+        assert!(
+            status.contains("old"),
+            "a retained price must be labelled with its age: `{status}`"
+        );
+
+        let live = StocksPanel::row("AAPL", cell, false, &theme, &grid, 8).spans[2]
+            .style
+            .fg;
+        let stale = StocksPanel::row("AAPL", cell, true, &theme, &grid, 8).spans[2]
+            .style
+            .fg;
+        assert_ne!(
+            live, stale,
+            "a stale price must not look the same as a live one"
         );
     }
 

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -1137,18 +1137,11 @@ fn centred(area: Rect, width: u16, height: u16) -> Rect {
     }
 }
 
-/// Truncate to `width` characters with an ellipsis, respecting char boundaries.
-fn truncate(text: &str, width: usize) -> String {
-    if width == 0 {
-        return String::new();
-    }
-    if text.chars().count() <= width {
-        return text.to_string();
-    }
-    let mut out: String = text.chars().take(width.saturating_sub(1)).collect();
-    out.push('…');
-    out
-}
+// Truncation is `grid::truncate`, which measures display cells. This module
+// had its own copy that counted `chars()`, and both callers pass a cell count
+// — `inner.width` and `bottom.width` — so a CJK title overflowed the panel by
+// one cell per character.
+use crate::grid::truncate;
 
 #[cfg(test)]
 mod tests {
@@ -1165,11 +1158,24 @@ mod tests {
     }
 
     #[test]
-    fn truncate_respects_char_boundaries() {
+    fn a_truncated_title_never_outgrows_its_budget_in_cells() {
         assert_eq!(truncate("hello", 10), "hello");
         assert_eq!(truncate("hello", 3), "he…");
-        assert_eq!(truncate("日本語テスト", 3), "日本…");
         assert_eq!(truncate("hello", 0), "");
+
+        // This used to assert `"日本…"` — five cells for a three-cell budget,
+        // which is how a task title got to overwrite the panel's own border.
+        // The test pinned the bug rather than catching it.
+        assert_eq!(truncate("日本語テスト", 3), "日…");
+
+        for width in 0..12 {
+            for text in ["hello", "日本語テスト", "a日b本c", "☀ 21°C"] {
+                assert!(
+                    crate::grid::display_width(&truncate(text, width)) <= width,
+                    "truncate({text:?}, {width}) overflows its budget"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -26,7 +26,7 @@ use crate::config::WeatherConfig;
 use crate::frame::Binding;
 use crate::glyphs;
 use crate::grid::{Column, Grid};
-use crate::panel::{Panel, RenderContext};
+use crate::panel::{Panel, RenderContext, describe_age};
 
 /// How long to wait on any single HTTP request.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
@@ -153,19 +153,6 @@ impl State {
     }
 }
 
-/// Render a duration the way a person would say it.
-fn describe_age(age: Duration) -> String {
-    let minutes = age.as_secs() / 60;
-    if minutes < 60 {
-        return format!("{minutes}m old");
-    }
-    let hours = minutes / 60;
-    if hours < 24 {
-        return format!("{hours}h old");
-    }
-    format!("{}d old", hours / 24)
-}
-
 /// The weather panel.
 #[derive(Debug)]
 pub struct WeatherPanel {
@@ -285,34 +272,75 @@ impl WeatherPanel {
     }
 }
 
-/// Fetch now, then every `refresh_minutes`, until the process exits.
+/// Fetch now, then every `refresh_minutes`, until `stop` is set.
 fn fetch_loop(
     config: &WeatherConfig,
     state: &Arc<Mutex<State>>,
     refresh: &Arc<Mutex<bool>>,
     stop: &Arc<AtomicBool>,
 ) {
-    // Resolve coordinates once; a geocoding failure is fatal for this panel and
-    // there is no point retrying it every cycle.
-    let located = match resolve_location(config) {
-        Ok(v) => v,
-        Err(e) => {
-            update(state, |s| s.error = Some(format!("{e:#}")));
-            return;
-        }
-    };
-
     let interval = Duration::from_secs(config.refresh_minutes.max(1) * 60);
+    poll(
+        config,
+        state,
+        refresh,
+        stop,
+        interval,
+        &resolve_location,
+        &fetch_weather,
+    );
+}
+
+/// The loop itself, with its two network calls as parameters.
+///
+/// Injected rather than called directly so a test can prove the thread outlives
+/// a failure without needing a network. The property under test is structural —
+/// that nothing returns early — and that cannot be checked from the outside.
+// No `Send`/`Sync` bound: `poll` runs entirely on the thread that called it,
+// and the caller owns the closures for the whole call.
+type Resolver<'a> = &'a dyn Fn(&WeatherConfig) -> Result<Located>;
+type Fetcher<'a> = &'a dyn Fn(&WeatherConfig, &Located) -> Result<WeatherData>;
+
+fn poll(
+    config: &WeatherConfig,
+    state: &Arc<Mutex<State>>,
+    refresh: &Arc<Mutex<bool>>,
+    stop: &Arc<AtomicBool>,
+    interval: Duration,
+    resolve_location: Resolver<'_>,
+    fetch_weather: Fetcher<'_>,
+) {
+    // Resolved once and then kept: a place does not move, and geocoding is a
+    // second request nobody asked for.
+    //
+    // A *failure* is a different matter. It used to end the thread, on the
+    // grounds that a bad location name will not fix itself — but the common
+    // failure is not a bad name, it is a laptop that resumed before Wi-Fi
+    // associated, or `rebuild_panels` firing during a blip. The panel drew
+    // "r to retry" and the key was dead, because nothing was left to read the
+    // flag it set. So the thread stays alive and retries until it succeeds.
+    let mut located: Option<Located> = None;
+
     while !stop.load(Ordering::Relaxed) {
-        match fetch_weather(config, &located) {
-            Ok(data) => update(state, |s| {
-                s.data = Some(Box::new(data));
-                s.fetched = Some(Instant::now());
-                s.error = None;
-            }),
-            // The reading and its timestamp are deliberately left alone, so a
-            // blip shows the last good data with its age rather than nothing.
-            Err(e) => update(state, |s| s.error = Some(format!("{e:#}"))),
+        if located.is_none() {
+            match resolve_location(config) {
+                Ok(place) => located = Some(place),
+                Err(e) => update(state, |s| s.error = Some(format!("{e:#}"))),
+            }
+        }
+
+        if let Some(place) = &located {
+            match fetch_weather(config, place) {
+                Ok(data) => update(state, |s| {
+                    s.data = Some(Box::new(data));
+                    s.fetched = Some(Instant::now());
+                    s.error = None;
+                }),
+                // The reading and its timestamp are deliberately left alone, so
+                // a blip shows the last good data with its age rather than
+                // nothing.
+                Err(e) => update(state, |s| s.error = Some(format!("{e:#}"))),
+            }
         }
 
         // Sleep in short slices so a manual refresh does not wait out the full
@@ -1377,5 +1405,129 @@ mod tests {
         assert!(grid.has("temp"));
         assert!(!grid.has("wind"));
         assert!(!grid.has("feels"));
+    }
+
+    #[test]
+    fn a_failed_geocode_is_retried_rather_than_ending_the_thread() {
+        use std::sync::atomic::AtomicUsize;
+
+        // Geocoding used to be resolved once before the loop, and a failure
+        // returned from the thread. The panel went on drawing "r to retry" with
+        // nothing left alive to read the flag that `r` sets, so the key did
+        // nothing, for ever — on the exact failure a laptop resuming before its
+        // Wi-Fi associates produces.
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&attempts);
+        let resolve = move |_: &WeatherConfig| -> Result<Located> {
+            // Fail the first two attempts, then succeed.
+            if counter.fetch_add(1, Ordering::Relaxed) < 2 {
+                anyhow::bail!("could not resolve `nowhere`");
+            }
+            Ok(Located {
+                name: "Cincinnati".into(),
+                latitude: 39.1,
+                longitude: -84.5,
+            })
+        };
+        let fetch = |_: &WeatherConfig, _: &Located| Ok(sample_data(true));
+
+        let state = Arc::new(Mutex::new(State::default()));
+        let refresh = Arc::new(Mutex::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        // A zero interval turns the wait into a no-op, so the passes happen as
+        // fast as the closures return and the test does not sleep.
+        poll_until(
+            &WeatherConfig::default(),
+            &state,
+            &refresh,
+            &stop,
+            Duration::ZERO,
+            &resolve,
+            &fetch,
+            3,
+        );
+
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            3,
+            "geocoding must be retried after it fails, and not once it succeeds"
+        );
+        let guard = state.lock().unwrap();
+        assert!(
+            guard.data.is_some(),
+            "the third pass should have produced a reading"
+        );
+        assert!(guard.error.is_none(), "a recovered fetch clears the error");
+    }
+
+    #[test]
+    fn a_geocode_failure_is_reported_without_losing_the_panel() {
+        let resolve = |_: &WeatherConfig| -> Result<Located> { anyhow::bail!("no such place") };
+        let fetch = |_: &WeatherConfig, _: &Located| -> Result<WeatherData> {
+            unreachable!("nothing to fetch without coordinates")
+        };
+
+        let state = Arc::new(Mutex::new(State::default()));
+        let refresh = Arc::new(Mutex::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        poll_until(
+            &WeatherConfig::default(),
+            &state,
+            &refresh,
+            &stop,
+            Duration::ZERO,
+            &resolve,
+            &fetch,
+            2,
+        );
+
+        let guard = state.lock().unwrap();
+        assert!(guard.data.is_none());
+        assert!(
+            guard
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("no such place")),
+            "the reason must reach the panel: {:?}",
+            guard.error
+        );
+    }
+
+    /// Run [`poll`] for exactly `passes` iterations by setting `stop` from a
+    /// watcher thread once the resolver has been called enough times.
+    ///
+    /// `poll` deliberately has no iteration limit — that is the whole point of
+    /// it — so a test bounds it from the outside, the way `shutdown` does.
+    #[allow(clippy::too_many_arguments)]
+    fn poll_until(
+        config: &WeatherConfig,
+        state: &Arc<Mutex<State>>,
+        refresh: &Arc<Mutex<bool>>,
+        stop: &Arc<AtomicBool>,
+        interval: Duration,
+        resolve: Resolver<'_>,
+        fetch: Fetcher<'_>,
+        passes: usize,
+    ) {
+        let seen = std::cell::Cell::new(0usize);
+        let counted_resolve = |c: &WeatherConfig| {
+            seen.set(seen.get() + 1);
+            if seen.get() >= passes {
+                stop.store(true, Ordering::Relaxed);
+            }
+            resolve(c)
+        };
+        // `poll` checks `stop` at the top of each pass, so the pass that trips
+        // the flag still completes.
+        poll(
+            config,
+            state,
+            refresh,
+            stop,
+            interval,
+            &counted_resolve,
+            fetch,
+        );
     }
 }


### PR DESCRIPTION
Task #5 of the adversarial-review plan. All six were confirmed against the code before any of them was touched; two turned out to be worse than the review described, and two had tests that were pinning the bug rather than catching it.

## Panel rectangles were indexed by layout column and read back by slot

`geometry` pushed one `Rect` per entry in `[layout]`; `render` looked them up by slot index. Any layout entry that produced no panel made the two disagree, and every later slot then drew — and hit-tested clicks — inside the previous entry's box.

The review called this latent because `Config::validate` rejects an unknown widget name. It is a bit closer than that: `App::new` does not re-validate, and neither does `rebuild_panels`, which is the function the panel picker calls every time you toggle a widget. So a test can reach the misaligned state directly, and it does.

The correct mapping already existed — `self.positions` plus `slot_at`, which `geometry` was already using two lines earlier for the maxima. The rect vector is now keyed by slot and written through it.

## `todo::truncate` counted characters against a budget in cells

Both callers pass a width in cells (`inner.width`, `bottom.width`), so a CJK or emoji title overflowed by one cell per character and drew over the panel's own border. Its test asserted:

```rust
assert_eq!(truncate("日本語テスト", 3), "日本…");   // five cells for a three-cell budget
```

That is the bug, frozen as an expectation. `grid.rs` already contained correct cell-measuring truncation inside `fit`, so that logic is now `grid::truncate` and both use it. The replacement test asserts the budget is never exceeded across a range of widths and inputs, rather than freezing one output string.

## `[theme]` accepted unknown fields

All fifteen structs in `config.rs` carry `deny_unknown_fields`; `Theme` and `GradientStops` did not. `deny_unknown_fields` on `Config` only guards the top level, so `[theme]` was handed to a struct that silently dropped anything it did not recognise — `acent = "#ff0000"` parsed clean and the colour never changed.

The consequence the review didn't reach: `stale_config_hint` carries entries for the pre-0.1.0 theme keys `rx` and `tx`, and because those parsed cleanly, the hint telling the user to run `--migrate-config` **could never fire for either one**. There is now a test asserting it does, and it passes.

## Weather died permanently on a transient geocode failure

Resolution happened once before the loop and a failure `return`ed from the thread. The panel then went on rendering `"r to retry"` with nothing alive to read the flag that `r` sets — so the key did nothing, for ever.

The failure this actually hits is not a mistyped location. It is a laptop that resumed before Wi-Fi associated, or `rebuild_panels` firing during a blip. The location is still resolved once and kept; a failure no longer ends the thread.

The loop's two network calls are parameters now. The property worth testing is structural — that nothing returns early — and that is not observable from outside the function.

## A failed quote destroyed the last good price, and nothing showed its age

One timed-out request blanked the price, the change, the percentage and the sparkline together for a full refresh interval (60s minimum). And with no timestamp anywhere, a fetch thread that quietly stopped went on showing confident-looking numbers for as long as the dashboard was open.

`Cell` is now shaped like `weather::State` — an optional quote with the `Instant` it landed, plus an optional error — and `update` merges rather than replaces. A retained price stays on screen, goes muted instead of coloured by a direction that may have reversed since, and the status line says how old it is.

The rule is the one the weather panel already documented and this one violated: old data labelled old is useful, no data is not, and old data presented as current is the only unacceptable outcome.

## The `?` overlay clipped silently at 80x24

Height came from `lines.len()` — before wrapping — and `Paragraph` had no scroll. With the tasks panel focused that is 29 rows of content in 22 rows of overlay, so **nine of its seventeen bindings did not exist** as far as anyone reading `?` could tell: `PgUp/PgDn`, `e`, `n`, `p/P`, `s`, `c`, `/`, `Esc` and `o`.

Measured under tmux at exactly 80x24 — footer reads `↓ 20/29`, and `End` brings all nine into view:

```
│   p / P       cycle priority               │
│   s           cycle sort                   │
│   c           show completed               │
│   /           filter                       │
│   Esc         clear filter                 │
│   o           show file path               │
│ ↑ 29/29 · any other key to close           │
```

Arrows, `PgUp`/`PgDn`, `Home` and `End` scroll — but only when something is below the fold, so `?` then Down still closes the overlay on a terminal with room, which is what "any key to close" promises. The footer is pinned to the last row rather than being the last line of the scrolling text, because a hint saying how to close the overlay is no use once it has scrolled out of the overlay.

## Incidental

Three duplicated helpers were consolidated where the fixes needed them anyway: `notes::wrapped_height` and its private `display_width` moved to `grid.rs` (the overlay needs the same measurement), and `weather::describe_age` moved to `panel.rs` (the stocks status line needs it). `grid::fit` now calls `grid::truncate` instead of carrying its own copy.

`Panel::remember`'s doc comment still instructed implementors to compare against the value the panel was built with — precisely the design 70007bf removed for making a preference impossible to retract. Corrected.

## Verification

The two fixes whose bug was structural were checked by reverting the fix and confirming the new test fails:

- rect indexing → `left: 0, right: 20` ("the clock took the missing panel's rectangle")
- geocode retry → `left: 1, right: 3` resolve attempts (the loop gave up after the first failure)

408 tests pass. `fmt`, `clippy -D warnings`, `cargo doc -D warnings` and `cargo publish --dry-run` all green — the doc gate caught a broken intra-doc link to a private item in this branch, which is the same class of failure that reddened `main` once before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)