### PR TITLE
Lead with what mirador is for, disclose the Yahoo position, stop implying a plugin API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ real test and a reassuring one.
 ```
 main.rs      CLI parsing, terminal setup
 app.rs       event loop, focus ring, grid geometry, help overlay, status bar
-panel.rs     the Panel trait — the only extension seam
+panel.rs     the Panel trait — the seam every widget goes through (in-tree)
 frame.rs     panel frames, Binding type, key hints punched into borders
 grid.rs      shared column grid with named headers
 chart.rs     braille graphs + baked colour gradients

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ cargo run -- --config /tmp/mirador.toml
 
 ## Adding a widget
 
-The `Panel` trait in `src/panel.rs` is the extension seam. To add a widget:
+The `Panel` trait in `src/panel.rs` is the seam. It is in-tree — mirador has no
+library target and `widgets::build` dispatches on a fixed match — so adding a
+widget means a pull request rather than a separate crate. Five places to touch:
 
 1. Create `src/widgets/<name>.rs` and implement `Panel`.
 2. Add a config struct to `src/config/widgets.rs` and a field on `Config` in

--- a/README.md
+++ b/README.md
@@ -25,13 +25,26 @@ panel is dimmed. Every screen in this README is a real capture, not a mock-up.*
 
 ## Why
 
-There are good terminal dashboards already, but the task panels in them tend to
-be flat checklists. mirador treats the to-do list as a first-class feature: due
-dates, priorities, notes, tags, and full editing without leaving the dashboard.
-Everything is stored in a plain TOML file you can hand-edit or keep in git.
+Most terminal dashboards are built to be *watched* — a system monitor you open
+when something is wrong, dense and busy and refreshing as fast as it can.
+mirador is built to be **glanced at**: one tab, all day, in the corner of your
+eye. Everything follows from that. Nothing blinks or shimmers. The unfocused
+panels dim so exactly one thing is at full brightness. A notice retires on your
+first keypress, because a dashboard that nags is a dashboard you close.
 
-No accounts. No API keys. No telemetry. Weather comes from
-[Open-Meteo](https://open-meteo.com), which is free and key-less.
+**Your data stays in files you own.** Tasks, notes and the watchlist are plain
+TOML you can hand-edit, keep in git, or delete. No database, no sync service,
+no account, no API key, no telemetry, and nothing phones home — including the
+updater, which runs only when you run it.
+
+**It is a real task list, not a checklist.** Due dates, priorities, notes, tags,
+filtering and full editing without leaving the dashboard. That is the panel most
+dashboards treat as a checkbox, and it is the one you will use most.
+
+The two network panels use free key-less endpoints:
+[Open-Meteo](https://open-meteo.com) for weather, and Yahoo's public chart
+endpoint for prices — see [Market data](#market-data) for what the second one
+means for you.
 
 ## Install
 
@@ -498,8 +511,28 @@ rows = [
 
 ### Market data
 
-The watchlist reads a free, keyless endpoint. Two things follow from that, and
-they are worth knowing before you file a bug:
+The watchlist reads `query1.finance.yahoo.com`, the endpoint Yahoo's own charts
+call. **It is not a documented or supported API**, and Yahoo has never published
+terms permitting third-party programs to use it. It could be changed, rate-
+limited or withdrawn without notice, and whether your particular use of it is
+permitted is between you and Yahoo — this project cannot grant you a licence to
+someone else's service, and does not claim to.
+
+mirador's position, stated plainly so you can decide for yourself:
+
+- It is used because it is the only source that needs no account and no key, and
+  bundling an API key in a public binary would make it a shared secret with a
+  shared rate limit.
+- It is treated as a guest: one request per symbol, never faster than once a
+  minute, sequential rather than parallel, and prices are never written to disk.
+- `QuoteSource` is a trait with exactly this in mind. When the endpoint changes
+  or you would rather use a provider you have an agreement with, the panel does
+  not need rewriting — the source does.
+- If none of that sits right with you, leave `stocks` out of your `[layout]`.
+  Nothing else in mirador contacts Yahoo, and a panel that is not placed is not
+  built.
+
+Two practical consequences, worth knowing before you file a bug:
 
 - **Access is gated on your IP address, not on a key.** Datacenter and VPN
   ranges are blocked wholesale, so the same build can work on your laptop and

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -1,6 +1,19 @@
-//! The [`Panel`] trait: the extension seam every dashboard widget implements.
+//! The [`Panel`] trait: the seam every dashboard widget goes through.
 //!
-//! A panel owns its own state and refresh cadence. The application shell is
+//! **This is an in-tree seam, not a plugin API.** mirador is a binary crate
+//! with no library target, so nothing outside it can name this trait; and even
+//! if it could, `widgets::build` dispatches on a fixed `match` over
+//! `WIDGET_NAMES` and each widget's settings are a field on `Config`. Adding a
+//! widget is a pull request, and `CONTRIBUTING.md` lists the five places to
+//! touch. A real plugin story needs three things this does not have: a runtime
+//! registry instead of that `match`, per-widget config carried as an
+//! unparsed `toml::Value` so a widget can own its own schema, and a library
+//! target with a deliberate public surface. Adding only the last of those
+//! would make the trait nameable without making it usable, which is worse than
+//! the honest version.
+//!
+//! What the seam does buy, in-tree, is real: a panel owns its own state and
+//! refresh cadence. The application shell is
 //! responsible only for layout, focus, frames and dispatching ticks and key
 //! events; it knows nothing about what any individual panel displays.
 //!


### PR DESCRIPTION
Task #11 of the adversarial-review plan. Three changes made, one deliberately not made, and two items that need you.

## The README led with the to-do list

That is a feature comparison against other dashboards, made in the section that should explain why this exists — and it buries the constraint that actually drives every decision in the codebase.

It now leads with it: most terminal dashboards are built to be **watched**, and this one is built to be **glanced at** — one tab, all day. Nothing blinks, unfocused panels dim so exactly one thing is at full brightness, a notice retires on your first keypress. Then data ownership (plain TOML, no account, no key, no telemetry, and an updater that runs only when you run it). Then the task list, which is still worth saying but is not the reason.

## The Yahoo position is now stated rather than implied

The README described the endpoint as "free and keyless" and went straight to rate limiting, which reads as though the only open question is whether it will work.

It is not a documented or supported API. Yahoo has never published terms permitting third-party programs to use it, and whether a given use is permitted is between the user and Yahoo — this project cannot grant a licence to somebody else's service and should not look like it is.

So the section now says that first, then says why it is used anyway (no account, no key, and a key baked into a public binary is a shared secret with a shared rate limit), how it is treated (one request per symbol, never faster than a minute, sequential, never persisted), that `QuoteSource` is a trait for exactly this reason, and that leaving `stocks` out of `[layout]` means nothing in mirador contacts Yahoo at all.

## `Panel` was called "the extension seam" in three places

To anyone who has not read `widgets/mod.rs`, that reads as a plugin API. It is not one:

- mirador is a binary crate with no library target, so nothing outside it can name the trait.
- `widgets::build` dispatches on a fixed `match` over `WIDGET_NAMES`.
- Each widget's settings are a field on `Config`, so a third-party widget could not carry its own schema.

All three places now say what is true: an in-tree seam, and adding a widget is a pull request.

## Declined: adding `src/lib.rs`

This is the part worth recording. On its own, a library target fixes only the *first* of those three problems. A trait that can be named but not registered is a worse outcome than the honest version — it looks like a plugin API in the rustdoc and fails at the first attempt to use it.

A real plugin story needs all three: a runtime registry instead of the match, per-widget config carried as an unparsed `toml::Value` so a widget owns its own schema, and a deliberate public surface rather than whatever `pub` happens to mean inside a binary crate. That is a design, not a one-line file. `panel.rs` now says so, where someone would go looking.

---

## Needs you

Two items in this task I should not do unilaterally:

1. **A demo GIF.** Worth having — it is the single biggest thing missing from the README for a reader deciding in ten seconds. I can script and record one under tmux if you want it, but it is a large binary committed to the repo and `Cargo.toml` currently excludes `*.gif`, so it would be another `raw.githubusercontent.com` reference with the floating-image caveat already documented in `CLAUDE.md`.

2. **Submissions to `awesome-rust`, `awesome-tuis` and `awesome-ratatui`.** These are pull requests to other people's repositories under your name. Say the word and I will prepare them, but I am not opening them without you asking.

I also did not evaluate **taskchampion** (the Taskwarrior 3 storage library) as a task backend. It is a real question — interoperating with Taskwarrior would be a genuine differentiator — but it is a product decision about what mirador's task list *is*, not a defect, and it would replace the plain-TOML story the README now leads with. Worth its own conversation rather than a quiet swap.

431 tests pass; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)