### PR TITLE
Carry panels across a layout change instead of rebuilding all of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Switching a panel on or off no longer disturbs the others.** Toggling
+  anything in the `w` picker used to rebuild every panel, which reset a running
+  pomodoro to 25:00 and sent the weather and market panels back to "loading" for
+  a fetch cycle. Panels that are still placed are now carried across untouched.
+  Keyboard focus follows its panel to wherever the new layout puts it, instead
+  of staying on an index that may now be a different panel.
+
 ## [0.5.0] - 2026-07-26
 
 Fifteen items from an adversarial review of the whole project, worked in order
@@ -555,6 +566,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/jchultarsky/mirador/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jchultarsky/mirador/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/jchultarsky/mirador/compare/v0.3.0...v0.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,9 +424,11 @@ open work is how the list stops being read.
   - **150x42, not smaller.** The clock drops its block numerals when its row is
     short, and those numerals are the one thing in mirador that looks like
     nothing else.
-  - **Start the pomodoro *after* the picker segment.** Toggling any panel
-    rebuilds every panel, which resets a running timer — so a demo that starts
-    it earlier records it silently giving up.
+  - **The order of the segments is now taste, not a workaround.** It used to
+    matter: toggling any panel rebuilt every panel, so starting the pomodoro
+    before the picker segment recorded the timer silently resetting, and the
+    weather and stocks panels spent a fetch cycle showing "loading" afterwards.
+    `rebuild_panels` carries panels across now, so neither happens.
 
 - **The README's images float; its prose does not.** `docs/screenshot.png` is
   referenced by absolute `raw.githubusercontent.com/.../main/...` URL, because

--- a/docs/record-demo.sh
+++ b/docs/record-demo.sh
@@ -137,28 +137,28 @@ key a 0.7                                        # add a task
 type_text "Renew the domain"
 key Enter 1.8                                    # and it is in the list
 
-# `End` selects the last widget, `network`. Toggling any panel rebuilds the
-# whole dashboard, and a re-added widget goes to the emptiest row — so removing
-# the *last* one is the case where it comes back exactly where it was. Any other
-# choice reshuffles the row, which reads as a glitch rather than as a feature.
+# `End` selects the last widget, `network`. A re-added widget goes to the
+# emptiest row, so removing the *last* one is the case where it comes back
+# exactly where it was; any other choice reshuffles the row, which reads as a
+# glitch rather than as a feature. The panels that stay put are carried across
+# rather than rebuilt, so nothing else on screen so much as blinks.
 tmux send-keys -t "$SESSION" 'w'; hold 1.0      # the panel picker
 key End 0.5
 key space 1.3                                    # a panel goes, the grid reflows
 key space 1.3                                    # and comes back
 key Escape 0.8
 
-# The help overlay goes last on purpose. Rebuilding the panels restarts the
-# weather and price fetches, so for a few seconds those two read "loading" —
-# real behaviour, but it looks like a fault in a silent GIF. Holding the overlay
-# over the top gives them time to come back before the last frames.
+# The help overlay before the timer, so the GIF ends on a running clock rather
+# than on a dialog. (This used to be a workaround: toggling a panel restarted
+# the weather and price fetches, and the overlay hid the few seconds of
+# "loading". Panels are carried across now, so it is just the better order.)
 tmux send-keys -t "$SESSION" '?'; hold 1.8      # every binding, scrollable
 key Down 0.4
 key Down 0.4
 key Down 0.8
 tmux send-keys -t "$SESSION" 'x'; hold 1.0      # any other key closes it
 
-# The timer is started last. Toggling a panel rebuilds every panel, which resets
-# a running pomodoro — so starting it earlier would show it silently give up.
+# Started last so the recording ends on something moving.
 tmux send-keys -t "$SESSION" '6'; hold 0.6
 key space 2.8                                    # started, and counting down
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -202,6 +202,11 @@ type Built = (Vec<Slot>, Vec<(usize, usize)>);
 
 /// A panel plus its tick bookkeeping.
 struct Slot {
+    /// Which widget this is, so a layout change can carry the panel across
+    /// rather than rebuilding it. Kept on the slot because the config's
+    /// `[layout]` has already been mutated by the time a rebuild runs, so it
+    /// no longer says what the *current* panels are.
+    widget: String,
     panel: Box<dyn Panel>,
     /// When this panel last ticked. `None` until it has, which is what makes
     /// the first tick fire immediately.
@@ -327,6 +332,7 @@ impl App {
                     .with_context(|| format!("building the `{}` panel", entry.widget))?;
                 if let Some(panel) = panel {
                     slots.push(Slot {
+                        widget: entry.widget.clone(),
                         panel,
                         last_tick: None,
                         area: None,
@@ -343,30 +349,135 @@ impl App {
         Ok((slots, positions))
     }
 
-    /// Rebuild every panel after the layout changed.
+    /// Reconcile the panels with a changed layout, carrying across every panel
+    /// that is still placed.
     ///
-    /// Panels are thrown away and remade rather than moved, which costs a fresh
-    /// weather fetch and an empty CPU history for the panels that survived. The
-    /// alternative is matching old panels to new positions by widget name and
-    /// carrying them across, which is a good deal more machinery for something
-    /// that happens when a person deliberately opens a dialog and toggles
-    /// something — a moment where a beat of re-fetching reads as the dashboard
-    /// responding rather than as a stall.
+    /// This used to throw every panel away and remake them all, on the grounds
+    /// that a beat of re-fetching reads as the dashboard responding. That was
+    /// wrong, and the demo recording is what showed it: **start the pomodoro,
+    /// toggle an unrelated panel, and the timer resets to 25:00.** A running
+    /// timer is not a cache that can be refilled — it is the user's state, and
+    /// nothing about switching the network panel off says to discard it. The
+    /// weather and stocks panels lost their readings the same way and spent a
+    /// fetch cycle showing "loading" after any toggle.
     ///
-    /// A failure leaves the previous panels in place: a layout that will not
-    /// build is a reason to refuse the change, not to end up with nothing.
+    /// A panel is matched to a layout entry by widget name. Nothing stops a
+    /// hand-written config placing the same widget twice — `validate` checks
+    /// that names are *known*, not that they are unique — so the surviving
+    /// panels are consumed from a pool rather than looked up, and a second
+    /// `clocks` entry gets a second panel rather than the same one twice.
+    ///
+    /// Two orderings matter here:
+    ///
+    /// 1. Every genuinely new panel is built **before** any existing one is
+    ///    disturbed, so a layout that will not build leaves the running
+    ///    dashboard exactly as it was. That was already true and is preserved.
+    /// 2. Panels are shut down only once the new arrangement is settled, and
+    ///    only the ones actually leaving. Dropping them without `shutdown`
+    ///    discards the task store's save-on-shutdown and leaks the fetch
+    ///    threads.
+    ///
+    /// This is only ever called after a `[layout]` edit, so no panel's *own*
+    /// config can have changed underneath it. A caller that changes, say,
+    /// `[weather].units` cannot use this — the carried-over panel would keep
+    /// the old setting.
     fn rebuild_panels(&mut self) -> Result<()> {
-        let (slots, positions) = Self::build_slots(&self.config)?;
-        // Built first, then the outgoing panels are told to stop: a layout that
-        // will not build must leave the running dashboard alone. Without this
-        // the old panels were simply dropped, so a toggle discarded the task
-        // store's save-on-shutdown and left the fetch threads running.
-        for slot in &mut self.slots {
-            slot.panel.shutdown();
+        use std::collections::{HashMap, VecDeque};
+
+        let desired: Vec<(usize, usize, String)> = self
+            .config
+            .layout
+            .rows
+            .iter()
+            .enumerate()
+            .flat_map(|(row, entry)| {
+                entry
+                    .panels
+                    .iter()
+                    .enumerate()
+                    .map(move |(column, panel)| (row, column, panel.widget.clone()))
+            })
+            .collect();
+
+        // What the live panels can supply, by name.
+        let mut spare: HashMap<&str, usize> = HashMap::new();
+        for slot in &self.slots {
+            *spare.entry(slot.widget.as_str()).or_default() += 1;
         }
+
+        // Build only what cannot be carried across. Any failure returns here,
+        // with `self` untouched.
+        let mut fresh: HashMap<String, VecDeque<Box<dyn Panel>>> = HashMap::new();
+        let mut placed = 0usize;
+        for (_, _, widget) in &desired {
+            if let Some(count) = spare.get_mut(widget.as_str())
+                && *count > 0
+            {
+                *count -= 1;
+                placed += 1;
+                continue;
+            }
+            let panel = crate::widgets::build(widget, &self.config)
+                .with_context(|| format!("building the `{widget}` panel"))?;
+            if let Some(panel) = panel {
+                fresh.entry(widget.clone()).or_default().push_back(panel);
+                placed += 1;
+            }
+        }
+
+        // Checked before anything is taken apart, so a layout that would leave
+        // nothing on screen is refused rather than applied.
+        anyhow::ensure!(
+            placed > 0,
+            "no panels were built; check the `[layout]` table in your config"
+        );
+
+        let focused = self.slots.get(self.focus).map(|slot| slot.widget.clone());
+
+        let mut pool: HashMap<String, VecDeque<Slot>> = HashMap::new();
+        for slot in std::mem::take(&mut self.slots) {
+            pool.entry(slot.widget.clone()).or_default().push_back(slot);
+        }
+
+        let mut slots = Vec::with_capacity(placed);
+        let mut positions = Vec::with_capacity(placed);
+        for (row, column, widget) in desired {
+            let carried = pool.get_mut(&widget).and_then(VecDeque::pop_front);
+            let slot = carried.or_else(|| {
+                fresh
+                    .get_mut(&widget)
+                    .and_then(VecDeque::pop_front)
+                    .map(|panel| Slot {
+                        widget: widget.clone(),
+                        panel,
+                        last_tick: None,
+                        area: None,
+                    })
+            });
+            if let Some(mut slot) = slot {
+                // The panel is almost certainly somewhere else on screen now,
+                // and `area` is what mouse events are matched against. Cleared
+                // rather than trusted until the next draw sets it.
+                slot.area = None;
+                slots.push(slot);
+                positions.push((row, column));
+            }
+        }
+
+        // Whatever is left was removed from the layout.
+        for (_, leaving) in pool {
+            for mut slot in leaving {
+                slot.panel.shutdown();
+            }
+        }
+
+        // Follow the focused panel to wherever it ended up, rather than leaving
+        // the highlight on whatever now occupies its old index.
+        self.focus = focused
+            .and_then(|widget| slots.iter().position(|slot| slot.widget == widget))
+            .unwrap_or_else(|| self.focus.min(slots.len().saturating_sub(1)));
         self.slots = slots;
         self.positions = positions;
-        self.focus = self.focus.min(self.slots.len().saturating_sub(1));
         self.unused_widgets = crate::widgets::unused_widgets(&self.config);
         Ok(())
     }
@@ -1426,6 +1537,97 @@ mod tests {
         let before = widths(&app);
         app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL));
         assert_ne!(widths(&app), before, "Ctrl+Left was swallowed by the panel");
+    }
+
+    #[test]
+    fn toggling_one_panel_leaves_the_others_untouched() {
+        // The bug the demo recording caught: `rebuild_panels` remade every
+        // panel, so switching the network panel off reset a running pomodoro to
+        // 25:00 and sent the weather and stocks panels back to "loading".
+        //
+        // Panels are compared by pointer identity — the same allocation before
+        // and after is the only thing that actually proves state survived,
+        // where comparing a rendered figure would pass for a panel that had
+        // been rebuilt and happened to look the same.
+        let mut app = App::new(config_with(&["clocks", "todo", "pomodoro"])).unwrap();
+        let before: Vec<*const u8> = app
+            .slots
+            .iter()
+            .map(|slot| std::ptr::from_ref(&*slot.panel).cast::<u8>())
+            .collect();
+
+        app.toggle_widget("pomodoro");
+        assert!(!app.config.layout.places("pomodoro"), "it went");
+
+        let after: Vec<*const u8> = app
+            .slots
+            .iter()
+            .map(|slot| std::ptr::from_ref(&*slot.panel).cast::<u8>())
+            .collect();
+        assert_eq!(after, before[..2], "the surviving panels were rebuilt");
+
+        // And back again: the two that never left are still the same panels.
+        app.toggle_widget("pomodoro");
+        assert!(app.config.layout.places("pomodoro"));
+        let again: Vec<*const u8> = app
+            .slots
+            .iter()
+            .take(2)
+            .map(|slot| std::ptr::from_ref(&*slot.panel).cast::<u8>())
+            .collect();
+        assert_eq!(again, before[..2], "re-adding a panel rebuilt the others");
+    }
+
+    #[test]
+    fn focus_follows_the_panel_rather_than_the_index() {
+        // Removing a panel to the left of the focused one shifts every later
+        // index down. Leaving `focus` where it was moves the highlight to a
+        // different panel, which gets noticed only when the next keypress goes
+        // somewhere unexpected.
+        //
+        // The indices are chosen so that clamping cannot pass by accident: with
+        // four panels and focus on the second, removing the first leaves the
+        // old `min(focus, len - 1)` pointing at the *third* widget.
+        let mut app = App::new(config_with(&["clocks", "todo", "pomodoro", "notes"])).unwrap();
+        app.focus = 1;
+        assert_eq!(app.slots[app.focus].widget, "todo");
+
+        app.toggle_widget("clocks");
+        assert_eq!(
+            app.slots[app.focus].widget, "todo",
+            "focus jumped to another panel"
+        );
+    }
+
+    #[test]
+    fn a_widget_placed_twice_gets_two_panels() {
+        // `Config::validate` checks that widget names are *known*, not that
+        // they are unique, so a hand-written config can place one twice.
+        // Matching panels to entries by name has to consume from a pool — a
+        // lookup would hand the same panel to both entries.
+        let mut config = config_with(&["clocks", "clocks", "todo"]);
+        config.layout.rows[0].panels[0].width = 30;
+        config.layout.rows[0].panels[1].width = 30;
+        config.layout.rows[0].panels[2].width = 40;
+
+        let mut app = App::new(config).unwrap();
+        assert_eq!(app.slots.len(), 3);
+
+        let distinct: std::collections::HashSet<*const u8> = app
+            .slots
+            .iter()
+            .map(|slot| std::ptr::from_ref(&*slot.panel).cast::<u8>())
+            .collect();
+        assert_eq!(distinct.len(), 3, "two entries share one panel");
+
+        // A rebuild must keep them distinct too.
+        app.toggle_widget("notes");
+        let distinct: std::collections::HashSet<*const u8> = app
+            .slots
+            .iter()
+            .map(|slot| std::ptr::from_ref(&*slot.panel).cast::<u8>())
+            .collect();
+        assert_eq!(distinct.len(), app.slots.len(), "a panel was reused twice");
     }
 
     #[test]


### PR DESCRIPTION
Fixes the bug the demo recording caught.

## The bug

Start the pomodoro, open the picker, toggle the **network** panel off and on — the timer is back at `25:00`. `rebuild_panels` threw every panel away and remade them whenever the layout changed, so switching one widget discarded the state of all the others. The weather and stocks panels lost their readings the same way and spent a fetch cycle showing "loading" after any toggle.

The old doc comment argued the trade explicitly: remaking everything "costs a fresh weather fetch and an empty CPU history", against machinery it judged not worth it. **That weighed a cache refill.** A running timer is not a cache — it is the user's state, and nothing about switching the network panel off says to throw it away.

## The fix

Panels are matched to layout entries by widget name and moved across.

Nothing stops a hand-written config placing the same widget twice — `Config::validate` checks that names are *known*, not that they are unique — so survivors are consumed from a **pool** rather than looked up by name. A lookup would hand the same panel to both entries.

Two orderings are load-bearing:

1. Every genuinely new panel is built **before** any existing one is disturbed, so a layout that will not build leaves the running dashboard exactly as it was. Already true; preserved.
2. Panels are shut down only once the new arrangement is settled, and only the ones actually leaving. Dropping them without `shutdown` discards the task store's save-on-shutdown and leaks the fetch threads.

**Focus now follows its panel rather than its index.** Removing a panel to the left of the focused one shifts every later index down, so clamping the old index moved the highlight onto a different panel — the sort of thing noticed only when the next keypress goes somewhere unexpected.

## Testing

By **pointer identity**, not rendered output. The same allocation before and after is the only thing that proves state survived; comparing a figure on screen would pass for a panel that had been rebuilt and happened to look the same.

Both tests were run against the old implementation and fail there:

```
assertion failed: the surviving panels were rebuilt
assertion failed: focus jumped to another panel
  left: "pomodoro"
 right: "todo"
```

The focus test needed strengthening to get there — with three panels, clamping lands on the right one **by coincidence**, so it uses four. Worth flagging: my first version of it passed against the buggy code.

A third test covers the duplicate-widget case. That one guards the new pool logic rather than demonstrating the old bug, since the old code built a fresh panel per entry and could not have shared one.

## Verified live

The way the bug was found — timer started, network toggled off and on:

```
=== timer started ===                     ┤focus├   24:56
=== after toggling network off and on === ┤focus├   24:47
=== weather / prices reloading? ===       0
```

It ran straight through.

440 tests; all gates green. The notes in `CLAUDE.md` and `docs/record-demo.sh` that told the next person to order the demo around this are updated — that ordering is taste now, not a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)