### PR TITLE
Sample the CPU and network every two seconds by default, not every one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`[cpu].sample_secs` and `[network].sample_secs` now default to 2.** Since
+  the redraw follows visible change, every sample is a new number and every new
+  number costs a repaint, so these two panels set the floor on what an idle
+  dashboard does. Measured at 400x100 on the default layout, redraws per idle
+  minute:
+
+  |                        | `sample_secs = 1` | `= 2` |
+  | ---                    | ---               | ---   |
+  | `show_seconds = true`  | 95                | 81    |
+  | `show_seconds = false` | 66                | 36    |
+
+  The second row is the change. The first is what the clock costs: with seconds
+  on it asks for a repaint every second and swamps the rest, which is worth
+  knowing before blaming the graphs.
+
+  The charts now cover twice the wall-clock time for the same buffer, and the
+  span beside the figure says so. The cost is a two-second average, so a brief
+  spike reads slightly lower — set it back to 1 if you would rather watch
+  closely than leave it open all day.
+
+  **Only new installs are affected.** The config seeds on first run and mirador
+  never rewrites it, so an existing `config.toml` keeps whatever it already
+  says.
+
 ## [0.5.2] - 2026-07-27
 
 Documentation only; no code changed since 0.5.1.
@@ -153,7 +181,7 @@ before 0.1.0, `mirador --migrate-config` will update it.
 - **Layout changes are written back into your config**, reversing an earlier
   decision to keep them out of it. The rule was never really "do not write to
   the config" — it was "do not *reserialise* it", because a round trip through
-  `toml` discards every comment in the file, including the 159 mirador wrote to
+  `toml` discards every comment in the file, including the ones mirador wrote to
   explain its own options. `--migrate-config` had already established the
   alternative: edit the lines that need editing and leave the rest alone.
 
@@ -582,6 +610,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.5.2...HEAD
 [0.5.2]: https://github.com/jchultarsky/mirador/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jchultarsky/mirador/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jchultarsky/mirador/compare/v0.4.0...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 159 of them, including the ones mirador
+    trip through `toml` discards all 167 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -258,7 +258,13 @@ chime_command            = []
 # ---------------------------------------------------------------------------
 [cpu]
 history       = 120            # samples kept in the moving chart
-sample_secs   = 1
+sample_secs   = 2             # seconds between samples. Every sample is a new
+                              # number, and a new number means a repaint, so
+                              # this and [network] set the floor on what an idle
+                              # dashboard costs: 66 redraws a minute at 1, 36 at
+                              # 2, with the clock's seconds off. 1 watches more
+                              # closely; 2 covers twice the time in the same
+                              # chart.
 show_per_core = true
 warn_pct      = 70.0
 critical_pct  = 90.0
@@ -272,4 +278,6 @@ critical_pct  = 90.0
 [network]
 interfaces  = []
 history     = 120
-sample_secs = 1
+sample_secs = 2               # see the note under [cpu]. Sampling the
+                              # interface list is the more expensive of the
+                              # two by roughly fifteen times.

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -266,6 +266,32 @@ pub struct CpuConfig {
     /// Number of samples retained in the moving chart.
     pub history: usize,
     /// Seconds between samples.
+    ///
+    /// Two, not one. Since the redraw follows visible change rather than the
+    /// tick, a fresh sample is a new number and every new number costs a
+    /// repaint of the whole grid — so this panel and `network` set the floor on
+    /// what an idle dashboard does.
+    ///
+    /// Measured at 400x100 on the default layout, redraws per idle minute:
+    ///
+    /// ```text
+    ///                        sample_secs = 1    = 2
+    ///   show_seconds = true          95          81
+    ///   show_seconds = false         66          36
+    /// ```
+    ///
+    /// The second row is the change; the first is what the clock costs. With
+    /// seconds on, the clock alone asks for a repaint every second and swamps
+    /// this, which is worth knowing before attributing an idle dashboard's cost
+    /// to the graphs.
+    ///
+    /// It also buys a chart covering twice the wall-clock time for the same
+    /// buffer — the span beside the figure is computed from the live sample
+    /// count, so it says so.
+    ///
+    /// The cost is that the figure is a two-second average, so a brief spike
+    /// reads slightly lower. Set it to 1 if you would rather watch it closely
+    /// than leave it open all day; the floor is 1 either way.
     pub sample_secs: u64,
     /// Also draw a per-core breakdown when the panel is tall enough.
     pub show_per_core: bool,
@@ -279,7 +305,7 @@ impl Default for CpuConfig {
     fn default() -> Self {
         Self {
             history: 120,
-            sample_secs: 1,
+            sample_secs: 2,
             show_per_core: true,
             warn_pct: 70.0,
             critical_pct: 90.0,
@@ -295,7 +321,11 @@ pub struct NetworkConfig {
     pub interfaces: Vec<String>,
     /// Number of samples retained in the moving chart.
     pub history: usize,
-    /// Seconds between samples.
+    /// Seconds between samples. See [`CpuConfig::sample_secs`] for why it is 2.
+    ///
+    /// This one is also the more expensive of the pair: enumerating interfaces
+    /// costs the better part of a millisecond a sample on macOS, against 60
+    /// microseconds for reading CPU usage.
     pub sample_secs: u64,
 }
 
@@ -304,7 +334,7 @@ impl Default for NetworkConfig {
         Self {
             interfaces: Vec::new(),
             history: 120,
-            sample_secs: 1,
+            sample_secs: 2,
         }
     }
 }

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -481,15 +481,17 @@ units = "imperial"
     }
 
     /// The comment count is the whole justification for this module, and it is
-    /// quoted in two places that no compiler checks: `CLAUDE.md` invariant 16
-    /// and the 0.4.0 changelog entry. It had already drifted into "~145" in
-    /// both, and "two hundred" in a third citation since removed.
+    /// quoted in `CLAUDE.md` invariant 16, which no compiler checks. It had
+    /// already drifted into "~145" there, "two hundred" in this file's header,
+    /// and "159" in the 0.4.0 changelog entry — the last two citations have
+    /// since been removed rather than maintained, a changelog being a record of
+    /// what was true then rather than a place to keep a live number.
     ///
     /// A failure here is not a bug in the config. It means the number moved and
-    /// the citations have to move with it.
+    /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 159;
+        const CITED: usize = 167;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))
@@ -497,8 +499,7 @@ units = "imperial"
         assert_eq!(
             actual, CITED,
             "the default config now has {actual} comment lines. Update this \
-             constant, `CLAUDE.md` invariant 16 and the 0.4.0 changelog entry \
-             — they all quote {CITED}."
+             constant and `CLAUDE.md` invariant 16 — both quote {CITED}."
         );
     }
 }


### PR DESCRIPTION
Since the redraw follows visible change rather than the tick, every sample is a new number and every new number costs a repaint of the whole grid. These two panels therefore set the floor on what an idle dashboard does.

## Measured

400×100, default layout, redraws per idle minute:

|                        | `sample_secs = 1` | `= 2` |
| ---                    | ---               | ---   |
| `show_seconds = true`  | 95                | 81    |
| `show_seconds = false` | 66                | **36** |

The second row is the change.

**The first row is the part I had wrong when I proposed this.** I told you it would "roughly halve" the redraw rate. With the shipped default it takes off 15%, because the clock with seconds showing asks for a repaint every second and swamps everything else. Both rows are now in the doc comment, because "the graphs are what an idle dashboard costs" is only true once the clock is not.

## The other half of the trade

The charts now cover twice the wall-clock time for the same buffer — the span beside the figure is computed from the live sample count, so it reads `40s` after forty seconds rather than `20s`. Verified on a running build.

The cost is that the figure is a two-second average, so a brief spike reads slightly lower. Anyone who would rather watch closely than leave it open all day sets it back to 1.

## Scope

**Only new installs are affected.** The config seeds on first run and mirador never rewrites it, so an existing `config.toml` keeps whatever it already says.

Both places that have to agree are updated: `CpuConfig`/`NetworkConfig`, and the `include_str!`-baked `assets/default_config.toml`.

## A note on the drift guard

Adding those comment lines tripped `the_comment_count_the_docs_quote_is_the_one_in_the_file` — twice, since I edited the config again after the first fix. That is the guard working: it named exactly which citations to update.

One of them was the 0.4.0 changelog entry. That citation is now **removed** rather than maintained: a changelog records what was true then, and pinning a live number in one guarantees it drifts. The test message and its doc comment say so.

440 tests; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)