### PR TITLE
Fix the drifted facts, and make the worst one self-checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ much they could cost someone.
 - **Layout changes are written back into your config**, reversing an earlier
   decision to keep them out of it. The rule was never really "do not write to
   the config" — it was "do not *reserialise* it", because a round trip through
-  `toml` discards every comment in the file, including the ~145 mirador wrote to
+  `toml` discards every comment in the file, including the 159 mirador wrote to
   explain its own options. `--migrate-config` had already established the
   alternative: edit the lines that need editing and leave the rest alone.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ hooks, calm by default so that *not* calm is legible at a glance.
 ## Commands
 
 ```sh
-cargo test                                    # 343 tests, all fast, no network
+cargo test                                    # all fast, no network, no fixtures
 cargo clippy --all-targets -- -D warnings     # must be silent
 cargo fmt --all -- --check                    # must be silent
 RUSTDOCFLAGS="-D warnings" \
@@ -111,13 +111,19 @@ grid.rs      shared column grid with named headers
 chart.rs     braille graphs + baked colour gradients
 glyphs.rs    block numerals, bold-uppercase labels, weather art
 theme.rs     colours and gradient stops
-config.rs    TOML config, validation, default file
+config/      mod.rs: paths, loading, validation; widgets.rs: one settings
+             struct per panel; layout.rs: the grid
+picker.rs    the `w` dialog — owns its cursor, returns an Action to the shell
 migrate.rs   textual in-place upgrade of configs written by older versions
 layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
+store.rs     write_atomic — every file mirador owns goes through it
 state.rs     UI-changed preferences, remembered across restarts
-task.rs      task model + atomic TOML store
-note.rs      note model + atomic TOML store
+task.rs      task model + TOML store
+note.rs      note model + TOML store
 quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
+poll.rs      the sliced sleep the two fetch threads share
+samples.rs   the bounded history behind the cpu and network graphs
+selection.rs list cursor movement and click-to-row
 textfield.rs single-line text editor used by task entry
 textarea.rs  multi-line text editor used by note bodies
 dateinput.rs due-date entry
@@ -130,9 +136,11 @@ widgets/     clocks, weather, todo, notes, stocks, calendar, pomodoro, cpu,
 the same thing — a scroll wheel must move the list it is aimed at without
 yanking the keyboard away from what the user was typing in.
 
-Adding a widget: implement `Panel`, add a config struct, add the name to
-`WIDGET_NAMES` and an arm to `build()` in `widgets/mod.rs`, document it in
-`assets/default_config.toml` and the README. Nothing else needs to know.
+Adding a widget: implement `Panel`, add a config struct to `config/widgets.rs`,
+add the name to `WIDGET_NAMES` and an arm to `build()` in `widgets/mod.rs`,
+document it in `assets/default_config.toml` and the README. Nothing else needs
+to know. `CONTRIBUTING.md` has the same list with more detail — this one is the
+map, that one is the procedure.
 
 ## Invariants — do not break these
 
@@ -189,7 +197,7 @@ Adding a widget: implement `Panel`, add a config struct, add the name to
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all ~145 of them, including the ones mirador
+    trip through `toml` discards all 159 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -401,8 +409,8 @@ inline `[theme]` table from a `theme = "name"` string).
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.1.0` is released**, on crates.io and as a GitHub release with binaries
-  for macOS arm64, macOS x86-64 and Linux x86-64. `0.0.0` is still on
+- **`0.4.0` is released**, on crates.io and as a GitHub release with binaries
+  for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,29 @@ cargo run
 
 Requires Rust 1.95 or newer.
 
-Before pushing, run what CI runs:
+Before pushing, run what CI runs. All six, not the first three — the last two
+catch things the others cannot, and both have reddened `main` before: a broken
+intra-doc link only `cargo doc` sees, and an `exclude` in `Cargo.toml` that
+dropped a file the build needed.
 
 ```sh
 cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+cargo publish --dry-run
 ```
+
+CI also builds and tests on macOS, and type-checks against the minimum
+supported Rust version:
+
+```sh
+cargo +1.95.0 check --all-targets
+```
+
+Note that `clippy` gates some lints on the `rust-version` field, so a newer
+toolchain locally can report warnings CI does not, and vice versa. When the two
+disagree, CI is the one that matters.
 
 To try changes against a throwaway config instead of your real one:
 
@@ -43,8 +59,10 @@ cargo run -- --config /tmp/mirador.toml
 The `Panel` trait in `src/panel.rs` is the extension seam. To add a widget:
 
 1. Create `src/widgets/<name>.rs` and implement `Panel`.
-2. Add a config struct to `src/config.rs` and a field on `Config`, with a
-   `Default` implementation for every value.
+2. Add a config struct to `src/config/widgets.rs` and a field on `Config` in
+   `src/config/mod.rs`, with a `Default` implementation for every value. Mark
+   the struct `#[serde(default, deny_unknown_fields)]` — a config key that is
+   silently ignored makes a stale config look like stale code.
 3. Add the name to `WIDGET_NAMES` and an arm to `build` in
    `src/widgets/mod.rs`.
 4. Document the widget in `assets/default_config.toml` and in the README's

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ and leaves a backup beside the original.
 
 ## The panels
 
-Eight widgets, each answering one question. Put the ones you want in the
+Nine widgets, each answering one question. Put the ones you want in the
 layout and drop the rest — an unused widget costs nothing but is also not
 built.
 

--- a/src/glyphs.rs
+++ b/src/glyphs.rs
@@ -273,7 +273,8 @@ pub fn art(sky: Sky) -> [&'static str; ART_HEIGHT] {
 /// Every glyph here is deliberately chosen so that `unicode-width` reports the
 /// same cell count the terminal actually draws. That sounds pedantic and is
 /// not: several of the obvious weather emoji — U+1F327 rain cloud, U+1F328
-/// snow cloud, U+2601 cloud — report width 1 but render as two cells, which
+/// snow cloud, U+2601 cloud, U+1F32B fog — report width 1 but render as two
+/// cells, which
 /// silently shifts every column after them and puts values under the wrong
 /// headers. The set below is restricted to glyphs that measure 2 and draw 2.
 ///

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -6,12 +6,10 @@
 //! recording it anywhere else would leave the file describing a dashboard
 //! nobody is looking at.
 //!
-//! Rewriting is **textual**, for the reason [`crate::migrate`] gives at
-//! length: a parse-and-reserialise round trip through `toml` discards every
-//! comment in the file, including the two hundred lines mirador itself wrote to
-//! explain the options. Lines are edited, inserted and deleted in place;
-//! everything else — spacing, ordering, comments, even a comment *inside* the
-//! layout block — is left exactly as the user left it.
+//! Rewriting is **textual**, for the reason [`crate::migrate`] gives at length
+//! and does not need repeating here. Lines are edited, inserted and deleted in
+//! place; everything else — spacing, ordering, comments, even a comment
+//! *inside* the layout block — is left exactly as the user left it.
 //!
 //! The safety property that makes this defensible is at the bottom of
 //! [`apply`]: the edited text is parsed before it is returned, and the layout it
@@ -480,5 +478,27 @@ units = "imperial"
 
         let without = SAMPLE.trim_end_matches('\n');
         assert!(!apply(without, &desired).unwrap().ends_with('\n'));
+    }
+
+    /// The comment count is the whole justification for this module, and it is
+    /// quoted in two places that no compiler checks: `CLAUDE.md` invariant 16
+    /// and the 0.4.0 changelog entry. It had already drifted into "~145" in
+    /// both, and "two hundred" in a third citation since removed.
+    ///
+    /// A failure here is not a bug in the config. It means the number moved and
+    /// the citations have to move with it.
+    #[test]
+    fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
+        const CITED: usize = 159;
+        let actual = crate::config::DEFAULT_CONFIG
+            .lines()
+            .filter(|line| line.trim_start().starts_with('#'))
+            .count();
+        assert_eq!(
+            actual, CITED,
+            "the default config now has {actual} comment lines. Update this \
+             constant, `CLAUDE.md` invariant 16 and the 0.4.0 changelog entry \
+             — they all quote {CITED}."
+        );
     }
 }


### PR DESCRIPTION
Task #8 of the adversarial-review plan. Every number below was measured against the thing it describes rather than taken from the review — and one of them turned out to be backwards.

## The drifted facts

| Claim | Said | Actually | Where |
|---|---|---|---|
| Comment lines in the default config | `~145` / `two hundred` | **159** | `CLAUDE.md`, `CHANGELOG.md`, `layout_edit.rs` |
| Test count | `343` | **430** | `CLAUDE.md` |
| Widget count | `Eight widgets` | **Nine** | `README.md` — nine lines after its own caption says "All nine panels" |
| Current release | `0.1.0` | **0.4.0** | `CLAUDE.md`, three releases and a platform later |

## The comment count now checks itself

159 is the entire justification for `layout_edit.rs` and `migrate.rs` existing, and it was quoted in three documents that no compiler reads. So:

```rust
#[test]
fn the_comment_count_the_docs_quote_is_the_one_in_the_file() { … }
```

It fails with a message naming the places to update. A fact quoted in three documents and checked by nothing will drift again — this one drifted twice, in two directions.

## The emoji finding was backwards

The review flagged "3 vs 4 emoji" between `glyphs.rs` and `CLAUDE.md`. I measured all four with `unicode-width`:

```
U+1F327 rain cloud: width 1
U+1F328 snow cloud: width 1
U+2601  cloud:      width 1
U+1F32B fog:        width 1
```

All four report 1 and draw 2. So `CLAUDE.md`'s list of four is correct and **`glyphs.rs` was the incomplete one** — and its own code already knew, because two lines below the comment it handles fog by "borrowing a neighbour that measures honestly". Fixed in the code, not the doc.

## CONTRIBUTING claimed CI runs three gates

It runs six. The two missing from the list are precisely the two that have reddened `main`: a broken intra-doc link only `cargo doc` sees, and an `exclude` in `Cargo.toml` that dropped a file the build needed. Now lists all of them, the MSRV check, and the note that clippy gates lints on `rust-version` — so a newer local toolchain can legitimately disagree with CI, and CI is the one that counts.

Its "adding a widget" step still pointed at `src/config.rs`, which #35 split; so did `CLAUDE.md`'s architecture map, which was also missing six modules. Both updated.

## On the "~600 lines of duplicated rationale"

**That figure did not reproduce, and I did not manufacture cuts to hit it.**

`src/` has 2885 comment lines in 19593 (14.7%), and the long blocks are almost entirely module-level `//!` docs — which is where rationale belongs in a project whose stated rule is "comments explain why, not what".

The two sections that look most like duplicates are the README's "Prior art" and `CLAUDE.md`'s "Techniques borrowed". They are complementary by design: one credits the projects for a reader, the other records the technique for an implementer, and the README already says so and links across.

The one genuine instance: `layout_edit.rs` restated the entire never-reserialise argument *immediately after* saying "for the reason `crate::migrate` gives at length". That is now just the pointer.

430 tests pass; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)