### PR TITLE
Fix the three per-frame costs that were algorithmic, and decline the two that were not

### DIFF
--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -810,10 +810,13 @@ impl Panel for NotesPanel {
             );
             frame.render_widget(Paragraph::new(grid.header(theme)), header_area);
 
+            // `NoteStore::get` is a linear scan; see the same fix in `todo.rs`.
+            let by_id: std::collections::HashMap<u64, &Note> =
+                self.store.notes().iter().map(|n| (n.id, n)).collect();
             let visible: Vec<&Note> = self
                 .view
                 .iter()
-                .filter_map(|id| self.store.get(*id))
+                .filter_map(|id| by_id.get(id).copied())
                 .collect();
             let items: Vec<ListItem> = visible
                 .iter()

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -25,6 +25,40 @@ use crate::task::{DueState, Priority, SortMode, Task, TaskStore};
 use crate::textfield::TextField;
 use crate::theme::Theme;
 
+/// The three tallies the header and the frame counter show.
+///
+/// Cached rather than recomputed, because they were four separate full scans of
+/// the store — three here and one in `counter()` — with `jiff` date arithmetic
+/// per task, and they run on **every frame**. `title()` and `counter()` are
+/// called by the shell's render loop outside `render()`, so no early-out
+/// protects them and a narrow or hidden panel paid the same price as a visible
+/// one. They also grew without bound: the store never drops completed tasks.
+///
+/// Now one pass, recomputed only where the answer can change — a store
+/// mutation, or the date rolling over at midnight, both of which already go
+/// through `refresh_view`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Counts {
+    open: usize,
+    overdue: usize,
+    today: usize,
+}
+
+impl Counts {
+    fn of(tasks: &[Task], today: Date) -> Self {
+        let mut counts = Self::default();
+        for task in tasks.iter().filter(|t| !t.done) {
+            counts.open += 1;
+            match task.due_state(today) {
+                DueState::Overdue(_) => counts.overdue += 1,
+                DueState::Today => counts.today += 1,
+                _ => {}
+            }
+        }
+        counts
+    }
+}
+
 /// Keys this panel responds to.
 ///
 /// The first few `primary` entries are what fits in the frame hint, so they
@@ -196,6 +230,8 @@ pub struct TodoPanel {
     mode: Mode,
     /// Task ids in display order, recomputed whenever the list changes.
     view: Vec<u64>,
+    /// The header and counter tallies, recomputed alongside `view`.
+    counts: Counts,
     list_state: ListState,
     /// Transient message with a severity flag.
     status: Option<(String, bool)>,
@@ -222,6 +258,7 @@ impl TodoPanel {
             filter: String::new(),
             mode: Mode::List,
             view: Vec::new(),
+            counts: Counts::default(),
             list_state: ListState::default(),
             status: None,
             today,
@@ -238,6 +275,7 @@ impl TodoPanel {
         self.view = self
             .store
             .view(self.sort, self.show_completed, &self.filter, self.today);
+        self.counts = Counts::of(self.store.tasks(), self.today);
 
         let index = previously_selected
             .and_then(|id| self.view.iter().position(|v| *v == id))
@@ -641,19 +679,11 @@ impl TodoPanel {
 
     /// The summary line: how much is open, and how it is sorted.
     fn header(&self, theme: &Theme) -> Line<'static> {
-        let open = self.store.tasks().iter().filter(|t| !t.done).count();
-        let overdue = self
-            .store
-            .tasks()
-            .iter()
-            .filter(|t| !t.done && matches!(t.due_state(self.today), DueState::Overdue(_)))
-            .count();
-        let today = self
-            .store
-            .tasks()
-            .iter()
-            .filter(|t| !t.done && matches!(t.due_state(self.today), DueState::Today))
-            .count();
+        let Counts {
+            open,
+            overdue,
+            today,
+        } = self.counts;
 
         let mut spans = Vec::new();
 
@@ -857,8 +887,7 @@ impl Panel for TodoPanel {
         if self.store.last_error.is_some() {
             return Some("unsaved!".into());
         }
-        let open = self.store.tasks().iter().filter(|t| !t.done).count();
-        Some(format!("{open} open"))
+        Some(format!("{} open", self.counts.open))
     }
 
     fn refresh_interval(&self) -> std::time::Duration {
@@ -985,10 +1014,16 @@ impl Panel for TodoPanel {
                 rows[2],
             );
         } else {
+            // `TaskStore::get` is a linear scan, so mapping the whole view
+            // through it was O(view x store) on every frame — over a store that
+            // never drops a completed task, so it grows monotonically with
+            // months of use. One pass to index, then a lookup per row.
+            let by_id: std::collections::HashMap<u64, &Task> =
+                self.store.tasks().iter().map(|t| (t.id, t)).collect();
             let visible: Vec<&Task> = self
                 .view
                 .iter()
-                .filter_map(|id| self.store.get(*id))
+                .filter_map(|id| by_id.get(id).copied())
                 .collect();
 
             // The list is indented by the selection marker, so the grid gets

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -270,6 +270,43 @@ impl WeatherPanel {
         data
     }
 
+    /// The frame counter for a given state.
+    ///
+    /// Split out so it can be computed from a borrow rather than a clone; see
+    /// [`WeatherPanel::with_state`].
+    fn counter_for(&self, state: &State) -> Option<String> {
+        let Some(data) = &state.data else {
+            return Some(if state.error.is_some() {
+                "offline".to_string()
+            } else {
+                "loading".to_string()
+            });
+        };
+
+        // The observation time matters: a dashboard left running all day must
+        // never let you mistake an old reading for a live one. Once it is stale
+        // the age replaces the time outright, because "at 09:00" is only
+        // alarming if you happen to know what time it is now.
+        if self.is_stale(state) {
+            return state.age().map(describe_age);
+        }
+        (!data.observed.is_empty()).then(|| format!("at {}", data.observed))
+    }
+
+    /// Read something out of the shared state without cloning all of it.
+    ///
+    /// `title` and `counter` are called by the shell on every frame, and both
+    /// wanted one small fact — the place name, the observation time. Taking a
+    /// whole `State` for either meant a deep copy of a boxed reading with its
+    /// 24 forecast slots and two `String`s, four times a frame between them and
+    /// `render`.
+    fn with_state<T>(&self, f: impl FnOnce(&State) -> T) -> T {
+        match self.state.lock() {
+            Ok(guard) => f(&guard),
+            Err(poisoned) => f(&poisoned.into_inner()),
+        }
+    }
+
     fn snapshot(&self) -> State {
         // A poisoned lock means the fetch thread panicked. Recover the value
         // rather than propagating the panic into the render loop: one dead
@@ -665,30 +702,14 @@ fn urlencode(input: &str) -> String {
 
 impl Panel for WeatherPanel {
     fn title(&self) -> String {
-        match self.snapshot().data {
+        self.with_state(|state| match &state.data {
             Some(data) => format!("Weather — {}", data.place),
             None => "Weather".to_string(),
-        }
+        })
     }
 
     fn counter(&self) -> Option<String> {
-        let state = self.snapshot();
-        let Some(data) = &state.data else {
-            return Some(if state.error.is_some() {
-                "offline".to_string()
-            } else {
-                "loading".to_string()
-            });
-        };
-
-        // The observation time matters: a dashboard left running all day must
-        // never let you mistake an old reading for a live one. Once it is stale
-        // the age replaces the time outright, because "at 09:00" is only
-        // alarming if you happen to know what time it is now.
-        if self.is_stale(&state) {
-            return state.age().map(describe_age);
-        }
-        (!data.observed.is_empty()).then(|| format!("at {}", data.observed))
+        self.with_state(|state| self.counter_for(state))
     }
 
     fn bindings(&self) -> &'static [Binding] {
@@ -764,10 +785,12 @@ impl Panel for WeatherPanel {
             return;
         }
 
-        let state = self.snapshot();
+        let mut state = self.snapshot();
         let is_old = self.is_stale(&state);
 
-        let Some(reading) = state.data.clone() else {
+        // `take`, not `clone`: `state` is already this function's own copy, so
+        // cloning the boxed reading out of it made a second one for nothing.
+        let Some(reading) = state.data.take() else {
             // Nothing has ever landed. Only here is the panel genuinely empty.
             let lines = match &state.error {
                 Some(message) => vec![
@@ -792,7 +815,9 @@ impl Panel for WeatherPanel {
             return;
         };
 
-        let data = Box::new(self.in_display_units(*reading));
+        // Unboxed once and left unboxed: it was immediately re-boxed, which is
+        // an allocation to hold a value that never leaves this function.
+        let data = self.in_display_units(*reading);
 
         // The art is the one indulgence in this panel, so it is the first thing
         // dropped when the panel gets short.


### PR DESCRIPTION
Task #15 of the adversarial-review plan — the last one.

The performance review is explicit that per-frame `format!`/`clone` churn is a **non-finding** (the allocator measured 0.03% of one core) and asks for the items that are genuinely complexity or deep copies. These are those, minus two I could not justify.

## Four full-store scans per frame, on the path with no early-out

`TodoPanel::header` counted open, overdue and today in **three separate passes** with `jiff` date arithmetic per task, and `counter()` made a fourth.

The part that makes it worse than it looks: `title()` and `counter()` are called from the shell's *render loop*, not from `render`. Nothing guards them — a panel too narrow to draw a single row paid exactly what a full one did. And the store never drops a completed task, so the cost grows monotonically with months of use.

Now one pass into a `Counts`, recomputed only where the answer can change: a store mutation, or the date rolling over at midnight. Both already go through `refresh_view`.

## O(view × store) row lookup, in two panels

`todo` and `notes` both mapped their whole filtered view through `Store::get`, which is a linear scan:

```rust
self.view.iter().filter_map(|id| self.store.get(*id))
```

One pass to index by id, then a lookup per row.

## Weather deep-cloned its entire `State` four times a frame

`title` and `counter` each took a full clone — a boxed reading with 24 forecast slots and two `String`s — to read one small fact, and both run every frame. They borrow now, through a `with_state` helper.

`render` also cloned `state.data` out of a `State` it already owned (`take` is free), then unboxed and immediately re-boxed the result. One clone a frame instead of four.

## Declined: restructuring the stocks board snapshot

The review flags cloning every `Quote` including its ~78-sample series while holding the board mutex. It is one clone per **frame**, not per row — a few kilobytes — and the alternative is holding the lock across the entire render, which blocks the fetch thread for considerably longer than the copy does. The current shape is right.

## Declined: rebuilding one panel instead of all of them

Toggling a widget in the picker does re-read three data files and spawn two threads inside `handle_key`, and that is worth knowing.

But the current code deliberately builds the new slots *before* shutting the old ones down, so a layout that fails to build leaves the running dashboard alone — and rebuilding selectively means re-deriving the position map for every panel that stayed. That is a design change rather than a tune, and toggling a widget is an act the user just performed and is waiting on. Noted rather than half-done.

## Verification

Under tmux: the cached tally still reads `1 overdue  4 open` against `4 open` in the border, the weather title still resolves to `Weather — Boston, Massachusetts` with `at 21:30` beside it, and the notes list still draws.

437 tests pass; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)