### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-07-26
 
-Findings from an adversarial review of the whole project, fixed in order of how
-much they could cost someone.
+Fifteen items from an adversarial review of the whole project, worked in order
+of how much each could cost someone.
+
+**Upgrading:** two changes can stop a config that used to start. A misspelled
+key under `[theme]` is now an error rather than being silently ignored, and an
+absurd `[weather].refresh_minutes` or `[stocks].refresh_secs` is rejected rather
+than wrapping. Both report the key and how to fix it. If your config was written
+before 0.1.0, `mirador --migrate-config` will update it.
 
 ### Fixed
 
@@ -549,7 +555,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.4.0...HEAD
+[0.5.0]: https://github.com/jchultarsky/mirador/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jchultarsky/mirador/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/jchultarsky/mirador/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jchultarsky/mirador/compare/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,7 +415,7 @@ open work is how the list stops being read.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.4.0` is released**, on crates.io and as a GitHub release with binaries
+- **`0.5.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ there are no backports. In practice that means whatever is on the
 
 | Version | Supported |
 | --- | --- |
-| 0.4.x | Yes |
-| < 0.4 | No — upgrade |
+| 0.5.x | Yes |
+| < 0.5 | No — upgrade |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Version bump, changelog date, and the version references that go with it.

## Why 0.5.0 and not 0.4.1

Two changes can stop a config that previously started:

- A misspelled key under `[theme]` is now an error rather than being silently accepted and ignored (`acent = "#ff0000"` used to parse clean and do nothing).
- An absurd `[weather].refresh_minutes` or `[stocks].refresh_secs` is rejected rather than wrapping into a tight loop against a free API.

Both name the offending key and say how to fix it, and a pre-0.1.0 config still has `mirador --migrate-config`. But a config that loaded yesterday and refuses today is a breaking change, and under pre-1.0 semver that is the minor position.

The `[Unreleased]` section becomes `[0.5.0] - 2026-07-26` and gains an upgrading note covering both. The `[Unreleased]` link definition goes with the heading — leaving a dangling one is the defect #38 fixed in the other direction.

## Also updated

- `SECURITY.md` supported-version table → `0.5.x`
- `CLAUDE.md`'s released-version note → `0.5.0`
- `Cargo.lock`

## Verified before pushing

- `dist plan --tag=v0.5.0` announces `v0.5.0` and plans all four targets, both installers, the updaters, checksums and `sha256.sum`
- `cargo publish --locked --dry-run` packages cleanly
- 437 tests, fmt, clippy, docs all green

Once this merges, the tag goes up and the release workflow takes it from there; `cargo publish` follows, in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)