### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-07-27
 
 ### Changed
 
@@ -610,7 +610,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.5.2...HEAD
+[0.6.0]: https://github.com/jchultarsky/mirador/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/jchultarsky/mirador/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jchultarsky/mirador/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jchultarsky/mirador/compare/v0.4.0...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,7 +451,7 @@ open work is how the list stops being read.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.5.2` is released**, on crates.io and as a GitHub release with binaries
+- **`0.6.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ there are no backports. In practice that means whatever is on the
 
 | Version | Supported |
 | --- | --- |
-| 0.5.x | Yes |
-| < 0.5 | No — upgrade |
+| 0.6.x | Yes |
+| < 0.6 | No — upgrade |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
One change since 0.5.2: `[cpu].sample_secs` and `[network].sample_secs` default to `2` rather than `1`.

## Why a minor rather than a patch

Nothing is broken, and no config stops loading — an existing `config.toml` keeps whatever it says, because the config seeds on first run and mirador never rewrites it.

But a new install now samples at half the rate, and its charts cover twice the wall-clock time for the same buffer. A graph that reads differently is a behaviour change, not a fix. Pre-1.0, that is the minor position.

Measured, redraws per idle minute at 400×100:

|                        | `sample_secs = 1` | `= 2` |
| ---                    | ---               | ---   |
| `show_seconds = true`  | 95                | 81    |
| `show_seconds = false` | 66                | **36** |

## Verified

- `dist plan --tag=v0.6.0` announces `v0.6.0` and plans all four targets, both installers, the updaters, checksums and `sha256.sum`
- `cargo publish --locked --dry-run` packages 51 files
- 440 tests, fmt, clippy, docs all green
- `SECURITY.md` supported-version table moved to `0.6.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)