### PR TITLE
Redraw when something changes, not when a timer fires

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -447,20 +447,32 @@ impl App {
     ///
     /// Returns whether any panel ticked, and so whether the screen may now be
     /// out of date.
+    /// Tick every panel whose interval has elapsed, and report whether any of
+    /// them said something a viewer could see had changed.
+    ///
+    /// The distinction is the whole point, and getting it wrong is invisible in
+    /// a screenshot and enormous in a profile. This used to return "some
+    /// panel's timer fired", which the run loop OR'd straight into `dirty`.
+    /// Measured on the shipped nine-panel default at 400x100: **243 redraws a
+    /// minute**, and the same 243 whether `show_seconds` was on or off — so
+    /// with seconds off the dashboard repainted 243 times to show content that
+    /// changed once.
     fn tick_panels(&mut self) -> bool {
         let now = Instant::now();
-        let mut ticked = false;
+        let mut changed = false;
         for slot in &mut self.slots {
             let due = slot
                 .last_tick
                 .is_none_or(|last| now.duration_since(last) >= slot.panel.refresh_interval());
             if due {
-                slot.panel.tick();
+                // Not `changed |= slot.panel.tick()`: `|=` short-circuits once
+                // the accumulator is true, and a panel that stops being ticked
+                // stops updating. The operand order is load-bearing.
+                changed = slot.panel.tick() || changed;
                 slot.last_tick = Some(now);
-                ticked = true;
             }
         }
-        ticked
+        changed
     }
 
     /// True when the focused panel is in a text-entry or modal state and global
@@ -1851,6 +1863,49 @@ mod tests {
         );
         assert_eq!(rects[1].x, rects[0].x + rects[0].width);
         assert_eq!(rects[0].width + rects[1].width, 60);
+    }
+
+    #[test]
+    fn a_settled_dashboard_stops_asking_to_be_redrawn() {
+        // The property this whole change exists for: with nothing moving,
+        // ticking must eventually report no change. Before, every panel whose
+        // timer fired counted as one, so the dashboard never went quiet and
+        // repainted at the fastest panel's cadence for ever.
+        //
+        // Panels that legitimately change on a timer are left out: the clock
+        // (its second or minute turns), pomodoro while running, and cpu and
+        // network (a fresh sample is a new number). What is left must settle.
+        let mut app = App::new(config_with(&["todo", "notes", "calendar"])).unwrap();
+
+        // The first tick may report a change; nothing has been drawn yet.
+        app.tick_panels();
+
+        for round in 0..5 {
+            // Force every panel due, so this cannot pass by ticking nothing.
+            for slot in &mut app.slots {
+                slot.last_tick = None;
+            }
+            assert!(
+                !app.tick_panels(),
+                "round {round}: a dashboard with nothing moving asked for a repaint"
+            );
+        }
+    }
+
+    #[test]
+    fn a_due_panel_is_ticked_even_when_an_earlier_one_already_reported_a_change() {
+        // `changed |= panel.tick()` would short-circuit and skip the call, and
+        // a panel that stops being ticked stops updating — a bug that would
+        // show up only when some *other* panel happened to change first.
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        for slot in &mut app.slots {
+            slot.last_tick = None;
+        }
+        app.tick_panels();
+        assert!(
+            app.slots.iter().all(|slot| slot.last_tick.is_some()),
+            "a due panel was skipped"
+        );
     }
 
     #[test]

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -113,13 +113,43 @@ pub trait Panel {
     }
 
     /// How often [`Panel::tick`] should be called.
+    ///
+    /// This is how often the panel wants to *look*, which is not the same as
+    /// how often it expects to have something new to show — a clock with
+    /// seconds ticks four times a second and changes once. Say how often you
+    /// need to check, and answer the second question from [`Panel::tick`].
     fn refresh_interval(&self) -> Duration {
         Duration::from_secs(1)
     }
 
-    /// Advance any time-based state. Must not block: panels needing network or
-    /// disk I/O do it on a background thread and poll the result here.
-    fn tick(&mut self) {}
+    /// Advance any time-based state, and report whether anything **a viewer
+    /// could see** changed.
+    ///
+    /// Must not block: panels needing network or disk I/O do it on a background
+    /// thread and poll the result here.
+    ///
+    /// The return value drives the redraw, and the distinction it draws is the
+    /// whole point. `true` means the next frame will differ from the last one.
+    /// It does *not* mean "my timer elapsed", "I re-read the clock", or "I
+    /// looked and there was nothing new" — a panel that says `true` on every
+    /// tick makes the shell repaint the entire dashboard at that panel's
+    /// cadence, whether or not a single cell would change.
+    ///
+    /// That was measurably the largest thing the program did. With the default
+    /// layout the clock panel drove a 250ms tick and reported nothing at all,
+    /// so the dashboard repainted four times a second, for ever — and with
+    /// `show_seconds = false`, where the visible content changes once a minute,
+    /// idle CPU was *identical*. 240 repaints per visible change.
+    ///
+    /// The cheap way to answer honestly is usually to compare what you are
+    /// about to render against what you rendered last: the formatted string,
+    /// the date, a generation counter bumped by your fetch thread. If a panel
+    /// truly cannot tell, `true` is correct and costs a repaint — but it should
+    /// then say why in a comment, because the next reader will assume it was
+    /// laziness.
+    fn tick(&mut self) -> bool {
+        false
+    }
 
     /// Draw the panel's contents. `area` is already inside the frame and its
     /// padding.

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -291,9 +291,15 @@ impl Panel for CalendarPanel {
         std::time::Duration::from_secs(30)
     }
 
-    fn tick(&mut self) {
-        // Re-read the date so the highlight crosses midnight on its own.
-        self.today = jiff::Zoned::now().date();
+    fn tick(&mut self) -> bool {
+        // Re-read the date so the highlight crosses midnight on its own — but
+        // report a change only when it actually crossed. This ran every 30
+        // seconds and assigned unconditionally, so it repainted the dashboard
+        // 2,880 times a day to move a highlight once.
+        let today = jiff::Zoned::now().date();
+        let moved = today != self.today;
+        self.today = today;
+        moved
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -52,6 +52,13 @@ pub struct ClocksPanel {
     /// Everything else, rendered as a labelled list.
     secondary: Vec<Clock>,
     show_seconds: bool,
+    /// The instant the last frame showed, in whichever unit is on screen.
+    ///
+    /// This panel is why the whole dashboard used to repaint four times a
+    /// second: it asked for a 250ms tick and had no `tick` at all, so every one
+    /// of them counted as a change. With `show_seconds = false` the visible
+    /// content moves once a minute and idle CPU was identical either way.
+    last_shown: Option<i64>,
 }
 
 impl ClocksPanel {
@@ -87,6 +94,7 @@ impl ClocksPanel {
             primary,
             secondary: clocks,
             show_seconds,
+            last_shown: None,
         }
     }
 }
@@ -173,7 +181,28 @@ impl Panel for ClocksPanel {
     }
 
     fn refresh_interval(&self) -> std::time::Duration {
-        std::time::Duration::from_millis(250)
+        // Often enough to land on the boundary promptly, and no more often than
+        // the smallest unit on screen needs.
+        if self.show_seconds {
+            std::time::Duration::from_millis(250)
+        } else {
+            std::time::Duration::from_secs(1)
+        }
+    }
+
+    fn tick(&mut self) -> bool {
+        // Every zone's minute turns on the same instant — UTC offsets are whole
+        // minutes, including the 30- and 45-minute ones — so one comparison
+        // covers the big clock, the zone list and the date line together.
+        let second = jiff::Timestamp::now().as_second();
+        let unit = if self.show_seconds {
+            second
+        } else {
+            second / 60
+        };
+        let moved = self.last_shown != Some(unit);
+        self.last_shown = Some(unit);
+        moved
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {

--- a/src/widgets/cpu.rs
+++ b/src/widgets/cpu.rs
@@ -66,14 +66,19 @@ impl CpuPanel {
     }
 
     /// Take a sample if enough time has passed since the last one.
-    fn sample(&mut self) {
+    ///
+    /// Returns whether it actually sampled. The tick runs at 500ms and the
+    /// default sample interval is a second, so half of all ticks do nothing —
+    /// and a tick that does nothing must not cost a repaint of the whole
+    /// dashboard.
+    fn sample(&mut self) -> bool {
         let interval = Duration::from_secs(self.config.sample_secs.max(1))
             // sysinfo needs a minimum gap between refreshes for its deltas to
             // be meaningful; sampling faster than this yields zeros.
             .max(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
 
         if self.last_sample.is_some_and(|at| at.elapsed() < interval) {
-            return;
+            return false;
         }
 
         self.system.refresh_cpu_usage();
@@ -93,6 +98,7 @@ impl CpuPanel {
             self.current.clamp(0.0, 100.0).round() as u64,
             capacity,
         );
+        true
     }
 
     /// How many samples to retain; see [`crate::samples::capacity`].
@@ -121,8 +127,8 @@ impl Panel for CpuPanel {
         Duration::from_millis(500)
     }
 
-    fn tick(&mut self) {
-        self.sample();
+    fn tick(&mut self) -> bool {
+        self.sample()
     }
 
     fn handle_key(&mut self, key: ratatui::crossterm::event::KeyEvent) -> crate::panel::KeyOutcome {

--- a/src/widgets/network.rs
+++ b/src/widgets/network.rs
@@ -78,11 +78,14 @@ impl NetworkPanel {
     }
 
     /// Sample byte counters and convert them to a rate.
-    fn sample(&mut self) {
+    ///
+    /// Returns whether it actually sampled; see `CpuPanel::sample` for why the
+    /// answer matters more than it looks.
+    fn sample(&mut self) -> bool {
         let interval = Duration::from_secs(self.config.sample_secs.max(1));
         let elapsed = self.last_sample.elapsed();
         if elapsed < interval {
-            return;
+            return false;
         }
 
         self.networks.refresh(true);
@@ -116,12 +119,14 @@ impl NetworkPanel {
             self.primed = true;
             self.rx_rate = 0;
             self.tx_rate = 0;
-            return;
+            // Still a change: the panel goes from "no reading" to two zeroes.
+            return true;
         }
 
         let capacity = self.capacity();
         push_bounded(&mut self.rx_history, self.rx_rate, capacity);
         push_bounded(&mut self.tx_history, self.tx_rate, capacity);
+        true
     }
 
     /// How many samples to retain; see [`crate::samples::capacity`].
@@ -191,8 +196,8 @@ impl Panel for NetworkPanel {
         Duration::from_millis(500)
     }
 
-    fn tick(&mut self) {
-        self.sample();
+    fn tick(&mut self) -> bool {
+        self.sample()
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -684,8 +684,13 @@ impl Panel for NotesPanel {
         std::time::Duration::from_mins(1)
     }
 
-    fn tick(&mut self) {
-        self.today = jiff::Zoned::now().date();
+    fn tick(&mut self) -> bool {
+        // Only the date matters here, and only when it changes: `today` decides
+        // whether a note is labelled "today" or by its date.
+        let today = jiff::Zoned::now().date();
+        let moved = today != self.today;
+        self.today = today;
+        moved
     }
 
     fn captures_input(&self) -> bool {

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -379,14 +379,22 @@ impl Panel for PomodoroPanel {
         Duration::from_secs(1)
     }
 
-    fn tick(&mut self) {
-        if self.is_running() && self.remaining().is_zero() {
+    fn tick(&mut self) -> bool {
+        if !self.is_running() {
+            // A paused or unstarted timer shows a fixed number. Nothing moves
+            // until a key does, and a key already forces a redraw.
+            return false;
+        }
+        if self.remaining().is_zero() {
             // Only a phase that ran out announces itself. Pressing `n` to skip
             // is you already knowing, and a bell for something you just did is
             // noise.
             self.sound_chime();
             self.advance();
         }
+        // A running timer's displayed minute:second changes every tick, which
+        // is exactly why `refresh_interval` is one second.
+        true
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -14,7 +14,7 @@
 //! that lives in a data file rather than in the config, which is what lets the
 //! panel edit it — mirador deliberately never rewrites its config.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -140,6 +140,13 @@ pub struct StocksPanel {
     /// when nothing has failed — a fetch thread that quietly stopped and a
     /// laptop resumed from sleep both look like success from here.
     stale_after: Duration,
+    /// Bumped by the fetch thread every time it writes a quote or an error.
+    ///
+    /// See `WeatherPanel::generation`: the board is a last-value-wins slot
+    /// behind a mutex, so nothing else tells the panel whether it moved.
+    generation: Arc<AtomicU64>,
+    /// The generation the last frame drew.
+    seen: u64,
     /// Set to ask the fetch thread to finish.
     ///
     /// Without it the thread outlives the panel: the picker rebuilds every
@@ -175,9 +182,11 @@ impl StocksPanel {
         }));
 
         let stop = Arc::new(AtomicBool::new(false));
+        let generation = Arc::new(AtomicU64::new(0));
         let shared_board = Arc::clone(&board);
         let shared_request = Arc::clone(&request);
         let shared_stop = Arc::clone(&stop);
+        let shared_generation = Arc::clone(&generation);
         // Never faster than a minute: the sources are free and unauthenticated,
         // and hammering them is how an IP gets blocked for everyone behind it.
         let interval = Duration::from_secs(config.refresh_secs.max(60));
@@ -191,6 +200,7 @@ impl StocksPanel {
                     &shared_board,
                     &shared_request,
                     &shared_stop,
+                    &shared_generation,
                     interval,
                     stagger,
                 );
@@ -210,6 +220,8 @@ impl StocksPanel {
             // Twice the interval, matching the weather panel: one missed cycle
             // is a blip, two is a pattern.
             stale_after: interval * 2,
+            generation,
+            seen: 0,
             stop,
         };
         panel.reselect();
@@ -512,6 +524,7 @@ fn fetch_loop(
     board: &Arc<Mutex<Board>>,
     request: &Arc<Mutex<Request>>,
     stop: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
     interval: Duration,
     stagger: Duration,
 ) {
@@ -526,7 +539,7 @@ fn fetch_loop(
 
         for symbol in &symbols {
             let result = source.fetch(symbol);
-            update(board, symbol, result);
+            update(board, generation, symbol, result);
             if stop.load(Ordering::Relaxed) {
                 return;
             }
@@ -552,21 +565,34 @@ fn fetch_loop(
 ///
 /// Merge rather than replace: a failure records the reason and leaves whatever
 /// price was already there, so the row keeps a real number with its age on it.
-fn update(board: &Arc<Mutex<Board>>, symbol: &str, result: anyhow::Result<Quote>) {
-    let mut guard = match board.lock() {
-        Ok(g) => g,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let Some(slot) = guard.iter_mut().find(|(s, _)| s == symbol) else {
-        return;
-    };
-    match result {
-        Ok(quote) => {
-            slot.1.quote = Some((quote, Instant::now()));
-            slot.1.error = None;
+fn update(
+    board: &Arc<Mutex<Board>>,
+    generation: &Arc<AtomicU64>,
+    symbol: &str,
+    result: anyhow::Result<Quote>,
+) {
+    {
+        let mut guard = match board.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(slot) = guard.iter_mut().find(|(s, _)| s == symbol) {
+            match result {
+                Ok(quote) => {
+                    slot.1.quote = Some((quote, Instant::now()));
+                    slot.1.error = None;
+                }
+                Err(e) => slot.1.error = Some(format!("{e:#}")),
+            }
         }
-        Err(e) => slot.1.error = Some(format!("{e:#}")),
     }
+
+    // After the write and after the lock, with `Release`, so a panel that sees
+    // the new number is guaranteed to see the board behind it. Bumped even for
+    // an error and even for a symbol that has since been removed: "the panel
+    // now shows a reason it did not show before" is a visible change, and one
+    // extra repaint a minute is not worth a second branch.
+    generation.fetch_add(1, Ordering::Release);
 }
 
 impl Panel for StocksPanel {
@@ -581,6 +607,15 @@ impl Panel for StocksPanel {
         }
         let n = self.watchlist.symbols().len();
         (n > 0).then(|| n.to_string())
+    }
+
+    fn tick(&mut self) -> bool {
+        // See `WeatherPanel::tick`: a fetch landing is the only thing that
+        // changes this panel without a keypress.
+        let now = self.generation.load(Ordering::Acquire);
+        let moved = now != self.seen;
+        self.seen = now;
+        moved
     }
 
     fn max_width(&self) -> Option<u16> {
@@ -1015,8 +1050,13 @@ mod tests {
         };
 
         let board = Arc::new(Mutex::new(vec![("AAPL".to_string(), Cell::default())]));
-        update(&board, "AAPL", Ok(quote));
-        update(&board, "AAPL", Err(anyhow::anyhow!("HTTP 429")));
+        update(&board, &Arc::new(AtomicU64::new(0)), "AAPL", Ok(quote));
+        update(
+            &board,
+            &Arc::new(AtomicU64::new(0)),
+            "AAPL",
+            Err(anyhow::anyhow!("HTTP 429")),
+        );
 
         let snapshot = board.lock().unwrap().clone();
         let cell = &snapshot[0].1;

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -866,12 +866,19 @@ impl Panel for TodoPanel {
         std::time::Duration::from_mins(1)
     }
 
-    fn tick(&mut self) {
+    fn tick(&mut self) -> bool {
+        // This already compared; the answer was simply thrown away, so the
+        // dashboard repainted every second to learn that the date had not
+        // changed.
         let today = jiff::Zoned::now().date();
-        if today != self.today {
-            self.today = today;
-            self.refresh_view();
+        if today == self.today {
+            return false;
         }
+        self.today = today;
+        // Overdue rows are coloured by date, so a day boundary restyles the
+        // list even when no task moved.
+        self.refresh_view();
+        true
     }
 
     fn remember(&self, state: &mut crate::state::UiState) {

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -10,7 +10,7 @@
 //! Each row is labelled with the hour it applies to, which the previous daily
 //! layout left the reader to infer.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -167,6 +167,15 @@ pub struct WeatherPanel {
     imperial: bool,
     /// Set to ask the fetch thread to finish; see `StocksPanel::stop`.
     stop: Arc<AtomicBool>,
+    /// Bumped by the fetch thread every time it writes to `state`.
+    ///
+    /// A mutex tells you nothing about whether the value behind it moved, and
+    /// this is a last-value-wins slot rather than a channel, so there is no
+    /// other way for the panel to know. Without it the panel had no `tick` and
+    /// no way to report a change, which is the same problem the clock had.
+    generation: Arc<AtomicU64>,
+    /// The generation the last frame drew.
+    seen: u64,
 }
 
 impl Drop for WeatherPanel {
@@ -205,13 +214,23 @@ impl WeatherPanel {
         let state = Arc::new(Mutex::new(State::default()));
         let refresh = Arc::new(Mutex::new(false));
         let stop = Arc::new(AtomicBool::new(false));
+        let generation = Arc::new(AtomicU64::new(0));
         let shared = Arc::clone(&state);
         let shared_refresh = Arc::clone(&refresh);
         let shared_stop = Arc::clone(&stop);
+        let shared_generation = Arc::clone(&generation);
 
         std::thread::Builder::new()
             .name("mirador-weather".into())
-            .spawn(move || fetch_loop(&config, &shared, &shared_refresh, &shared_stop))
+            .spawn(move || {
+                fetch_loop(
+                    &config,
+                    &shared,
+                    &shared_refresh,
+                    &shared_stop,
+                    &shared_generation,
+                );
+            })
             .expect("spawning the weather thread");
 
         Self {
@@ -221,6 +240,8 @@ impl WeatherPanel {
             stale_after,
             imperial,
             stop,
+            generation,
+            seen: 0,
         }
     }
 
@@ -271,6 +292,7 @@ fn fetch_loop(
     state: &Arc<Mutex<State>>,
     refresh: &Arc<Mutex<bool>>,
     stop: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
 ) {
     let interval = Duration::from_secs(config.refresh_minutes.max(1) * 60);
     poll(
@@ -278,6 +300,7 @@ fn fetch_loop(
         state,
         refresh,
         stop,
+        generation,
         interval,
         &resolve_location,
         &fetch_weather,
@@ -294,11 +317,13 @@ fn fetch_loop(
 type Resolver<'a> = &'a dyn Fn(&WeatherConfig) -> Result<Located>;
 type Fetcher<'a> = &'a dyn Fn(&WeatherConfig, &Located) -> Result<WeatherData>;
 
+#[allow(clippy::too_many_arguments)]
 fn poll(
     config: &WeatherConfig,
     state: &Arc<Mutex<State>>,
     refresh: &Arc<Mutex<bool>>,
     stop: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
     interval: Duration,
     resolve_location: Resolver<'_>,
     fetch_weather: Fetcher<'_>,
@@ -318,13 +343,13 @@ fn poll(
         if located.is_none() {
             match resolve_location(config) {
                 Ok(place) => located = Some(place),
-                Err(e) => update(state, |s| s.error = Some(format!("{e:#}"))),
+                Err(e) => update(state, generation, |s| s.error = Some(format!("{e:#}"))),
             }
         }
 
         if let Some(place) = &located {
             match fetch_weather(config, place) {
-                Ok(data) => update(state, |s| {
+                Ok(data) => update(state, generation, |s| {
                     s.data = Some(Box::new(data));
                     s.fetched = Some(Instant::now());
                     s.error = None;
@@ -332,7 +357,7 @@ fn poll(
                 // The reading and its timestamp are deliberately left alone, so
                 // a blip shows the last good data with its age rather than
                 // nothing.
-                Err(e) => update(state, |s| s.error = Some(format!("{e:#}"))),
+                Err(e) => update(state, generation, |s| s.error = Some(format!("{e:#}"))),
             }
         }
 
@@ -346,11 +371,16 @@ fn poll(
     }
 }
 
-fn update(state: &Arc<Mutex<State>>, f: impl FnOnce(&mut State)) {
+/// Apply a change to the shared state and mark it as new.
+///
+/// The generation is bumped *after* the write and with `Release`, so a panel
+/// that sees the new number is guaranteed to see the data behind it.
+fn update(state: &Arc<Mutex<State>>, generation: &Arc<AtomicU64>, f: impl FnOnce(&mut State)) {
     match state.lock() {
         Ok(mut guard) => f(&mut guard),
         Err(poisoned) => f(&mut poisoned.into_inner()),
     }
+    generation.fetch_add(1, Ordering::Release);
 }
 
 /// A place with coordinates.
@@ -689,6 +719,18 @@ impl Panel for WeatherPanel {
         Duration::from_secs(2)
     }
 
+    fn tick(&mut self) -> bool {
+        // A fetch that landed since the last frame is the only thing that can
+        // change this panel without a keypress. Reading a counter is cheaper
+        // than taking the mutex, and far cheaper than repainting the dashboard
+        // every two seconds to find nothing new — which is what happened while
+        // this panel had no `tick` at all.
+        let now = self.generation.load(Ordering::Acquire);
+        let moved = now != self.seen;
+        self.seen = now;
+        moved
+    }
+
     fn handle_key(&mut self, key: ratatui::crossterm::event::KeyEvent) -> crate::panel::KeyOutcome {
         use ratatui::crossterm::event::KeyCode;
         match key.code {
@@ -965,6 +1007,8 @@ mod tests {
             stale_after: Duration::from_hours(1),
             imperial,
             stop: Arc::new(AtomicBool::new(false)),
+            generation: Arc::new(AtomicU64::new(0)),
+            seen: 0,
         }
     }
 
@@ -1079,11 +1123,13 @@ mod tests {
         // whole refresh interval because one request timed out loses more than
         // it protects.
         let state = Arc::new(Mutex::new(State::default()));
-        update(&state, |s| {
+        update(&state, &Arc::new(AtomicU64::new(0)), |s| {
             s.data = Some(Box::new(sample_data(true)));
             s.fetched = Some(Instant::now());
         });
-        update(&state, |s| s.error = Some("network request failed".into()));
+        update(&state, &Arc::new(AtomicU64::new(0)), |s| {
+            s.error = Some("network request failed".into());
+        });
 
         let snapshot = state.lock().unwrap().clone();
         assert!(snapshot.data.is_some(), "the reading must survive");
@@ -1093,8 +1139,10 @@ mod tests {
     #[test]
     fn a_successful_refresh_clears_a_previous_error() {
         let state = Arc::new(Mutex::new(State::default()));
-        update(&state, |s| s.error = Some("boom".into()));
-        update(&state, |s| {
+        update(&state, &Arc::new(AtomicU64::new(0)), |s| {
+            s.error = Some("boom".into());
+        });
+        update(&state, &Arc::new(AtomicU64::new(0)), |s| {
             s.data = Some(Box::new(sample_data(true)));
             s.fetched = Some(Instant::now());
             s.error = None;
@@ -1137,7 +1185,7 @@ mod tests {
     #[test]
     fn the_counter_shows_the_age_once_stale_and_the_observation_time_otherwise() {
         let panel = panel_showing(true);
-        update(&panel.state, |s| {
+        update(&panel.state, &Arc::new(AtomicU64::new(0)), |s| {
             s.data = Some(Box::new(sample_data(true)));
             s.fetched = Some(Instant::now());
         });
@@ -1145,7 +1193,9 @@ mod tests {
 
         // "at 13:00" is only alarming if you happen to know the time now, so
         // the age replaces it outright rather than sitting beside it.
-        update(&panel.state, |s| s.error = Some("timed out".into()));
+        update(&panel.state, &Arc::new(AtomicU64::new(0)), |s| {
+            s.error = Some("timed out".into());
+        });
         assert_eq!(panel.counter(), Some("0m old".to_string()));
     }
 
@@ -1154,7 +1204,9 @@ mod tests {
         let panel = panel_showing(true);
         assert_eq!(panel.counter(), Some("loading".to_string()));
 
-        update(&panel.state, |s| s.error = Some("no such host".into()));
+        update(&panel.state, &Arc::new(AtomicU64::new(0)), |s| {
+            s.error = Some("no such host".into());
+        });
         assert_eq!(
             panel.counter(),
             Some("offline".to_string()),
@@ -1493,6 +1545,7 @@ mod tests {
         fetch: Fetcher<'_>,
         passes: usize,
     ) {
+        let generation = Arc::new(AtomicU64::new(0));
         let seen = std::cell::Cell::new(0usize);
         let counted_resolve = |c: &WeatherConfig| {
             seen.set(seen.get() + 1);
@@ -1508,6 +1561,7 @@ mod tests {
             state,
             refresh,
             stop,
+            &generation,
             interval,
             &counted_resolve,
             fetch,


### PR DESCRIPTION
Task #12 of the adversarial-review plan, and the largest measured item in it.

## The bug

`Panel::tick` returned nothing, so `tick_panels` could only report *"some panel's timer elapsed"* — and the run loop OR'd that straight into `dirty`. Every panel laundered a no-op into a full nine-panel repaint.

- **clocks** asked for a 250ms refresh and **had no `tick` at all**, falling through to the trait's empty default. Four times a second, for ever, it did nothing and the dashboard repainted.
- **calendar** re-read the date every 30s and assigned it without comparing.
- **todo** *did* compare — and threw the answer away.
- **cpu** and **network** return early unless their sample interval elapsed, so half their ticks were no-ops that still repainted.
- **weather** and **stocks** had no tick and no way to know whether their fetch thread had written anything.

## The measurement

Counting `terminal.draw` calls over 60 idle seconds at 400×100 with the shipped nine-panel default, this build against `5e75bf7` built the same way:

| config | before | after | |
|---|---|---|---|
| `show_seconds = false` | 243 draws/min | **62** | 3.9× |
| `show_seconds = true` | 245 draws/min | **99** | 2.5× |

**The first row is the finding in one line.** Before, the two configurations cost *the same* — 243 and 245 — so turning seconds off changed what was on screen and not what the program did. It now costs what it looks like it costs.

The 62 that remain are real: `[cpu].sample_secs` and `[network].sample_secs` default to `1`, so those two graphs genuinely have a new number every second. Raising either lowers the count further — which is now a knob that does something.

### An honest caveat on the CPU figure

The review measured 0.87% of one core and predicted ~0.10% after. I measure **~0.08% before and ~0.05% after** with `ps` on the same machine — an order of magnitude below its absolute numbers, and close enough to `ps`'s 10ms quantisation that I would not defend the ratio. Draw counts are the reliable measure here, and they are what the table above rests on.

## How each panel answers

- **clocks** compares the epoch second, or the epoch *minute* when `show_seconds` is off. Every zone's minute turns on the same instant — UTC offsets are whole minutes, including the 30- and 45-minute ones — so one comparison covers the big clock, the zone list and the date line together. Its refresh interval also drops to 1s when seconds are hidden.
- **calendar**, **notes**, **todo** compare the date they already read.
- **pomodoro** returns `false` while stopped and `true` while running, which is exactly when its displayed second moves.
- **cpu** and **network** return whether `sample()` actually sampled.
- **weather** and **stocks** carry an `Arc<AtomicU64>` the fetch thread bumps after every write, with `Release`/`Acquire` so a panel that sees the new number is guaranteed to see the data behind it. A mutex says nothing about whether the value behind it moved, and both are last-value-wins slots rather than channels.

## Guarding it

```rust
changed = slot.panel.tick() || changed;   // not `changed |= …`
```

`|=` short-circuits once the accumulator is true, which would silently stop ticking panels whenever some *other* panel happened to change first. There is a test for that, and one that drives a dashboard of panels which should settle and asserts repeated forced ticks stop reporting change — the property that did not hold before.

## Verified live

Under tmux: the clock still advances second by second (`21:12:51 → 21:12:54`) and a started pomodoro still counts down (`24:58 → 24:55`). A change like this fails by making something go stale, and that is not visible in a test that never draws.

433 tests pass; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)