### PR TITLE
Stop the network panel lying about the session, and stop `r` bypassing the rate floor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,6 +58,13 @@ fn plain_text(lines: &[Line<'_>]) -> String {
         .join("\n")
 }
 
+/// How long a run of resize keystrokes must be quiet before the layout is
+/// written back.
+///
+/// Long enough to sit out key auto-repeat, short enough that closing the window
+/// a moment later still keeps the change.
+const RESIZE_SETTLE: Duration = Duration::from_millis(750);
+
 /// Smallest weight a panel or row may be squeezed to.
 const MIN_WEIGHT: u16 = 1;
 
@@ -252,6 +259,8 @@ pub struct App {
     /// The config file, so layout changes can be written back to it. `None` in
     /// tests, which is what keeps them off a real user's config.
     config_path: Option<PathBuf>,
+    /// When the last `Ctrl+arrow` landed, if one is still unwritten.
+    last_resize: Option<Instant>,
     /// Whether the layout has been changed since it was last written.
     layout_dirty: bool,
     /// Why the last layout write failed, if it did. Shown in the picker: a
@@ -299,6 +308,7 @@ impl App {
             unused_widgets,
             picker: None,
             config_path: None,
+            last_resize: None,
             layout_dirty: false,
             layout_error: None,
             state_path: None,
@@ -399,6 +409,27 @@ impl App {
             }
 
             dirty |= self.tick_panels();
+
+            // Resizes are batched rather than written per keystroke —
+            // `Ctrl+arrow` auto-repeats, and rewriting the config on every
+            // repeat would be absurd — but they are not batched all the way to
+            // exit any more. Closing the terminal window is a normal way to
+            // stop a dashboard you leave open all day, and it never reaches the
+            // code below: the process is signalled and the pending resize is
+            // gone. This settles once the repeats stop, which is the earliest
+            // moment the write is not wasted.
+            //
+            // Deliberately not a signal handler. The only thing at risk is this
+            // one write, `SIGKILL` cannot be caught anyway, and the terminal
+            // does not need restoring when the terminal is what went away.
+            if self.layout_dirty
+                && self
+                    .last_resize
+                    .is_some_and(|at| at.elapsed() >= RESIZE_SETTLE)
+            {
+                self.write_layout();
+                self.last_resize = None;
+            }
         }
 
         for slot in &mut self.slots {
@@ -407,8 +438,6 @@ impl App {
         // Once more on the way out, in case the last thing changed was not a
         // key — and because Ctrl+C reaches here too.
         self.persist_preferences();
-        // Resizes batch to here rather than writing per keystroke: Ctrl+arrow
-        // repeats, and a config rewritten on every repeat would be absurd.
         self.write_layout();
         Ok(())
     }
@@ -570,6 +599,9 @@ impl App {
             // marking those dirty would write the config on shutdown after a
             // session that changed nothing.
             self.layout_dirty |= resized;
+            if resized {
+                self.last_resize = Some(Instant::now());
+            }
             // Swallowed either way: a resize that hit the minimum is still a
             // resize key, and must not fall through to a panel binding.
             return;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,12 @@ use serde::Deserialize;
 
 use crate::theme::Theme;
 
+/// The longest poll interval any panel will accept, in minutes.
+///
+/// Past any legitimate setting and comfortably inside the `u64` arithmetic that
+/// turns it into a `Duration`.
+const A_YEAR_IN_MINUTES: u64 = 365 * 24 * 60;
+
 /// The default config written on first run.
 pub const DEFAULT_CONFIG: &str = include_str!("../../assets/default_config.toml");
 
@@ -189,6 +195,32 @@ impl Config {
                  interval before the long break."
             );
         }
+
+        // Poll intervals are multiplied out to seconds and then to a `Duration`,
+        // and both `.max(1)` guards only the low end. An absurd value from a
+        // hand-edited config overflows the multiply in release, wraps to a tiny
+        // interval, and turns a polite once-every-thirty-minutes fetch into a
+        // tight loop against somebody else's free API — the one failure mode
+        // that costs a stranger rather than the user.
+        //
+        // A year is well past any legitimate setting and comfortably inside the
+        // arithmetic.
+        if self.weather.refresh_minutes > A_YEAR_IN_MINUTES {
+            anyhow::bail!(
+                "`[weather].refresh_minutes` is {}; the maximum is {A_YEAR_IN_MINUTES} \
+                 (one year). Leave it out to use the default of 30.",
+                self.weather.refresh_minutes
+            );
+        }
+        if self.stocks.refresh_secs > A_YEAR_IN_MINUTES * 60 {
+            anyhow::bail!(
+                "`[stocks].refresh_secs` is {}; the maximum is {} (one year). \
+                 Leave it out to use the default of 120.",
+                self.stocks.refresh_secs,
+                A_YEAR_IN_MINUTES * 60
+            );
+        }
+
         Ok(())
     }
 
@@ -463,6 +495,29 @@ mod tests {
                 "`{key}` did not name its replacement: {message}"
             );
         }
+    }
+
+    #[test]
+    fn an_absurd_poll_interval_is_rejected_rather_than_wrapping() {
+        // `refresh_minutes * 60` and `* 60 * 2` are unchecked `u64` multiplies.
+        // A value near `u64::MAX` wraps in release into a tiny interval, which
+        // is a tight loop against a free API someone else pays for.
+        let config: Config =
+            toml::from_str(&format!("[weather]\nrefresh_minutes = {}", u64::MAX)).expect("parses");
+        let err = config.validate().expect_err("must be rejected");
+        assert!(
+            format!("{err:#}").contains("refresh_minutes"),
+            "the error must name the key: {err:#}"
+        );
+
+        let config: Config =
+            toml::from_str(&format!("[stocks]\nrefresh_secs = {}", u64::MAX)).expect("parses");
+        assert!(config.validate().is_err());
+
+        // The defaults, and a generous manual setting, still pass.
+        assert!(Config::default().validate().is_ok());
+        let config: Config = toml::from_str("[weather]\nrefresh_minutes = 1440").expect("parses");
+        assert!(config.validate().is_ok(), "a day is a legitimate setting");
     }
 
     #[test]

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -243,7 +243,7 @@ fn month_block(
 /// Returns `(columns, rows)`, each at least one so there is always something to
 /// draw; ratatui clips a block that genuinely does not fit.
 fn grid_shape(area: Rect, months_across: usize) -> (usize, usize) {
-    let fits_across = usize::from((area.width + GAP) / (MONTH_WIDTH + GAP)).max(1);
+    let fits_across = usize::from((area.width.saturating_add(GAP)) / (MONTH_WIDTH + GAP)).max(1);
     let columns = fits_across.min(months_across.max(1));
     let fits_down = usize::from(area.height / MONTH_HEIGHT).max(1);
     let rows = fits_down.min(MAX_MONTHS.div_ceil(columns).max(1));

--- a/src/widgets/network.rs
+++ b/src/widgets/network.rs
@@ -32,6 +32,14 @@ pub struct NetworkPanel {
     tx_rate: u64,
     rx_total: u64,
     tx_total: u64,
+    /// The since-boot counters as they read at the first sample.
+    ///
+    /// `sysinfo`'s `total_received` counts from boot, not from when the
+    /// `Networks` list was built, so the panel's "session" line was reporting
+    /// the machine's whole uptime. On a host up for three weeks it read 128 GB
+    /// within a minute of launch. Subtracting the first reading makes the label
+    /// true; `None` until that first sample lands.
+    since_boot: Option<(u64, u64)>,
     last_sample: Instant,
     /// False until the second sample, since the first has no delta to compare.
     primed: bool,
@@ -63,6 +71,7 @@ impl NetworkPanel {
             graph_cells: 0,
             rx_total: 0,
             tx_total: 0,
+            since_boot: None,
             last_sample: Instant::now(),
             primed: false,
         }
@@ -109,8 +118,12 @@ impl NetworkPanel {
         let seconds = elapsed.as_secs_f64().max(0.001);
         self.rx_rate = (rx_delta as f64 / seconds) as u64;
         self.tx_rate = (tx_delta as f64 / seconds) as u64;
-        self.rx_total = rx_total;
-        self.tx_total = tx_total;
+        let (rx_base, tx_base) = *self.since_boot.get_or_insert((rx_total, tx_total));
+        // Saturating: an interface disappearing takes its counter with it, so
+        // the sum can fall below the baseline. Zero is the honest answer then,
+        // not a number wrapped around u64.
+        self.rx_total = rx_total.saturating_sub(rx_base);
+        self.tx_total = tx_total.saturating_sub(tx_base);
         self.last_sample = Instant::now();
 
         // The first refresh after construction reports the counters since the

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -44,6 +44,13 @@ const BINDINGS: &[Binding] = &[
     Binding::extra("o", "show file path"),
 ];
 
+/// The shortest gap between two rounds of polling, however it was asked for.
+///
+/// Not a tuning knob. The quote sources are free and unauthenticated and gate
+/// on IP reputation, so exceeding this costs everyone behind the same address,
+/// not just the user who held the key down.
+const MIN_SECONDS_BETWEEN_POLLS: u64 = 60;
+
 /// Widest the intraday sparkline is drawn.
 const SPARK_WIDTH: u16 = 12;
 
@@ -189,7 +196,7 @@ impl StocksPanel {
         let shared_generation = Arc::clone(&generation);
         // Never faster than a minute: the sources are free and unauthenticated,
         // and hammering them is how an IP gets blocked for everyone behind it.
-        let interval = Duration::from_secs(config.refresh_secs.max(60));
+        let interval = Duration::from_secs(config.refresh_secs.max(MIN_SECONDS_BETWEEN_POLLS));
         let stagger = Duration::from_millis(config.stagger_ms.clamp(100, 10_000));
 
         std::thread::Builder::new()
@@ -528,7 +535,26 @@ fn fetch_loop(
     interval: Duration,
     stagger: Duration,
 ) {
+    // The floor is enforced here rather than only in the interval, because `r`
+    // and a watchlist edit both break the wait early — so a held `r` re-polled
+    // every symbol as fast as the requests completed, against a source
+    // `quote.rs` documents as gating on IP reputation, and under a comment in
+    // `CLAUDE.md` claiming the limit was "enforced in code, not just
+    // documented". It was not.
+    //
+    // A wake that arrives too soon waits out the remainder instead of being
+    // dropped: the user asked for a refresh and should get one, just not now.
+    let floor = Duration::from_secs(MIN_SECONDS_BETWEEN_POLLS);
+    let mut last_poll: Option<Instant> = None;
+
     while !stop.load(Ordering::Relaxed) {
+        if let Some(at) = last_poll
+            && let Some(remaining) = floor.checked_sub(at.elapsed())
+            && crate::poll::wait(remaining, stop, || false) == crate::poll::Wake::Stop
+        {
+            return;
+        }
+
         let symbols = {
             let guard = match request.lock() {
                 Ok(g) => g,
@@ -537,6 +563,7 @@ fn fetch_loop(
             guard.symbols.clone()
         };
 
+        last_poll = Some(Instant::now());
         for symbol in &symbols {
             let result = source.fetch(symbol);
             update(board, generation, symbol, result);
@@ -1031,6 +1058,76 @@ mod tests {
         assert!(
             text.contains("429"),
             "the reason must reach the user: `{text}`"
+        );
+    }
+
+    #[test]
+    fn holding_r_cannot_poll_faster_than_the_floor() {
+        use std::sync::atomic::AtomicUsize;
+
+        /// Counts calls and returns instantly, so the loop is bounded only by
+        /// its own rate limiting rather than by how long a request takes.
+        struct Counting(Arc<AtomicUsize>);
+        impl QuoteSource for Counting {
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+            fn fetch(&self, symbol: &str) -> anyhow::Result<Quote> {
+                self.0.fetch_add(1, Ordering::Relaxed);
+                Ok(Quote {
+                    symbol: symbol.to_string(),
+                    price: 1.0,
+                    previous_close: 1.0,
+                    currency: None,
+                    series: vec![],
+                    delayed: false,
+                })
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let source = Counting(Arc::clone(&calls));
+        let board = Arc::new(Mutex::new(vec![("AAPL".to_string(), Cell::default())]));
+        let request = Arc::new(Mutex::new(Request {
+            symbols: vec!["AAPL".into()],
+            // Held down: every time the loop looks, a refresh is waiting.
+            refresh: true,
+        }));
+        let stop = Arc::new(AtomicBool::new(false));
+        let generation = Arc::new(AtomicU64::new(0));
+
+        // Keep asking for a refresh for as long as the loop runs, and stop it
+        // after a couple of seconds.
+        let ticking = Arc::clone(&request);
+        let flag = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let until = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < until {
+                if let Ok(mut guard) = ticking.lock() {
+                    guard.refresh = true;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            flag.store(true, Ordering::Relaxed);
+        });
+
+        fetch_loop(
+            &source,
+            &board,
+            &request,
+            &stop,
+            &generation,
+            Duration::from_millis(1),
+            Duration::ZERO,
+        );
+
+        // Two seconds against a 60-second floor: the first poll, and nothing
+        // else. Before, `r` broke the wait and the loop re-polled every symbol
+        // as fast as the requests came back.
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "the rate floor was bypassed by a held refresh key"
         );
     }
 


### PR DESCRIPTION
Task #14 of the adversarial-review plan.

## "SESSION" was reporting the machine's uptime

`sysinfo`'s `total_received` counts from **boot**, not from when the `Networks` list was built — so the line labelled `SESSION` showed everything the host had ever transferred, and got worse the longer the *machine* had been up. Same family as invariant 13.

The review measured **128 GB within a minute of launch** on a host up three weeks. After: on a host up 22 days,

```
SESSION  ↓ 15.9 KB  ↑ 19.1 KB
```

…eight seconds after launch. The first sample's reading is kept and subtracted, saturating because an interface disappearing takes its counter with it.

## A held `r` re-polled as fast as requests completed

The 60-second floor was applied to the *interval* — and `r` and a watchlist edit both break the wait early, so nothing consulted it on that path. Terminal auto-repeat on a held `r` therefore hammered a source `quote.rs` documents as gating on **IP reputation**, which costs everyone behind the same address.

It did so under a comment in `CLAUDE.md` claiming the limit was *"enforced in code, not just documented"*. It was not.

Measured against the emulated old behaviour: **8 polls in 2 seconds** — one per 250ms wait slice. The floor is now enforced at the top of the loop against the last poll, and the test drives a held refresh for two seconds and asserts exactly one poll:

```
assertion `left == right` failed: the rate floor was bypassed by a held refresh key
  left: 8
 right: 1
```

A wake that arrives too soon waits out the remainder rather than being dropped — the user asked for a refresh and gets one, just not now.

## `refresh_minutes` and `refresh_secs` were unbounded

Both are multiplied out to a `Duration` with unchecked `u64` arithmetic, and `.max(1)` guards only the low end. An absurd hand-edited value wraps in release into a *tiny* interval — turning a polite thirty-minute fetch into a tight loop against somebody else's free API. That is the one failure mode here that costs a stranger rather than the user.

Both now bounded at a year, which is well past any legitimate setting and comfortably inside the arithmetic. `Config::default()` and a one-day interval both still validate.

## Resize weights no longer wait for a clean exit

They were batched to the end of `run`, which closing the terminal window never reaches — and closing the window is a normal way to stop a dashboard you leave open all day.

They now settle 750ms after the last `Ctrl+arrow`: long enough to sit out key auto-repeat, short enough that closing the window a moment later keeps the change.

**Deliberately not a signal handler**, and deliberately not a new dependency for one. The only thing at risk was this single write, `SIGKILL` cannot be caught anyway, and the terminal does not need restoring when the terminal is what went away.

## Also

`calendar.rs`'s one unchecked `u16 +` on an externally supplied width. `saturating_add` costs nothing.

437 tests pass; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)