### PR TITLE
Show the recording only; two captures of the same screen was one too many

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,15 +430,22 @@ open work is how the list stops being read.
     weather and stocks panels spent a fetch cycle showing "loading" afterwards.
     `rebuild_panels` carries panels across now, so neither happens.
 
-- **The README's images float; its prose does not.** `docs/screenshot.png` is
+- **The README's images float; its prose does not.** `docs/demo.gif` is
   referenced by absolute `raw.githubusercontent.com/.../main/...` URL, because
-  `Cargo.toml` excludes `/docs` and `*.png` and a relative path would render on
-  GitHub and 404 on crates.io. The consequence is easy to miss: replacing the
-  capture updates it on *every* published version at once, while the caption
-  and alt text around it stay frozen at whatever each release baked in. 0.3.0
-  spent an hour showing the pomodoro panel above a caption explaining that the
-  shot predated it. A caption that describes the picture has to ship in the
-  same release as the picture.
+  `Cargo.toml` excludes `/docs`, `*.gif` and `*.png`, and a relative path would
+  render on GitHub and 404 on crates.io. The consequence is easy to miss:
+  replacing the capture updates it on *every* published version at once, while
+  the caption and alt text around it stay frozen at whatever each release baked
+  in. 0.3.0 spent an hour showing the pomodoro panel above a caption explaining
+  that the shot predated it. A caption that describes the picture has to ship in
+  the same release as the picture.
+
+  **`docs/screenshot.png` is no longer in the README and must not be deleted.**
+  0.1.0 through 0.5.1 all shipped a README pointing at that URL, and those
+  READMEs are frozen on crates.io. Removing the file would break the image on
+  six published pages that nobody can edit. It costs nothing to keep — `/docs`
+  never reaches the crate — so it stays as an asset the past still needs. The
+  same will be true of `demo.gif` the day something replaces it.
 
 - Originally built in a Linux container, where `sysinfo`'s macOS CPU and network
   paths went unexercised. Both have since been run on macOS against a real

--- a/README.md
+++ b/README.md
@@ -16,22 +16,20 @@ nothing shimmers, and nothing is designed to pull you back to it.
 
 A *mirador* is a lookout — the tower you climb to see everything at once.
 
-![The mirador dashboard: a block-numeral clock, four months of calendar, weather with an hourly forecast, the task list and notes, a running pomodoro timer, and a market watchlist beside live CPU and network graphs](https://raw.githubusercontent.com/jchultarsky/mirador/main/docs/screenshot.png)
+![All nine mirador panels on a wide terminal, in use: a block-numeral clock, four months of calendar, weather with an hourly forecast, the task list and notes, a pomodoro timer, and a market watchlist beside live CPU and network graphs. Focus moves between panels, a task is typed in and added to the list, the panel picker switches a panel off and the grid reflows around it, the help overlay opens and scrolls, and the pomodoro timer starts counting down](https://raw.githubusercontent.com/jchultarsky/mirador/main/docs/demo.gif)
 
-*All nine panels on a wide terminal, on a first run — the tasks and the note
-are the examples mirador seeds for you. The pomodoro panel has focus, which is
-why its frame is lit and its key hints are in its bottom border; every other
-panel is dimmed. Every screen in this README is a real capture, not a mock-up.*
-
-![A recording of mirador in use: focus moves between panels, a task is typed in and added to the list, the panel picker switches a panel off and the grid reflows around it, the help overlay opens and scrolls, and a pomodoro timer starts counting down](https://raw.githubusercontent.com/jchultarsky/mirador/main/docs/demo.gif)
+*All nine panels on a wide terminal, on a first run — the tasks and the note are
+the examples mirador seeds for you. The lit frame is the focused panel, with its
+own keys in its bottom border; every other panel is dimmed, so exactly one thing
+is at full brightness.*
 
 *Thirty seconds of it in use, at 150x42. Focus moves with `Tab`; a task is typed
 in and lands in the list, which goes from four open to five. `w` opens the panel
 picker, switches one off, and the grid closes over the gap; `?` lists every
 binding for the focused panel and scrolls when there are more than fit. The
 weather, the prices and the graphs are whatever was true while it recorded —
-`docs/record-demo.sh` drives a real build under tmux and nothing in it is
-staged.*
+`docs/record-demo.sh` drives a real build under tmux, and nothing in this README
+is staged or a mock-up.*
 
 ## Why
 
@@ -427,7 +425,7 @@ changes, not merely because time passed.
 > These two panels are the one thing this README will not show you in a code
 > block. Braille is missing from several of the fonts GitHub falls back to, so
 > the glyphs render at a width the surrounding box characters do not share and
-> the panel tears itself apart. The screenshot at the top of this file shows
+> the panel tears itself apart. The recording at the top of this file shows
 > them as they actually look. It is a real terminal, which is the only place
 > the alignment is guaranteed.
 


### PR DESCRIPTION
The static screenshot and the GIF opened on the same dashboard, so the README made its first impression twice. The recording is the better of the two — it is the same screen *plus* what happens when you press something — so it keeps the slot.

Its caption absorbs the facts the screenshot's carried and the GIF's didn't: nine panels, a first run with the seeded tasks and note, and the lit-frame-versus-dimmed convention, which is otherwise hard to notice without being told.

## `docs/screenshot.png` stays on disk

Removing it from the README is not the same as deleting it, and deleting it would have been a mistake I nearly made.

**Every published version from 0.1.0 to 0.5.1 ships a README pointing at that URL**, and those READMEs are frozen on crates.io — six pages nobody can edit. The image is referenced absolutely (`raw.githubusercontent.com/.../main/...`) precisely because `Cargo.toml` excludes `/docs`, so deleting the file would break the image on all six.

It costs nothing to keep: `/docs` never reaches the crate, and the package is still 51 files. `CLAUDE.md` now records why it stays, next to the existing note about the images floating — along with the observation that the same will be true of `demo.gif` the day something replaces it.

## Also

Fixed the one line of prose that pointed at "the screenshot at the top of this file" — the paragraph explaining why the braille CPU and network graphs aren't shown in a code block. Exactly the sort of reference that rots silently when an image moves.

440 tests; `cargo publish --dry-run` unchanged at 51 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)