### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.1] - 2026-07-26
 
 ### Fixed
 
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a fetch cycle. Panels that are still placed are now carried across untouched.
   Keyboard focus follows its panel to wherever the new layout puts it, instead
   of staying on an index that may now be a different panel.
+
+### Added
+
+- A [demo recording](https://github.com/jchultarsky/mirador#readme) in the
+  README, and `docs/record-demo.sh` that regenerates it from a real build.
 
 ## [0.5.0] - 2026-07-26
 
@@ -566,7 +571,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.5.0...HEAD
+[0.5.1]: https://github.com/jchultarsky/mirador/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jchultarsky/mirador/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jchultarsky/mirador/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/jchultarsky/mirador/compare/v0.3.0...v0.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,7 +444,7 @@ open work is how the list stops being read.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.5.0` is released**, on crates.io and as a GitHub release with binaries
+- **`0.5.1` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
One bug fix since 0.5.0, plus the demo recording.

## Why a patch

Toggling a panel in the picker no longer disturbs the others — a running pomodoro keeps running, the weather and market panels keep their readings, and focus follows its panel rather than its index.

No config that loaded under 0.5.0 stops loading, nothing is removed, and there is no new behaviour to opt into. The dashboard simply stops throwing away state it had no reason to. That is the patch position.

The other two commits since v0.5.0 are documentation: the demo GIF (excluded from the published crate) and a note recording that build attestations verify.

## Verified before pushing

- `dist plan --tag=v0.5.1` announces `v0.5.1` and plans all four targets, both installers, the updaters, checksums and `sha256.sum`
- `cargo publish --locked --dry-run` packages 51 files
- 440 tests, fmt, clippy, docs all green

Tag and `cargo publish` follow once this merges, in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)