### PR TITLE
Fix five documentation defects, two of which contradicted the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,7 +357,12 @@ costs exactly one request. **Requires a browser `User-Agent`** or you get HTTP
 - `parse_chart` is split from the HTTP call so it is tested against captured
   JSON. **No test in this repo touches the network** — keep it that way.
 
-## Theming — decided, not yet built
+## Named themes — decided, not yet built
+
+The `[theme]` table itself **is** built and shipping: every colour the dashboard
+draws with is configurable, gradients included, with names, hex and 256-colour
+indices accepted and bad values rejected at parse time. What is not built is
+*named* themes — `theme = "nord"` and a themes directory.
 
 Follow Helix. `theme = "name"` plus theme files in
 `<config>/mirador/themes/<name>.toml`, with:
@@ -379,19 +384,20 @@ inline `[theme]` table from a `theme = "name"` string).
 
 ## Open work, in priority order
 
-1. **Settings editable from the UI — decided and built.** The owner's call was
-   the state file, following the watchlist: config seeds, `state.rs` records
-   where the user moved since, and the config is still never rewritten. Live
-   for weather units, task sort and completed-visibility, clock seconds and
-   pomodoro durations.
+Only things that are actually open. A "decided and built" entry in a list called
+open work is how the list stops being read.
 
-   What is *not* covered: `[weather].location`, which was the original example.
-   Editing it needs text entry in the panel rather than a toggle, and that is a
-   UI question rather than a persistence one now that the storage exists.
-2. Calendar panel reading a local `.ics` — the shipped `calendar` widget is a
-   date grid only, deliberately offline; events are a separate, larger panel.
-3. Theme system per above.
-4. "What changed since I last looked" markers.
+1. **Editing `[weather].location` from the panel.** Everything else the UI can
+   change is already remembered — units, task sort and completed-visibility,
+   clock seconds, pomodoro durations — through `state.rs`, which records where
+   the user moved from what the config seeded. Location is the one that needs
+   text entry in the panel rather than a toggle, so it is a UI question now
+   rather than a persistence one.
+2. **Named themes**, per the section above. The `[theme]` table is built; the
+   `theme = "nord"` layer over it is not.
+3. **Calendar reading a local `.ics`.** The shipped `calendar` widget is a date
+   grid only, deliberately offline; events are a separate and much larger panel.
+4. **"What changed since I last looked" markers.**
 
 ## Housekeeping
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ rows = [
 | Widget | What it shows |
 | --- | --- |
 | `clocks` | Any number of world clocks, by IANA timezone |
-| `weather` | Current conditions plus a 1–7 day forecast |
+| `weather` | Current conditions plus an hour-by-hour forecast |
 | `todo` | The task list, with full editing |
 | `notes` | Free-form notes: a list of titles and dates above the note you are reading |
 | `stocks` | A watchlist: last price, the day's change, and an intraday sparkline |
@@ -524,11 +524,23 @@ working; copying a value off the dashboard needs the terminal's override
 modifier, which is Shift in most terminals and Option in macOS Terminal and
 iTerm2. Set `[general].mouse = false` to keep ordinary selection instead.
 
-Colours accept a name (`red`, `light-blue`), a hex string (`#ff8800`), or a
-256-colour index (`12`). `reset` uses your terminal's own default.
+### Colours
 
-An unknown widget name or a malformed colour is reported at startup with a
-message that says how to fix it, rather than being ignored.
+Every colour the dashboard draws with lives under `[theme]`, and the graph
+gradients under `[theme.rx_gradient]` and friends. A colour accepts a name
+(`red`, `light-blue`), a hex string (`#ff8800`), or a 256-colour index (`12`).
+`reset` uses your terminal's own default.
+
+### When something is wrong with your config
+
+mirador refuses to start rather than starting wrong. An unknown widget name, a
+malformed colour, or a key it does not recognise is reported with a message
+that says how to fix it — including, for a key that was renamed in an earlier
+version, which key replaced it and that `mirador --migrate-config` will do it
+for you.
+
+A key that is silently ignored is the worst outcome a config can have, because
+it makes a stale config look like stale code.
 
 ## Task file format
 
@@ -538,17 +550,30 @@ or wherever `[todo].file` points. Press `o` in the task panel to see the path.
 ```toml
 [[task]]
 id = 1
-title = "Publish 0.0.0 placeholder"
-notes = "Reserve the crates.io name"
-due = "2026-07-28"
+title = "Renew the domain"
+notes = "Registrar sends the reminder to the old address"
+due = "2026-08-14"
 priority = "high"     # high | medium | low | none
-tags = ["mirador", "rust"]
+tags = ["admin"]
 done = false
-created = "2026-07-25"
+created = "2026-08-01"
+
+[[task]]
+id = 2
+title = "Read the ratatui 0.30 release notes"
+priority = "low"
+done = true
+created = "2026-07-30"
+completed = "2026-08-02"   # set when `done` flips; used by the `c` filter
 ```
 
-Writes are atomic — mirador writes a temporary file and renames it — so an
-interrupted save can never truncate your tasks.
+Only `id`, `title`, `done` and `created` are required; everything else may be
+left out.
+
+Writes are atomic — the file is written under a temporary name, flushed to the
+disk, and renamed over the original — so an interrupted save or a full disk can
+never truncate your tasks. The same goes for your notes, your watchlist and the
+config itself.
 
 ## Contributing
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -550,6 +550,43 @@ fn cmp_due(a: &Task, b: &Task) -> Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The README shows a `todos.toml` and tells people they can edit it by
+    /// hand. A wrong example there is worse than no example, because it fails
+    /// on *their* file after they have typed something into it.
+    ///
+    /// So the example is extracted from the README and parsed. The one this
+    /// replaced had drifted into a real task from this project's own
+    /// development, dated and long since done — nothing checked it, so nothing
+    /// noticed.
+    #[test]
+    fn the_task_file_example_in_the_readme_actually_parses() {
+        let readme = include_str!("../README.md");
+        let start = readme
+            .find("## Task file format")
+            .expect("the README documents the task file format");
+        let block = readme[start..]
+            .split("```toml")
+            .nth(1)
+            .and_then(|rest| rest.split("```").next())
+            .expect("that section shows a toml example");
+
+        let parsed: TaskFile = toml::from_str(block)
+            .unwrap_or_else(|e| panic!("the README example does not parse: {e}\n\n{block}"));
+
+        assert_eq!(parsed.tasks.len(), 2, "both examples must survive parsing");
+        assert!(
+            parsed.tasks.iter().any(|t| t.done && t.completed.is_some()),
+            "the example should show what a finished task looks like"
+        );
+        assert!(
+            parsed
+                .tasks
+                .iter()
+                .any(|t| t.notes.is_none() && t.tags.is_empty()),
+            "and that the optional fields really are optional"
+        );
+    }
     use jiff::civil::date;
 
     fn today() -> Date {


### PR DESCRIPTION
Task #10 of the adversarial-review plan.

## The widget table advertised a config key mirador refuses to load

> | `weather` | Current conditions plus a **1–7 day forecast** |

The forecast has been hourly since 0.1.0. `forecast_days` was *removed*, and `stale_config_hint` has carried a migration entry pointing at `forecast_hours` ever since — so anyone following the README would hit the error path the README was supposed to prevent.

## The task file example was a real dev task from before the crate was named

```toml
title = "Publish 0.0.0 placeholder"
notes = "Reserve the crates.io name"
due = "2026-07-28"
```

The README tells people they can edit this file by hand, which makes a wrong example worse than no example — it fails on *their* file, after they have typed something into it.

It is now two tasks that show what the format is for: one with a due date, tags and notes, one completed with its `completed` date, and a note that only four fields are required.

And it is **extracted from the README and parsed by a test**:

```rust
fn the_task_file_example_in_the_readme_actually_parses()
```

Nothing checked the old one, which is why nobody noticed it rotting.

## Two paragraphs were orphaned under the wrong heading

`### Mouse` ended with a paragraph about colour syntax and one about startup error reporting — neither of which has anything to do with the mouse, and neither of which anyone looking for them would find there.

Now `### Colours` and `### When something is wrong with your config`. The second gained the point worth making: mirador refuses to start rather than starting wrong, and a silently ignored key is the worst outcome a config can have, because it makes a stale config look like stale code.

## `## Theming — decided, not yet built` described a shipped feature as unbuilt

The `[theme]` table is live: every colour the dashboard draws with is configurable, gradients included, with names, hex and 256-colour indices accepted and bad values rejected at parse time. What is *not* built is **named** themes — `theme = "nord"` and a themes directory. The heading now says which is which.

## "Open work, in priority order" led with a closed item

Its first entry was marked "decided and built". A list of open work whose first entry is closed is a list that stops being read. Trimmed to the four things that are actually open.

## Declined: splitting CLAUDE.md

It is 455 lines under fourteen headings, and its purpose is to be read in full by someone starting work here. Splitting it across files makes that less likely, not more: the failure mode of one long document is skimming, and the failure mode of a directory of short ones is missing one entirely.

The two real problems with it were that it had drifted out of date in three places and had lost track of what was finished. Both are fixed — here and in #36 — and the architecture map now lists every module, including the six added since it was written.

431 tests pass; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)