### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-07-27
+
+Documentation only; no code changed since 0.5.1.
+
+### Changed
+
+- The README opens on the demo recording alone. It previously showed a static
+  screenshot of the same dashboard immediately above it, which made the same
+  first impression twice; the recording is that screen plus what happens when
+  you press something.
+
 ## [0.5.1] - 2026-07-26
 
 ### Fixed
@@ -571,6 +582,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
+[0.5.2]: https://github.com/jchultarsky/mirador/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jchultarsky/mirador/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jchultarsky/mirador/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jchultarsky/mirador/compare/v0.3.1...v0.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,7 +451,7 @@ open work is how the list stops being read.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.5.1` is released**, on crates.io and as a GitHub release with binaries
+- **`0.5.2` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
**Documentation only — no code changed since 0.5.1.**

The single change is the README opening on the demo recording alone, rather than on a static screenshot of the same dashboard followed by a recording of it.

## Why cut a release for a README

The README is packaged (`readme = "README.md"`), and crates.io renders the copy that shipped with each version. So the 0.5.1 page keeps showing both images until something newer replaces it. Publishing is the only way that page changes.

Thin, but real. Flagging it plainly so the version number is not mistaken for a behaviour change: `mirador 0.5.2` and `mirador 0.5.1` are the same program.

## Verified

- `dist plan --tag=v0.5.2` announces `v0.5.2` and plans all four targets, both installers, the updaters, checksums and `sha256.sum`
- `cargo publish --locked --dry-run` packages 51 files
- 440 tests, fmt, clippy, docs all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)