### PR TITLE
Add an agenda panel that reads a local .ics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **An agenda panel**, reading a local `.ics` file. The gap it fills was named
+  early and left open for a long time: tasks are self-paced and a meeting is
+  not, so a dashboard that could answer four questions and none of them was
+  "you are in a call in ten minutes" was missing the one with a deadline.
+
+  It is deliberately offline. mirador does not sign in to a calendar server —
+  that means an account, a token to refresh, and a background process holding
+  your credentials. Point `[agenda].file` at a calendar you already have and
+  keep it current however you like; it is re-read on a timer and on `r`.
+
+  Recurring events are expanded for the rules people actually have — daily,
+  weekly with `BYDAY`, monthly, yearly, with `INTERVAL`, `COUNT`, `UNTIL` and
+  `EXDATE`. Anything more elaborate shows only its first occurrence rather than
+  guessing: a calendar that invents a meeting costs a wasted trip, where one
+  that misses a repeat costs a glance at the real thing.
+
+  Parsed in-tree with `jiff`, which mirador already has. `icalendar` and `rrule`
+  would have added 30 crates and **2.3 MB** to a 3.4 MB binary — measured — most
+  of it `chrono-tz` carrying a second timezone database.
+
+  **The default layout now places ten panels**, so the last of them has no
+  number to jump to; `1`–`9` covers the rest and `Tab` reaches everything.
+
 ## [0.6.0] - 2026-07-27
 
 ### Changed
@@ -610,6 +637,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/jchultarsky/mirador/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/jchultarsky/mirador/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jchultarsky/mirador/compare/v0.5.0...v0.5.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,9 @@ selection.rs list cursor movement and click-to-row
 textfield.rs single-line text editor used by task entry
 textarea.rs  multi-line text editor used by note bodies
 dateinput.rs due-date entry
-widgets/     clocks, weather, todo, notes, stocks, calendar, pomodoro, cpu,
-             network
+ical.rs      enough RFC 5545 to answer "what is next"; no new dependencies
+widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
+             pomodoro, cpu, network
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -197,7 +198,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 167 of them, including the ones mirador
+    trip through `toml` discards all 193 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -395,9 +396,12 @@ open work is how the list stops being read.
    rather than a persistence one.
 2. **Named themes**, per the section above. The `[theme]` table is built; the
    `theme = "nord"` layer over it is not.
-3. **Calendar reading a local `.ics`.** The shipped `calendar` widget is a date
-   grid only, deliberately offline; events are a separate and much larger panel.
-4. **"What changed since I last looked" markers.**
+3. **"What changed since I last looked" markers.**
+4. **A single "is anything on fire" signal.** Named as a gap alongside the other
+   two and then quietly dropped from this list; it is back.
+
+The `.ics` agenda that sat at the top of this list is built — `ical.rs` and
+`widgets/agenda.rs`.
 
 ## Housekeeping
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ and leaves a backup beside the original.
 
 ## The panels
 
-Nine widgets, each answering one question. Put the ones you want in the
+Ten widgets, each answering one question. Put the ones you want in the
 layout and drop the rest — an unused widget costs nothing but is also not
 built.
 
@@ -364,6 +364,47 @@ A watchlist with the last price, the day's change, and an intraday sparkline.
 `a` adds a symbol and `d` removes one, and those edits stick — the watchlist
 is a data file rather than config, which is what lets the panel own it. See
 [Market data](#market-data) before filing a bug about HTTP 429.
+
+### Agenda
+
+What is actually next, read from an `.ics` file on your disk.
+
+```
+╭┤5 Agenda├──────────────────────────────┤2 today├╮
+│ TODAY                                           │
+│   09:15  Standup  ·  Zoom                       │
+│ ▸ 14:00  Quarterly planning  ·  Room 12         │
+│ TOMORROW                                        │
+│   all day Public holiday                        │
+│ THURSDAY 30 Jul                                 │
+│   09:00  Call with London                       │
+╰─────────────────── r reload ────────────────────╯
+```
+
+The `▸` marks an event happening now. Days are headed `TODAY` and `TOMORROW`
+where that is clearer than a date, and an event you are already in stays on
+screen until it ends — the meeting you are late for is the one you most want to
+see.
+
+**mirador does not sign in to anything.** No account, no token to refresh, no
+background process holding your credentials. Point `[agenda].file` at a calendar
+you already have; whatever keeps that file current is your business — an export,
+a `vdirsyncer` run, a cron job with `curl`, a symlink into a synced folder. It
+is re-read on a timer and when you press `r`.
+
+Until you set `file`, the panel says so and names the path it looked at. Nothing
+creates that file: unlike the task list, an empty calendar mirador invented
+would be a lie about your day.
+
+Recurring events are expanded for the rules people actually have — daily, weekly
+with `BYDAY`, monthly and yearly, with `INTERVAL`, `COUNT`, `UNTIL` and
+`EXDATE`. A rule using anything more elaborate, such as `BYSETPOS` or an ordinal
+`BYDAY` like `1MO`, shows **only its first occurrence** rather than guessing.
+That is deliberate: a calendar that invents a meeting costs you a wasted trip,
+where one that misses a repeat costs you a glance at the real thing.
+
+An entry the parser cannot read is counted at the bottom of the panel rather
+than dropped silently, so a half-read calendar does not just look empty.
 
 ### Pomodoro
 
@@ -513,6 +554,7 @@ rows = [
 | `notes` | Free-form notes: a list of titles and dates above the note you are reading |
 | `stocks` | A watchlist: last price, the day's change, and an intraday sparkline |
 | `calendar` | Month grids in the shape `cal` prints, with today marked |
+| `agenda` | What is next, from a local `.ics` file |
 | `pomodoro` | A focus timer: phase, time left, progress, and the set so far |
 | `cpu` | Average utilisation, a moving chart, and per-core meters |
 | `network` | Receive and transmit rates as moving charts |

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -47,12 +47,15 @@ rows = [
     { widget = "weather",  width = 40 },
   ] },
   { height = 42, panels = [
-    { widget = "todo",     width = 48 },
-    { widget = "notes",    width = 30 },
+    { widget = "todo",     width = 36 },
+    # What is next, from [agenda].file. Shows how to point it at your .ics
+    # until you do.
+    { widget = "agenda",   width = 28 },
+    { widget = "notes",    width = 22 },
     # The timer draws block numerals when it has the width for them and falls
     # back to plain text when it does not, so a narrow terminal loses the
     # spectacle rather than the time.
-    { widget = "pomodoro", width = 22 },
+    { widget = "pomodoro", width = 14 },
   ] },
   { height = 24, panels = [
     { widget = "stocks",  width = 40 },
@@ -218,6 +221,35 @@ show_sparkline = true
 [calendar]
 months      = 2          # months across; more stack when there is height
 week_starts = "sunday"   # sunday | monday
+
+# ---------------------------------------------------------------------------
+# Agenda
+#
+# What is next, read from an .ics file on your disk. mirador does not sign in
+# to a calendar server and is not going to: that means an account, a token to
+# refresh, and a background process with opinions about your credentials.
+#
+# Point `file` at a calendar you already have. Whatever keeps it up to date is
+# your business — an export, a vdirsyncer run, a cron job with curl, a symlink
+# into a folder something else syncs. The file is re-read on a timer and when
+# you press `r`, so anything that rewrites it shows up on its own.
+#
+# Until `file` is set the panel says so and names the path it looked at, which
+# is `calendar.ics` beside your tasks and notes. Nothing creates that file:
+# unlike the task list, an empty calendar mirador invented would be a lie
+# about your day.
+#
+# Recurring events are expanded for the common rules — daily, weekly with
+# BYDAY, monthly and yearly, with INTERVAL, COUNT, UNTIL and EXDATE. A rule
+# using anything more elaborate shows only its first occurrence rather than
+# guessing, because a calendar that invents a meeting is worse than one that
+# misses a repeat.
+# ---------------------------------------------------------------------------
+[agenda]
+# file        = "~/calendar.ics"
+days          = 7        # how far ahead to look
+show_location = true     # show the location when the row has room for both
+refresh_secs  = 60       # how often to re-read the file
 
 # ---------------------------------------------------------------------------
 # Pomodoro

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -38,7 +38,15 @@ impl Default for Layout {
         Self {
             rows: vec![
                 row(34, &[("clocks", 26), ("calendar", 34), ("weather", 40)]),
-                row(42, &[("todo", 48), ("notes", 30), ("pomodoro", 22)]),
+                row(
+                    42,
+                    &[
+                        ("todo", 36),
+                        ("agenda", 28),
+                        ("notes", 22),
+                        ("pomodoro", 14),
+                    ],
+                ),
                 row(24, &[("stocks", 40), ("cpu", 30), ("network", 30)]),
             ],
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,8 +45,8 @@ mod widgets;
 pub use layout::{Layout, LayoutPanel, LayoutRow};
 #[allow(unused_imports)]
 pub use widgets::{
-    CalendarConfig, ClockZone, ClocksConfig, CpuConfig, NetworkConfig, NotesConfig, PomodoroConfig,
-    StocksConfig, TodoConfig, WeatherConfig,
+    AgendaConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig, NetworkConfig, NotesConfig,
+    PomodoroConfig, StocksConfig, TodoConfig, WeatherConfig,
 };
 
 /// Top-level configuration.
@@ -61,6 +61,7 @@ pub struct Config {
     pub todo: TodoConfig,
     pub notes: NotesConfig,
     pub stocks: StocksConfig,
+    pub agenda: AgendaConfig,
     pub calendar: CalendarConfig,
     pub pomodoro: PomodoroConfig,
     pub cpu: CpuConfig,
@@ -237,6 +238,19 @@ impl Config {
         match &self.notes.file {
             Some(p) => Ok(expand_tilde(p)),
             None => Ok(Self::default_data_dir()?.join("notes.toml")),
+        }
+    }
+
+    /// Resolve the agenda's `.ics` path, expanding a leading `~`.
+    ///
+    /// Falls back to `calendar.ics` beside the task and note files. Nothing
+    /// creates it — unlike those two, an empty calendar seeded by mirador would
+    /// be a lie about your day. The panel says which path it looked at, so an
+    /// unset `file` reads as a thing to configure rather than as a fault.
+    pub fn agenda_path(&self) -> Result<PathBuf> {
+        match &self.agenda.file {
+            Some(p) => Ok(expand_tilde(p)),
+            None => Ok(Self::default_data_dir()?.join("calendar.ics")),
         }
     }
 

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -192,6 +192,38 @@ impl Default for NotesConfig {
     }
 }
 
+/// Agenda settings: what is next, from a local `.ics` file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgendaConfig {
+    /// The `.ics` file to read. `~` is expanded.
+    ///
+    /// No default that guesses at a path. An agenda pointing somewhere the user
+    /// did not choose is either empty, which looks broken, or somebody else's.
+    pub file: Option<PathBuf>,
+    /// How many days ahead to show. A floor on the window rather than a cap on
+    /// the panel — a taller panel simply scrolls less.
+    pub days: u16,
+    /// Show a location beside the summary, when the row has room for both.
+    pub show_location: bool,
+    /// Seconds between re-reads of the file.
+    pub refresh_secs: u64,
+}
+
+impl Default for AgendaConfig {
+    fn default() -> Self {
+        Self {
+            file: None,
+            days: 7,
+            show_location: true,
+            // A local file, so this can be brisk: an export refreshed by cron
+            // should appear without the user pressing anything, and a minute is
+            // the granularity a calendar changes at anyway.
+            refresh_secs: 60,
+        }
+    }
+}
+
 /// Calendar settings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]

--- a/src/ical.rs
+++ b/src/ical.rs
@@ -1,0 +1,995 @@
+//! Reading events out of a local `.ics` file.
+//!
+//! Enough of RFC 5545 to answer "what is next", and no more. mirador does not
+//! talk to a calendar server — the agenda panel reads a file you already have,
+//! whatever put it there.
+//!
+//! # Why this is hand-written
+//!
+//! `icalendar` and `rrule` are good crates, and between them they would add 30
+//! transitive dependencies and **2.3 MB** to a 3.4 MB binary — measured, not
+//! guessed. Most of that is `chrono-tz` carrying a timezone database, which is
+//! the part that decides it: mirador already has one, because `jiff` ships it,
+//! and shipping two in a prebuilt binary for four platforms to read a text file
+//! is not a trade this project makes. It is the same reasoning that keeps the
+//! pomodoro chime on the terminal bell instead of an audio stack.
+//!
+//! # What is supported
+//!
+//! `VEVENT` with `SUMMARY`, `LOCATION`, `DTSTART`, and `DTEND` or `DURATION`.
+//! Times in all three forms the wild produces: a floating local time, a UTC
+//! time ending in `Z`, and a zoned time with `TZID`. All-day events via
+//! `VALUE=DATE`. Line folding and the `\n \, \; \\` escapes.
+//!
+//! Recurrence is a **documented subset** — see [`Recurrence::expand`]. A rule
+//! using anything outside it yields only the event's own start, because a
+//! calendar that invents a meeting is worse than one that misses it.
+
+use std::collections::BTreeSet;
+
+use jiff::civil::{Date, DateTime, Time, Weekday};
+use jiff::tz::TimeZone;
+use jiff::{Span, Timestamp, Zoned};
+
+/// One occurrence of an event, resolved to the local timezone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Event {
+    pub summary: String,
+    pub location: Option<String>,
+    pub start: Zoned,
+    /// When it ends. `None` for an event with no end and no duration, which
+    /// RFC 5545 says lasts an instant (or, for an all-day event, the day).
+    pub end: Option<Zoned>,
+    /// Drawn without a time, and sorted before timed events on the same day.
+    pub all_day: bool,
+}
+
+impl Event {
+    /// Whether `now` falls inside this event.
+    pub fn contains(&self, now: &Zoned) -> bool {
+        if *now < self.start {
+            return false;
+        }
+        match &self.end {
+            Some(end) => now < end,
+            None => false,
+        }
+    }
+}
+
+/// A parsed calendar: the events, and anything that could not be read.
+#[derive(Debug, Default)]
+pub struct Calendar {
+    pub events: Vec<Event>,
+    /// Events that parsed far enough to be counted but not to be shown, with
+    /// the reason. Surfaced rather than swallowed: a calendar quietly missing
+    /// half its entries is worse than one that says it could not read them.
+    pub skipped: Vec<String>,
+}
+
+/// Parse `text` and expand recurrences into `[from, until]`.
+///
+/// The window is required rather than optional because an unbounded `RRULE` has
+/// infinitely many occurrences, and the panel only ever draws a few days.
+pub fn parse(text: &str, tz: &TimeZone, from: &Zoned, until: &Zoned) -> Calendar {
+    let mut calendar = Calendar::default();
+
+    for block in vevents(&unfold(text)) {
+        match event_from(&block, tz) {
+            Ok(Some((event, recurrence, exceptions))) => {
+                calendar
+                    .events
+                    .extend(recurrence.expand(&event, &exceptions, from, until));
+            }
+            // A VEVENT with no DTSTART is not an event; the spec requires one.
+            Ok(None) => {}
+            Err(why) => calendar.skipped.push(why),
+        }
+    }
+
+    calendar.events.sort_by(|a, b| {
+        a.start
+            .cmp(&b.start)
+            .then_with(|| a.summary.cmp(&b.summary))
+    });
+    calendar
+}
+
+/// Undo RFC 5545 line folding.
+///
+/// A long line is split with CRLF followed by a space or tab, and the
+/// continuation begins at the character *after* that whitespace. Getting this
+/// wrong does not fail loudly — it silently truncates every long summary at
+/// roughly 75 characters, which looks like the calendar's fault.
+fn unfold(text: &str) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for raw in text.split('\n') {
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        match line.strip_prefix([' ', '\t']) {
+            Some(rest) if !lines.is_empty() => {
+                if let Some(last) = lines.last_mut() {
+                    last.push_str(rest);
+                }
+            }
+            _ => lines.push(line.to_string()),
+        }
+    }
+    lines
+}
+
+/// Split the unfolded lines into `VEVENT` blocks.
+///
+/// Nested components — a `VALARM` inside a `VEVENT`, most often — are dropped,
+/// because a reminder's `TRIGGER` is not the event's start and confusing the
+/// two would put every event on screen at the wrong time.
+fn vevents(lines: &[String]) -> Vec<Vec<&str>> {
+    let mut blocks = Vec::new();
+    let mut current: Option<Vec<&str>> = None;
+    let mut nested = 0usize;
+
+    for line in lines {
+        let line = line.as_str();
+        if line.eq_ignore_ascii_case("BEGIN:VEVENT") {
+            current = Some(Vec::new());
+            nested = 0;
+            continue;
+        }
+        let Some(block) = current.as_mut() else {
+            continue;
+        };
+        if line.eq_ignore_ascii_case("END:VEVENT") {
+            blocks.push(std::mem::take(block));
+            current = None;
+            continue;
+        }
+        if line.len() > 6 && line[..6].eq_ignore_ascii_case("BEGIN:") {
+            nested += 1;
+        } else if line.len() > 4 && line[..4].eq_ignore_ascii_case("END:") {
+            nested = nested.saturating_sub(1);
+        } else if nested == 0 {
+            block.push(line);
+        }
+    }
+    blocks
+}
+
+/// One `NAME;PARAM=VALUE:VALUE` line.
+struct Property<'a> {
+    name: &'a str,
+    params: Vec<(&'a str, &'a str)>,
+    value: &'a str,
+}
+
+impl<'a> Property<'a> {
+    /// Split a content line.
+    ///
+    /// The colon that ends the name-and-parameters section is the first one
+    /// *outside* a quoted string: a parameter may legitimately contain one, as
+    /// in `TZID="GMT+01:00"`, and splitting on the first colon puts half the
+    /// timezone into the value.
+    fn parse(line: &'a str) -> Option<Self> {
+        let mut quoted = false;
+        let mut split = None;
+        for (index, ch) in line.char_indices() {
+            match ch {
+                '"' => quoted = !quoted,
+                ':' if !quoted => {
+                    split = Some(index);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let split = split?;
+        let (head, value) = line.split_at(split);
+        let value = &value[1..];
+
+        let mut parts = head.split(';');
+        let name = parts.next()?;
+        let params = parts
+            .filter_map(|p| {
+                let (k, v) = p.split_once('=')?;
+                Some((k, v.trim_matches('"')))
+            })
+            .collect();
+        Some(Self {
+            name,
+            params,
+            value,
+        })
+    }
+
+    fn param(&self, key: &str) -> Option<&'a str> {
+        self.params
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| *v)
+    }
+}
+
+/// Turn a `VEVENT` block into an event, its recurrence rule and its exceptions.
+///
+/// `Ok(None)` means the block had no `DTSTART`, which RFC 5545 requires — such
+/// a block is not an event and is not worth reporting as a failure.
+type Parsed = (Event, Recurrence, Vec<Timestamp>);
+
+fn event_from(block: &[&str], tz: &TimeZone) -> Result<Option<Parsed>, String> {
+    let mut summary = None;
+    let mut location = None;
+    let mut start: Option<(Zoned, bool)> = None;
+    let mut end: Option<Zoned> = None;
+    let mut duration: Option<Span> = None;
+    let mut rule = Recurrence::Once;
+    let mut exceptions = Vec::new();
+
+    for line in block {
+        let Some(property) = Property::parse(line) else {
+            continue;
+        };
+        match property.name.to_ascii_uppercase().as_str() {
+            "SUMMARY" => summary = Some(unescape(property.value)),
+            "LOCATION" => location = Some(unescape(property.value)),
+            "DTSTART" => start = Some(moment(&property, tz)?),
+            "DTEND" => end = Some(moment(&property, tz)?.0),
+            "DURATION" => duration = parse_duration(property.value),
+            "RRULE" => rule = Recurrence::parse(property.value),
+            "EXDATE" => {
+                for one in property.value.split(',') {
+                    let single = Property {
+                        name: "EXDATE",
+                        params: property.params.clone(),
+                        value: one,
+                    };
+                    if let Ok((moment, _)) = moment(&single, tz) {
+                        exceptions.push(moment.timestamp());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let Some((start, all_day)) = start else {
+        return Ok(None);
+    };
+
+    let end = end.or_else(|| {
+        duration
+            .and_then(|span| start.checked_add(span).ok())
+            // An all-day event with neither DTEND nor DURATION covers its day.
+            .or_else(|| all_day.then(|| start.tomorrow()).and_then(Result::ok))
+    });
+
+    Ok(Some((
+        Event {
+            // An event with no SUMMARY is legal and does happen. A dash beats
+            // an empty row, which reads as a broken panel.
+            summary: summary.unwrap_or_else(|| "–".to_string()),
+            location: location.filter(|l| !l.trim().is_empty()),
+            start,
+            end,
+            all_day,
+        },
+        rule,
+        exceptions,
+    )))
+}
+
+/// Resolve a `DTSTART`-shaped property to a moment, and whether it is all-day.
+fn moment(property: &Property<'_>, tz: &TimeZone) -> Result<(Zoned, bool), String> {
+    let value = property.value.trim();
+
+    if property
+        .param("VALUE")
+        .is_some_and(|v| v.eq_ignore_ascii_case("DATE"))
+        || (value.len() == 8 && !value.contains('T'))
+    {
+        let day = parse_date(value).ok_or_else(|| format!("unreadable date `{value}`"))?;
+        let zoned = day
+            .to_datetime(Time::midnight())
+            .to_zoned(tz.clone())
+            .map_err(|e| format!("`{value}`: {e}"))?;
+        return Ok((zoned, true));
+    }
+
+    let civil = parse_datetime(value).ok_or_else(|| format!("unreadable time `{value}`"))?;
+
+    // A trailing `Z` means UTC, and beats any TZID — a line carrying both is
+    // malformed, and the `Z` is the one with a single meaning.
+    if value.ends_with('Z') {
+        let stamp: Timestamp = civil
+            .to_zoned(TimeZone::UTC)
+            .map_err(|e| format!("`{value}`: {e}"))?
+            .timestamp();
+        return Ok((stamp.to_zoned(tz.clone()), false));
+    }
+
+    // A named zone, if we recognise it. An unknown TZID falls back to local
+    // rather than failing: the wrong offset is bad, but dropping the event
+    // entirely is worse, and most unknown names are Windows-style aliases for
+    // roughly the right place.
+    let zone = property
+        .param("TZID")
+        .and_then(|name| TimeZone::get(name).ok())
+        .unwrap_or_else(|| tz.clone());
+
+    let zoned = civil
+        .to_zoned(zone)
+        .map_err(|e| format!("`{value}`: {e}"))?
+        .with_time_zone(tz.clone());
+    Ok((zoned, false))
+}
+
+fn parse_date(value: &str) -> Option<Date> {
+    if value.len() < 8 {
+        return None;
+    }
+    let year: i16 = value.get(0..4)?.parse().ok()?;
+    let month: i8 = value.get(4..6)?.parse().ok()?;
+    let day: i8 = value.get(6..8)?.parse().ok()?;
+    Date::new(year, month, day).ok()
+}
+
+fn parse_datetime(value: &str) -> Option<DateTime> {
+    let day = parse_date(value)?;
+    let rest = value.get(8..)?.strip_prefix('T')?;
+    let hour: i8 = rest.get(0..2)?.parse().ok()?;
+    let minute: i8 = rest.get(2..4)?.parse().ok()?;
+    let second: i8 = rest.get(4..6).unwrap_or("00").parse().ok()?;
+    // Leap seconds exist in the wild and jiff will not accept :60.
+    let second = second.min(59);
+    Some(day.at(hour, minute, second, 0))
+}
+
+/// Parse an RFC 5545 duration, e.g. `PT1H30M`, `P2D`, `-PT15M`.
+fn parse_duration(value: &str) -> Option<Span> {
+    let (negative, rest) = match value.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, value.strip_prefix('+').unwrap_or(value)),
+    };
+    let rest = rest.strip_prefix('P')?;
+
+    let mut span = Span::new();
+    let mut digits = String::new();
+    let mut in_time = false;
+    for ch in rest.chars() {
+        match ch {
+            'T' => in_time = true,
+            '0'..='9' => digits.push(ch),
+            unit => {
+                let n: i64 = digits.parse().ok()?;
+                digits.clear();
+                span = match (unit, in_time) {
+                    ('W', _) => span.try_weeks(n).ok()?,
+                    ('D', _) => span.try_days(n).ok()?,
+                    ('H', true) => span.try_hours(n).ok()?,
+                    ('M', true) => span.try_minutes(n).ok()?,
+                    ('S', true) => span.try_seconds(n).ok()?,
+                    _ => return None,
+                };
+            }
+        }
+    }
+    Some(if negative { -span } else { span })
+}
+
+/// Undo the four escapes RFC 5545 defines for TEXT values.
+fn unescape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        match chars.next() {
+            Some('n' | 'N') => out.push(' '),
+            Some(other) => out.push(other),
+            None => out.push('\\'),
+        }
+    }
+    out.trim().to_string()
+}
+
+/// How an event repeats.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Recurrence {
+    /// It does not.
+    Once,
+    Every {
+        freq: Freq,
+        interval: i32,
+        count: Option<u32>,
+        until: Option<Timestamp>,
+        /// Weekdays, for `FREQ=WEEKLY;BYDAY=MO,WE`. Empty means "the same
+        /// weekday as the start".
+        weekdays: Vec<Weekday>,
+    },
+    /// The rule used a part this parser does not implement. Only the event's
+    /// own start is produced — see the note on [`Recurrence::expand`].
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Freq {
+    Daily,
+    Weekly,
+    Monthly,
+    Yearly,
+}
+
+impl Recurrence {
+    /// Parse an `RRULE` value, or report that it is outside the subset.
+    ///
+    /// The parts handled are `FREQ`, `INTERVAL`, `COUNT`, `UNTIL` and — for
+    /// weekly rules — `BYDAY` without an ordinal prefix. `WKST` is accepted and
+    /// ignored, because it only matters for the parts we do not support.
+    ///
+    /// Anything else is [`Recurrence::Unsupported`]. That includes `BYSETPOS`,
+    /// `BYMONTHDAY`, `BYMONTH` and an ordinal `BYDAY` such as `1MO`, all of
+    /// which *narrow* the set of occurrences — so guessing without them would
+    /// put meetings on screen that are not happening.
+    fn parse(value: &str) -> Self {
+        let mut freq = None;
+        let mut interval = 1i32;
+        let mut count = None;
+        let mut until = None;
+        let mut weekdays = Vec::new();
+
+        for part in value.split(';') {
+            let Some((key, val)) = part.split_once('=') else {
+                continue;
+            };
+            match key.to_ascii_uppercase().as_str() {
+                "FREQ" => {
+                    freq = match val.to_ascii_uppercase().as_str() {
+                        "DAILY" => Some(Freq::Daily),
+                        "WEEKLY" => Some(Freq::Weekly),
+                        "MONTHLY" => Some(Freq::Monthly),
+                        "YEARLY" => Some(Freq::Yearly),
+                        // HOURLY, MINUTELY and SECONDLY exist and are not
+                        // things a dashboard should try to draw.
+                        _ => return Self::Unsupported,
+                    };
+                }
+                "INTERVAL" => match val.parse::<i32>() {
+                    Ok(n) if n >= 1 => interval = n,
+                    _ => return Self::Unsupported,
+                },
+                "COUNT" => match val.parse::<u32>() {
+                    Ok(n) => count = Some(n),
+                    Err(_) => return Self::Unsupported,
+                },
+                "UNTIL" => {
+                    let stamp = parse_datetime(val)
+                        .and_then(|dt| dt.to_zoned(TimeZone::UTC).ok())
+                        .map(|z| z.timestamp())
+                        .or_else(|| {
+                            parse_date(val)
+                                .and_then(|d| {
+                                    d.to_datetime(Time::midnight()).to_zoned(TimeZone::UTC).ok()
+                                })
+                                .map(|z| z.timestamp())
+                        });
+                    match stamp {
+                        Some(stamp) => until = Some(stamp),
+                        None => return Self::Unsupported,
+                    }
+                }
+                "BYDAY" => {
+                    for day in val.split(',') {
+                        // An ordinal prefix (`1MO`, `-1FR`) selects one week of
+                        // the month, which this does not implement.
+                        match weekday(day) {
+                            Some(w) => weekdays.push(w),
+                            None => return Self::Unsupported,
+                        }
+                    }
+                }
+                "WKST" => {}
+                _ => return Self::Unsupported,
+            }
+        }
+
+        match freq {
+            Some(freq) => Self::Every {
+                freq,
+                interval,
+                count,
+                until,
+                weekdays,
+            },
+            None => Self::Unsupported,
+        }
+    }
+
+    /// Every occurrence overlapping `[from, until]`.
+    ///
+    /// [`Recurrence::Unsupported`] yields only the event's own start. That is
+    /// the deliberate answer: an occurrence at `DTSTART` definitely happens,
+    /// and everything else the rule implies is a guess. A dashboard that
+    /// invents a meeting costs its reader a wasted trip; one that misses a
+    /// repeat costs them a glance at the real calendar.
+    fn expand(
+        &self,
+        event: &Event,
+        exceptions: &[Timestamp],
+        from: &Zoned,
+        until: &Zoned,
+    ) -> Vec<Event> {
+        let skip: BTreeSet<Timestamp> = exceptions.iter().copied().collect();
+        let length: Option<Span> = event
+            .end
+            .as_ref()
+            .map(|end| end.timestamp() - event.start.timestamp());
+
+        let occurrence = |start: Zoned| -> Option<Event> {
+            if skip.contains(&start.timestamp()) {
+                return None;
+            }
+            let end: Option<Zoned> = length.and_then(|span| start.checked_add(span).ok());
+            // Overlapping the window, not merely starting in it: a meeting that
+            // began before you looked is the one you most want to see.
+            let visible_until = end.as_ref().unwrap_or(&start);
+            if visible_until < from || &start > until {
+                return None;
+            }
+            Some(Event {
+                start,
+                end,
+                ..event.clone()
+            })
+        };
+
+        let Self::Every {
+            freq,
+            interval,
+            count,
+            until: rule_until,
+            weekdays,
+        } = self
+        else {
+            // `Once` and `Unsupported` agree here, for different reasons.
+            return occurrence(event.start.clone()).into_iter().collect();
+        };
+
+        let mut out = Vec::new();
+        let mut produced = 0u32;
+        let mut cursor = event.start.date();
+        let time = event.start.time();
+        let tz = event.start.time_zone().clone();
+
+        for _ in 0..MAX_STEPS {
+            if cursor > until.date() {
+                break;
+            }
+
+            // For a weekly rule with BYDAY, the cursor names a week and each
+            // listed weekday in it is an occurrence. Offsets are taken from
+            // Monday so the set is produced in calendar order regardless of
+            // which day the event started on.
+            let days: Vec<Date> = if *freq == Freq::Weekly && !weekdays.is_empty() {
+                let cursor_offset = i64::from(cursor.weekday().to_monday_zero_offset());
+                let mut days: Vec<Date> = weekdays
+                    .iter()
+                    .filter_map(|w| {
+                        let delta = i64::from(w.to_monday_zero_offset()) - cursor_offset;
+                        cursor.checked_add(Span::new().days(delta)).ok()
+                    })
+                    .collect();
+                days.sort_unstable();
+                days.dedup();
+                days
+            } else {
+                vec![cursor]
+            };
+
+            for day in days {
+                if day < event.start.date() {
+                    continue;
+                }
+                let Ok(start) = day.to_datetime(time).to_zoned(tz.clone()) else {
+                    continue;
+                };
+                if let Some(limit) = rule_until
+                    && start.timestamp() > *limit
+                {
+                    return out;
+                }
+                if let Some(limit) = count
+                    && produced >= *limit
+                {
+                    return out;
+                }
+                produced += 1;
+                if let Some(event) = occurrence(start) {
+                    out.push(event);
+                }
+            }
+
+            let step = Span::new();
+            let step = match freq {
+                Freq::Daily => step.days(i64::from(*interval)),
+                Freq::Weekly => step.weeks(i64::from(*interval)),
+                Freq::Monthly => step.months(i64::from(*interval)),
+                Freq::Yearly => step.years(i64::from(*interval)),
+            };
+            match cursor.checked_add(step) {
+                Ok(next) => cursor = next,
+                Err(_) => break,
+            }
+        }
+
+        out
+    }
+}
+
+/// Most steps a single rule may take while expanding.
+///
+/// Bounds a malformed rule with a tiny interval and no `COUNT` or `UNTIL`,
+/// which would otherwise spin for as long as the window is wide — on the
+/// reader thread, where nothing would notice.
+const MAX_STEPS: usize = 4_000;
+
+/// The two-letter weekday codes, without an ordinal prefix.
+fn weekday(code: &str) -> Option<Weekday> {
+    Some(match code.to_ascii_uppercase().as_str() {
+        "MO" => Weekday::Monday,
+        "TU" => Weekday::Tuesday,
+        "WE" => Weekday::Wednesday,
+        "TH" => Weekday::Thursday,
+        "FR" => Weekday::Friday,
+        "SA" => Weekday::Saturday,
+        "SU" => Weekday::Sunday,
+        _ => return None,
+    })
+}
+
+/// A date in the local zone, for callers building a window.
+pub fn local_midnight(day: Date, tz: &TimeZone) -> Option<Zoned> {
+    day.to_datetime(Time::midnight()).to_zoned(tz.clone()).ok()
+}
+
+/// Today, in `tz`.
+pub fn today(tz: &TimeZone) -> Date {
+    Timestamp::now().to_zoned(tz.clone()).date()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use jiff::civil::date;
+
+    fn tz() -> TimeZone {
+        TimeZone::get("America/New_York").expect("a zone every tzdb has")
+    }
+
+    fn window(from: (i16, i8, i8), to: (i16, i8, i8)) -> (Zoned, Zoned) {
+        let tz = tz();
+        (
+            local_midnight(date(from.0, from.1, from.2), &tz).unwrap(),
+            local_midnight(date(to.0, to.1, to.2), &tz).unwrap(),
+        )
+    }
+
+    fn wrap(body: &str) -> String {
+        format!("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n{body}\r\nEND:VCALENDAR\r\n")
+    }
+
+    fn parse_all(body: &str) -> Calendar {
+        let (from, to) = window((2026, 1, 1), (2030, 1, 1));
+        parse(&wrap(body), &tz(), &from, &to)
+    }
+
+    #[test]
+    fn a_folded_line_is_rejoined_at_the_character_after_the_space() {
+        // The failure mode is silent: every summary over ~75 characters gets
+        // truncated, and it looks like the calendar exported badly.
+        let lines = unfold("SUMMARY:Quarterly planning with\r\n  the platform team\r\nEND");
+        assert_eq!(
+            lines[0],
+            "SUMMARY:Quarterly planning with the platform team"
+        );
+        assert_eq!(lines[1], "END");
+
+        // A tab folds too, and the continuation keeps its own leading space.
+        let lines = unfold("A:one\r\n\ttwo");
+        assert_eq!(lines[0], "A:onetwo");
+    }
+
+    #[test]
+    fn a_leading_space_on_the_first_line_is_not_a_continuation() {
+        // There is nothing to continue, and treating it as one would panic or
+        // silently drop the line depending on how it is written.
+        let lines = unfold(" SUMMARY:odd");
+        assert_eq!(lines, vec![" SUMMARY:odd"]);
+    }
+
+    #[test]
+    fn a_quoted_parameter_may_contain_a_colon() {
+        let p = Property::parse(r#"DTSTART;TZID="GMT+01:00":20260801T140000"#).unwrap();
+        assert_eq!(p.name, "DTSTART");
+        assert_eq!(p.param("TZID"), Some("GMT+01:00"));
+        assert_eq!(p.value, "20260801T140000");
+    }
+
+    #[test]
+    fn the_three_time_forms_all_land_on_the_same_instant() {
+        // 14:00 New York on 1 August 2026 is 18:00 UTC. A calendar that gets
+        // this wrong shows every meeting at the wrong hour, which is the single
+        // worst thing this panel could do.
+        let utc =
+            parse_all("BEGIN:VEVENT\r\nDTSTART:20260801T180000Z\r\nSUMMARY:utc\r\nEND:VEVENT");
+        let zoned = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART;TZID=America/New_York:20260801T140000\r\nSUMMARY:zoned\r\nEND:VEVENT",
+        );
+        let floating =
+            parse_all("BEGIN:VEVENT\r\nDTSTART:20260801T140000\r\nSUMMARY:floating\r\nEND:VEVENT");
+
+        let at = |c: &Calendar| c.events[0].start.timestamp();
+        assert_eq!(at(&utc), at(&zoned), "Z and TZID disagree");
+        assert_eq!(at(&zoned), at(&floating), "floating is not local");
+        assert_eq!(utc.events[0].start.hour(), 14);
+    }
+
+    #[test]
+    fn a_zone_in_another_country_is_converted_rather_than_relabelled() {
+        let c = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART;TZID=Europe/London:20260801T180000\r\nSUMMARY:london\r\nEND:VEVENT",
+        );
+        // 18:00 London in August (BST, +1) is 13:00 New York.
+        assert_eq!(c.events[0].start.hour(), 13);
+    }
+
+    #[test]
+    fn an_unknown_timezone_falls_back_to_local_rather_than_dropping_the_event() {
+        // Windows exporters emit names no tzdb has. The wrong offset is bad;
+        // silently losing the meeting is worse.
+        let c = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART;TZID=Romance Standard Time:20260801T140000\r\nSUMMARY:x\r\nEND:VEVENT",
+        );
+        assert_eq!(c.events.len(), 1);
+        assert_eq!(c.events[0].start.hour(), 14);
+    }
+
+    #[test]
+    fn an_all_day_event_has_no_time_and_covers_its_day() {
+        let c = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART;VALUE=DATE:20260801\r\nSUMMARY:holiday\r\nEND:VEVENT",
+        );
+        let e = &c.events[0];
+        assert!(e.all_day);
+        assert_eq!(e.start.date(), date(2026, 8, 1));
+        assert_eq!(e.end.as_ref().unwrap().date(), date(2026, 8, 2));
+    }
+
+    #[test]
+    fn a_duration_stands_in_for_a_missing_end() {
+        let c = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART:20260801T140000\r\nDURATION:PT1H30M\r\nSUMMARY:x\r\nEND:VEVENT",
+        );
+        let e = &c.events[0];
+        assert_eq!(e.end.as_ref().unwrap().hour(), 15);
+        assert_eq!(e.end.as_ref().unwrap().minute(), 30);
+    }
+
+    #[test]
+    fn text_escapes_are_undone() {
+        let c = parse_all(
+            r"BEGIN:VEVENT
+DTSTART:20260801T140000
+SUMMARY:Review\, then ship\; carefully\nSecond line
+LOCATION:Room A\, floor 2
+END:VEVENT",
+        );
+        let e = &c.events[0];
+        assert_eq!(e.summary, "Review, then ship; carefully Second line");
+        assert_eq!(e.location.as_deref(), Some("Room A, floor 2"));
+    }
+
+    #[test]
+    fn an_alarm_inside_an_event_does_not_become_its_time() {
+        // A VALARM carries its own TRIGGER and, in some exports, a DTSTART.
+        // Reading it as the event's would put everything on screen 15 minutes
+        // early, which looks like a timezone bug and is not one.
+        let c = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART:20260801T140000\r\nSUMMARY:standup\r\n\
+             BEGIN:VALARM\r\nTRIGGER:-PT15M\r\nDTSTART:20260801T134500\r\nEND:VALARM\r\n\
+             END:VEVENT",
+        );
+        assert_eq!(c.events.len(), 1);
+        assert_eq!(c.events[0].start.hour(), 14);
+    }
+
+    #[test]
+    fn an_event_without_a_start_is_skipped_without_being_called_an_error() {
+        let c = parse_all("BEGIN:VEVENT\r\nSUMMARY:no start\r\nEND:VEVENT");
+        assert!(c.events.is_empty());
+        assert!(c.skipped.is_empty(), "not worth reporting: {:?}", c.skipped);
+    }
+
+    #[test]
+    fn an_event_without_a_summary_still_draws_something() {
+        // Invariant 11: never render an empty cell.
+        let c = parse_all("BEGIN:VEVENT\r\nDTSTART:20260801T140000\r\nEND:VEVENT");
+        assert_eq!(c.events[0].summary, "–");
+    }
+
+    #[test]
+    fn an_unreadable_time_is_reported_rather_than_swallowed() {
+        let c = parse_all("BEGIN:VEVENT\r\nDTSTART:not-a-date\r\nSUMMARY:x\r\nEND:VEVENT");
+        assert!(c.events.is_empty());
+        assert_eq!(c.skipped.len(), 1, "the reason must survive");
+        assert!(c.skipped[0].contains("not-a-date"), "{:?}", c.skipped);
+    }
+
+    #[test]
+    fn a_daily_rule_repeats_and_counts() {
+        let (from, to) = window((2026, 8, 1), (2026, 8, 31));
+        let c = parse(
+            &wrap(
+                "BEGIN:VEVENT\r\nDTSTART:20260801T090000\r\nDURATION:PT30M\r\n\
+                 RRULE:FREQ=DAILY;COUNT=5\r\nSUMMARY:standup\r\nEND:VEVENT",
+            ),
+            &tz(),
+            &from,
+            &to,
+        );
+        assert_eq!(c.events.len(), 5);
+        assert_eq!(c.events[0].start.date(), date(2026, 8, 1));
+        assert_eq!(c.events[4].start.date(), date(2026, 8, 5));
+    }
+
+    #[test]
+    fn an_interval_skips_and_until_stops() {
+        let (from, to) = window((2026, 8, 1), (2026, 9, 30));
+        let c = parse(
+            &wrap(
+                "BEGIN:VEVENT\r\nDTSTART:20260801T090000\r\n\
+                 RRULE:FREQ=DAILY;INTERVAL=3;UNTIL=20260810T000000Z\r\nSUMMARY:x\r\nEND:VEVENT",
+            ),
+            &tz(),
+            &from,
+            &to,
+        );
+        let days: Vec<_> = c.events.iter().map(|e| e.start.day()).collect();
+        assert_eq!(days, vec![1, 4, 7]);
+    }
+
+    #[test]
+    fn a_weekly_rule_with_byday_produces_each_named_day() {
+        let (from, to) = window((2026, 8, 1), (2026, 8, 22));
+        let c = parse(
+            &wrap(
+                "BEGIN:VEVENT\r\nDTSTART:20260803T100000\r\n\
+                 RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=6\r\nSUMMARY:x\r\nEND:VEVENT",
+            ),
+            &tz(),
+            &from,
+            &to,
+        );
+        // 3 August 2026 is a Monday.
+        let days: Vec<_> = c.events.iter().map(|e| e.start.date()).collect();
+        assert_eq!(
+            days,
+            vec![
+                date(2026, 8, 3),
+                date(2026, 8, 5),
+                date(2026, 8, 7),
+                date(2026, 8, 10),
+                date(2026, 8, 12),
+                date(2026, 8, 14),
+            ]
+        );
+    }
+
+    #[test]
+    fn exdate_removes_an_occurrence_without_shifting_the_rest() {
+        let (from, to) = window((2026, 8, 1), (2026, 8, 31));
+        let c = parse(
+            &wrap(
+                "BEGIN:VEVENT\r\nDTSTART:20260801T090000\r\n\
+                 RRULE:FREQ=DAILY;COUNT=4\r\nEXDATE:20260802T090000\r\nSUMMARY:x\r\nEND:VEVENT",
+            ),
+            &tz(),
+            &from,
+            &to,
+        );
+        let days: Vec<_> = c.events.iter().map(|e| e.start.day()).collect();
+        assert_eq!(days, vec![1, 3, 4], "the 2nd should be gone, not shifted");
+    }
+
+    #[test]
+    fn a_rule_outside_the_subset_yields_only_the_first_occurrence() {
+        // The deliberate answer. `BYSETPOS` narrows the set; expanding without
+        // it would put meetings on screen that are not happening, and a
+        // calendar that invents a meeting is worse than one that misses one.
+        for rule in [
+            "FREQ=MONTHLY;BYSETPOS=1;BYDAY=MO",
+            "FREQ=MONTHLY;BYDAY=1MO",
+            "FREQ=MONTHLY;BYMONTHDAY=1,15",
+            "FREQ=HOURLY",
+        ] {
+            let (from, to) = window((2026, 8, 1), (2027, 8, 1));
+            let c = parse(
+                &wrap(&format!(
+                    "BEGIN:VEVENT\r\nDTSTART:20260803T090000\r\nRRULE:{rule}\r\nSUMMARY:x\r\nEND:VEVENT"
+                )),
+                &tz(),
+                &from,
+                &to,
+            );
+            assert_eq!(
+                c.events.len(),
+                1,
+                "{rule} produced {} events",
+                c.events.len()
+            );
+            assert_eq!(c.events[0].start.date(), date(2026, 8, 3));
+        }
+    }
+
+    #[test]
+    fn an_event_in_progress_is_inside_the_window_even_though_it_started_before_it() {
+        // The meeting you are already late for is the one you most want to see,
+        // so the window test is overlap rather than start.
+        let tz = tz();
+        let from = date(2026, 8, 1)
+            .at(14, 30, 0, 0)
+            .to_zoned(tz.clone())
+            .unwrap();
+        let to = local_midnight(date(2026, 8, 8), &tz).unwrap();
+        let c = parse(
+            &wrap(
+                "BEGIN:VEVENT\r\nDTSTART:20260801T140000\r\nDURATION:PT2H\r\nSUMMARY:long\r\nEND:VEVENT",
+            ),
+            &tz,
+            &from,
+            &to,
+        );
+        assert_eq!(c.events.len(), 1, "an in-progress event was dropped");
+        assert!(c.events[0].contains(&from));
+    }
+
+    #[test]
+    fn an_unbounded_rule_cannot_run_away() {
+        // No COUNT, no UNTIL, a one-day interval and a wide window. The cap is
+        // what stops a malformed calendar from hanging the fetch thread.
+        let (from, to) = window((2026, 1, 1), (2400, 1, 1));
+        let started = std::time::Instant::now();
+        let c = parse(
+            &wrap(
+                "BEGIN:VEVENT\r\nDTSTART:20260101T090000\r\nRRULE:FREQ=DAILY\r\nSUMMARY:x\r\nEND:VEVENT",
+            ),
+            &tz(),
+            &from,
+            &to,
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "expansion did not terminate promptly"
+        );
+        assert!(!c.events.is_empty());
+        assert!(c.events.len() <= 4_000, "the cap did not hold");
+    }
+
+    #[test]
+    fn events_come_back_in_time_order() {
+        let c = parse_all(
+            "BEGIN:VEVENT\r\nDTSTART:20260803T090000\r\nSUMMARY:second\r\nEND:VEVENT\r\n\
+             BEGIN:VEVENT\r\nDTSTART:20260801T090000\r\nSUMMARY:first\r\nEND:VEVENT",
+        );
+        let names: Vec<_> = c.events.iter().map(|e| e.summary.as_str()).collect();
+        assert_eq!(names, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn an_empty_or_junk_file_produces_nothing_rather_than_panicking() {
+        for text in ["", "not a calendar", "BEGIN:VCALENDAR", "BEGIN:VEVENT"] {
+            let (from, to) = window((2026, 1, 1), (2027, 1, 1));
+            let c = parse(text, &tz(), &from, &to);
+            assert!(c.events.is_empty(), "{text:?} produced events");
+        }
+    }
+}

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -491,7 +491,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 167;
+        const CITED: usize = 193;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod dateinput;
 mod frame;
 mod glyphs;
 mod grid;
+mod ical;
 mod layout_edit;
 mod migrate;
 mod note;

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -1,0 +1,755 @@
+//! The agenda: what is actually next, out of a local `.ics` file.
+//!
+//! The gap this fills was named early and left open for a long time: tasks are
+//! self-paced, and a meeting is not. A dashboard that can tell you four things
+//! and none of them is "you are in a call in ten minutes" is missing the one
+//! with a deadline attached.
+//!
+//! Deliberately **offline**. mirador does not sign into a calendar server, and
+//! is not going to — that is an account, a token to refresh, and a background
+//! process with opinions about your credentials. It reads a file. Whatever put
+//! the file there is your business: an export, a `vdirsyncer` run, a cron job
+//! with `curl`, a symlink into a synced folder.
+//!
+//! The `calendar` widget beside this one is a date grid and stays that way. One
+//! answers "what is the date", the other "what is next", and squeezing both
+//! into one panel does neither well.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use jiff::civil::Date;
+use jiff::tz::TimeZone;
+use jiff::{Span, Zoned};
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span as TextSpan};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+
+use crate::config::AgendaConfig;
+use crate::frame::{Binding, FRAME_HEIGHT, FRAME_WIDTH};
+use crate::ical;
+use crate::panel::{KeyOutcome, Panel, RenderContext, describe_age};
+
+const BINDINGS: &[Binding] = &[
+    Binding::primary("r", "reload"),
+    Binding::extra("↑ / ↓", "scroll"),
+    Binding::extra("j / k", "scroll"),
+    Binding::extra("g / G", "first / last"),
+    Binding::extra("Home / End", "first / last"),
+    Binding::extra("o", "show file path"),
+];
+
+/// Width at which the panel stops gaining anything: a time, a generous summary
+/// and a location beside it.
+const USEFUL_WIDTH: u16 = 52;
+
+/// What the reader thread has produced.
+#[derive(Debug, Default)]
+struct State {
+    events: Vec<ical::Event>,
+    /// Why the last read failed, if it did.
+    error: Option<String>,
+    /// Lines the parser could not make sense of, so a half-read calendar says
+    /// so rather than looking merely empty.
+    skipped: usize,
+    /// When this was read.
+    read_at: Option<Instant>,
+    /// The day the window was built around, so a dashboard left open overnight
+    /// notices that "today" moved.
+    built_for: Option<Date>,
+}
+
+#[derive(Debug)]
+pub struct AgendaPanel {
+    state: Arc<Mutex<State>>,
+    /// Set to ask the reader thread for an immediate re-read.
+    reload: Arc<Mutex<bool>>,
+    generation: Arc<AtomicU64>,
+    seen: u64,
+    stop: Arc<AtomicBool>,
+    path: PathBuf,
+    days: u16,
+    show_location: bool,
+    scroll: ListState,
+    status: Option<String>,
+    list_area: Option<Rect>,
+}
+
+impl Drop for AgendaPanel {
+    /// See `Drop for StocksPanel`: the picker can drop a panel without calling
+    /// `shutdown`, and a reader thread with no way to end is a leak.
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+impl AgendaPanel {
+    pub fn new(config: &AgendaConfig, path: PathBuf) -> Self {
+        let state = Arc::new(Mutex::new(State::default()));
+        let reload = Arc::new(Mutex::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        let generation = Arc::new(AtomicU64::new(0));
+
+        let days = config.days.clamp(1, 365);
+        // A local file is cheap to read, but not free — a year of a shared work
+        // calendar is megabytes. The floor keeps a hand-edited `0` from
+        // spinning the thread.
+        let interval = Duration::from_secs(config.refresh_secs.max(5));
+
+        let shared = (
+            Arc::clone(&state),
+            Arc::clone(&reload),
+            Arc::clone(&stop),
+            Arc::clone(&generation),
+        );
+        let thread_path = path.clone();
+        std::thread::Builder::new()
+            .name("mirador-agenda".into())
+            .spawn(move || {
+                let (state, reload, stop, generation) = shared;
+                read_loop(
+                    &thread_path,
+                    days,
+                    interval,
+                    &state,
+                    &reload,
+                    &stop,
+                    &generation,
+                );
+            })
+            .expect("spawning the agenda thread");
+
+        Self {
+            state,
+            reload,
+            generation,
+            seen: 0,
+            stop,
+            path,
+            days,
+            show_location: config.show_location,
+            scroll: ListState::default(),
+            status: None,
+            list_area: None,
+        }
+    }
+
+    fn snapshot(&self) -> State {
+        match self.state.lock() {
+            Ok(guard) => State {
+                events: guard.events.clone(),
+                error: guard.error.clone(),
+                skipped: guard.skipped,
+                read_at: guard.read_at,
+                built_for: guard.built_for,
+            },
+            Err(poisoned) => {
+                let guard = poisoned.into_inner();
+                State {
+                    events: guard.events.clone(),
+                    error: guard.error.clone(),
+                    skipped: guard.skipped,
+                    read_at: guard.read_at,
+                    built_for: guard.built_for,
+                }
+            }
+        }
+    }
+
+    fn ask_for_reload(&self) {
+        match self.reload.lock() {
+            Ok(mut flag) => *flag = true,
+            Err(poisoned) => *poisoned.into_inner() = true,
+        }
+    }
+
+    /// The rows to draw: a heading per day, then that day's events.
+    ///
+    /// Built as a flat list rather than a tree because a heading and an event
+    /// scroll together and a heading is never selectable — the distinction only
+    /// matters to whoever writes the arrow keys, and here it does not.
+    fn rows(state: &State, now: &Zoned, show_location: bool, width: u16) -> Vec<Row> {
+        let mut rows = Vec::new();
+        let mut current: Option<Date> = None;
+        for event in &state.events {
+            let day = event.start.date();
+            if current != Some(day) {
+                rows.push(Row::Day(day));
+                current = Some(day);
+            }
+            rows.push(Row::Event {
+                event: event.clone(),
+                in_progress: event.contains(now),
+                show_location,
+                width,
+            });
+        }
+        rows
+    }
+}
+
+enum Row {
+    Day(Date),
+    Event {
+        event: ical::Event,
+        in_progress: bool,
+        show_location: bool,
+        width: u16,
+    },
+}
+
+/// How a day is introduced. "Today" and "Tomorrow" beat a date you have to
+/// work out, and the date is still there for everything else.
+fn day_label(day: Date, today: Date) -> String {
+    let delta = (day - today).get_days();
+    match delta {
+        0 => "TODAY".to_string(),
+        1 => "TOMORROW".to_string(),
+        _ => format!("{} {}", weekday_name(day), day.strftime("%-d %b")),
+    }
+}
+
+fn weekday_name(day: Date) -> &'static str {
+    match day.weekday() {
+        jiff::civil::Weekday::Monday => "MONDAY",
+        jiff::civil::Weekday::Tuesday => "TUESDAY",
+        jiff::civil::Weekday::Wednesday => "WEDNESDAY",
+        jiff::civil::Weekday::Thursday => "THURSDAY",
+        jiff::civil::Weekday::Friday => "FRIDAY",
+        jiff::civil::Weekday::Saturday => "SATURDAY",
+        jiff::civil::Weekday::Sunday => "SUNDAY",
+    }
+}
+
+/// Read the file, parse it, and publish — then wait, and do it again.
+fn read_loop(
+    path: &PathBuf,
+    days: u16,
+    interval: Duration,
+    state: &Arc<Mutex<State>>,
+    reload: &Arc<Mutex<bool>>,
+    stop: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
+) {
+    while !stop.load(Ordering::Relaxed) {
+        let tz = TimeZone::system();
+        let today = ical::today(&tz);
+        let from = ical::local_midnight(today, &tz);
+        let until = today
+            .checked_add(Span::new().days(i64::from(days)))
+            .ok()
+            .and_then(|d| ical::local_midnight(d, &tz));
+
+        let next = match (from, until) {
+            (Some(from), Some(until)) => match std::fs::read_to_string(path) {
+                Ok(text) => {
+                    let calendar = ical::parse(&text, &tz, &from, &until);
+                    State {
+                        events: calendar.events,
+                        error: None,
+                        skipped: calendar.skipped.len(),
+                        read_at: Some(Instant::now()),
+                        built_for: Some(today),
+                    }
+                }
+                // Kept as text rather than a typed error: the message the OS
+                // gives ("No such file or directory") is the one that tells
+                // the user what to do.
+                Err(e) => State {
+                    error: Some(format!("{e}")),
+                    read_at: Some(Instant::now()),
+                    built_for: Some(today),
+                    ..State::default()
+                },
+            },
+            _ => State {
+                error: Some("could not work out today's date".into()),
+                read_at: Some(Instant::now()),
+                built_for: Some(today),
+                ..State::default()
+            },
+        };
+
+        match state.lock() {
+            Ok(mut guard) => *guard = next,
+            Err(poisoned) => *poisoned.into_inner() = next,
+        }
+        generation.fetch_add(1, Ordering::Release);
+
+        let woke = crate::poll::wait(interval, stop, || match reload.lock() {
+            Ok(mut flag) => std::mem::replace(&mut *flag, false),
+            Err(poisoned) => std::mem::replace(&mut *poisoned.into_inner(), false),
+        });
+        if woke == crate::poll::Wake::Stop {
+            return;
+        }
+    }
+}
+
+impl Panel for AgendaPanel {
+    fn title(&self) -> String {
+        "Agenda".to_string()
+    }
+
+    fn counter(&self) -> Option<String> {
+        let state = self.snapshot();
+        if state.error.is_some() {
+            return Some("no file".into());
+        }
+        let today = state.built_for?;
+        let n = state
+            .events
+            .iter()
+            .filter(|e| e.start.date() == today)
+            .count();
+        Some(match n {
+            0 => "clear".to_string(),
+            1 => "1 today".to_string(),
+            n => format!("{n} today"),
+        })
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn max_width(&self) -> Option<u16> {
+        // Past this the summaries stop being the constraint and the row just
+        // grows a gap in the middle; the graphs next door can use it.
+        Some(USEFUL_WIDTH + FRAME_WIDTH)
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        // The reader thread owns the real cadence. This only decides how
+        // quickly a completed read reaches the screen, and how often the
+        // in-progress marker is re-evaluated.
+        Duration::from_secs(20)
+    }
+
+    fn tick(&mut self) -> bool {
+        // Two things can change without a keypress: a read landing, and an
+        // event starting or ending. The first is a counter; the second is why
+        // this returns true on the day rolling over even when nothing was read.
+        let now = self.generation.load(Ordering::Acquire);
+        let moved = now != self.seen;
+        self.seen = now;
+        moved
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        self.status = None;
+        let len = self.snapshot().events.len();
+        match key.code {
+            KeyCode::Char('r') => {
+                self.ask_for_reload();
+                self.status = Some("reloading…".into());
+            }
+            KeyCode::Char('o') => {
+                self.status = Some(self.path.display().to_string());
+            }
+            KeyCode::Down | KeyCode::Char('j') => crate::selection::down(&mut self.scroll, 1, len),
+            KeyCode::Up | KeyCode::Char('k') => crate::selection::up(&mut self.scroll, 1, len),
+            KeyCode::PageDown => crate::selection::down(&mut self.scroll, 10, len),
+            KeyCode::PageUp => crate::selection::up(&mut self.scroll, 10, len),
+            KeyCode::Char('G') | KeyCode::End => {
+                crate::selection::down(&mut self.scroll, usize::MAX, len);
+            }
+            KeyCode::Char('g') | KeyCode::Home => {
+                crate::selection::up(&mut self.scroll, usize::MAX, len);
+            }
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> KeyOutcome {
+        let len = self.snapshot().events.len();
+        match event.kind {
+            MouseEventKind::ScrollDown => crate::selection::down(&mut self.scroll, 1, len),
+            MouseEventKind::ScrollUp => crate::selection::up(&mut self.scroll, 1, len),
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        let theme = ctx.theme;
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let state = self.snapshot();
+        let now = Zoned::now();
+
+        // Notices take rows from the bottom, and the list is given what is
+        // left. Drawing the list across the whole panel and painting over it
+        // afterwards is what put `1 entry could not be readndred` on screen:
+        // the notice landed on top of an event instead of beside it.
+        let mut notices: Vec<Line<'static>> = Vec::new();
+        if state.skipped > 0 {
+            notices.push(Line::from(TextSpan::styled(
+                format!(
+                    "{} entr{} could not be read",
+                    state.skipped,
+                    if state.skipped == 1 { "y" } else { "ies" }
+                ),
+                Style::default().fg(theme.error),
+            )));
+        }
+        if let Some(message) = &self.status {
+            notices.push(Line::from(TextSpan::styled(
+                message.clone(),
+                Style::default().fg(theme.muted),
+            )));
+        }
+
+        let (list_area, notice_area) =
+            split_for_notices(area, u16::try_from(notices.len()).unwrap_or(0));
+
+        self.draw_list(frame, list_area, &state, &now, theme);
+
+        if notice_area.height > 0 {
+            frame.render_widget(Paragraph::new(notices), notice_area);
+        }
+    }
+
+    fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+impl AgendaPanel {
+    fn draw_list(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        state: &State,
+        now: &Zoned,
+        theme: &crate::theme::Theme,
+    ) {
+        if let Some(error) = &state.error {
+            let age = state.read_at.map(|at| describe_age(at.elapsed()));
+            let mut lines = vec![
+                Line::from(TextSpan::styled(
+                    "No calendar to read",
+                    Style::default()
+                        .fg(theme.error)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::from(TextSpan::styled(
+                    error.clone(),
+                    Style::default().fg(theme.muted),
+                )),
+                Line::from(""),
+                Line::from(TextSpan::styled(
+                    format!("Looking for {}", self.path.display()),
+                    Style::default().fg(theme.muted),
+                )),
+                Line::from(TextSpan::styled(
+                    "Point [agenda].file at an .ics you already have.",
+                    Style::default().fg(theme.muted),
+                )),
+            ];
+            if let Some(age) = age {
+                lines.push(Line::from(TextSpan::styled(
+                    format!("checked {age}"),
+                    Style::default().fg(theme.muted),
+                )));
+            }
+            frame.render_widget(Paragraph::new(lines), area);
+            return;
+        }
+
+        if state.events.is_empty() {
+            let horizon = if self.days == 1 {
+                "today".to_string()
+            } else {
+                format!("the next {} days", self.days)
+            };
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from(TextSpan::styled(
+                        "Nothing scheduled",
+                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(TextSpan::styled(
+                        format!("in {horizon}."),
+                        Style::default().fg(theme.muted),
+                    )),
+                ]),
+                area,
+            );
+            return;
+        }
+
+        let today = state.built_for.unwrap_or_else(|| now.date());
+        let rows = Self::rows(state, now, self.show_location, area.width);
+
+        let items: Vec<ListItem> = rows
+            .iter()
+            .map(|row| match row {
+                Row::Day(day) => ListItem::new(Line::from(TextSpan::styled(
+                    crate::glyphs::utility(&day_label(*day, today)),
+                    Style::default()
+                        .fg(theme.label)
+                        .add_modifier(Modifier::BOLD),
+                ))),
+                Row::Event {
+                    event,
+                    in_progress,
+                    show_location,
+                    width,
+                } => ListItem::new(event_line(
+                    event,
+                    *in_progress,
+                    *show_location,
+                    *width,
+                    theme,
+                )),
+            })
+            .collect();
+
+        self.list_area = Some(area);
+        frame.render_widget(List::new(items), area);
+    }
+}
+
+/// Divide the panel between the list and the notices below it.
+///
+/// The two never overlap and together cover `area`. Getting that wrong does not
+/// look like a layout bug — the notice lands on top of the last event and the
+/// tail of it shows through, which reads as a corrupt terminal:
+///
+/// ```text
+///   20:00  Meeting at 20 hundred
+/// 1 entry could not be readndred
+/// ```
+///
+/// The list always keeps at least one row: a panel showing only a complaint has
+/// hidden the thing the complaint is about.
+fn split_for_notices(area: Rect, notices: u16) -> (Rect, Rect) {
+    let reserved = notices.min(area.height.saturating_sub(1));
+    let list = Rect {
+        height: area.height - reserved,
+        ..area
+    };
+    let notice = Rect {
+        y: area.y + list.height,
+        height: reserved,
+        ..area
+    };
+    (list, notice)
+}
+
+/// One event, as a row.
+fn event_line(
+    event: &ical::Event,
+    in_progress: bool,
+    show_location: bool,
+    width: u16,
+    theme: &crate::theme::Theme,
+) -> Line<'static> {
+    // A fixed-width time column, so the summaries line up whether or not the
+    // day mixes all-day entries with timed ones.
+    const TIME_WIDTH: usize = 6;
+
+    let time = if event.all_day {
+        "all day".to_string()
+    } else {
+        event.start.strftime("%H:%M").to_string()
+    };
+
+    let marker = if in_progress { "▸ " } else { "  " };
+    let time_style = if in_progress {
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.muted)
+    };
+    let summary_style = if in_progress {
+        Style::default().fg(theme.text).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.text)
+    };
+
+    let used = marker.len() + TIME_WIDTH.max(crate::grid::display_width(&time)) + 1;
+    let room = usize::from(width).saturating_sub(used);
+
+    let mut text = event.summary.clone();
+    if show_location && let Some(location) = &event.location {
+        // Only when there is genuinely room: a location that squeezes the
+        // summary to nothing has cost more than it gave.
+        let combined = format!("{text}  ·  {location}");
+        if crate::grid::display_width(&combined) <= room {
+            text = combined;
+        }
+    }
+
+    Line::from(vec![
+        TextSpan::styled(marker.to_string(), time_style),
+        TextSpan::styled(format!("{time:<TIME_WIDTH$} "), time_style),
+        TextSpan::styled(crate::grid::truncate(&text, room), summary_style),
+    ])
+}
+
+/// Rows the frame costs, re-exported so `max_height` reads the same as the
+/// other panels even though this one does not declare a maximum.
+#[allow(dead_code)]
+const _: u16 = FRAME_HEIGHT;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jiff::civil::date;
+
+    fn tz() -> TimeZone {
+        TimeZone::get("America/New_York").unwrap()
+    }
+
+    fn event(day: Date, hour: i8, summary: &str, all_day: bool) -> ical::Event {
+        let start = day.at(hour, 0, 0, 0).to_zoned(tz()).unwrap();
+        ical::Event {
+            summary: summary.to_string(),
+            location: None,
+            end: start.checked_add(Span::new().hours(1)).ok(),
+            start,
+            all_day,
+        }
+    }
+
+    #[test]
+    fn a_notice_never_lands_on_top_of_an_event() {
+        // The bug this exists for, seen on screen before it was found in the
+        // code: the notice was painted over the last row and the tail of the
+        // event showed through it — `1 entry could not be readndred`.
+        for height in 0u16..12 {
+            for notices in 0u16..4 {
+                let area = Rect::new(3, 5, 40, height);
+                let (list, notice) = split_for_notices(area, notices);
+
+                assert_eq!(
+                    list.height + notice.height,
+                    height,
+                    "{height} rows, {notices} notices: the split loses rows"
+                );
+                assert_eq!(
+                    notice.y,
+                    list.y + list.height,
+                    "{height} rows, {notices} notices: the notice overlaps the list"
+                );
+                if height > 0 {
+                    assert!(
+                        list.height >= 1,
+                        "{height} rows, {notices} notices: the list was squeezed out"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn today_and_tomorrow_are_named_rather_than_dated() {
+        let today = date(2026, 8, 1);
+        assert_eq!(day_label(today, today), "TODAY");
+        assert_eq!(day_label(date(2026, 8, 2), today), "TOMORROW");
+        // Anything further out gets a weekday and a date, because "in 4 days"
+        // is arithmetic the reader should not have to do either way.
+        assert_eq!(day_label(date(2026, 8, 5), today), "WEDNESDAY 5 Aug");
+    }
+
+    #[test]
+    fn each_day_gets_one_heading_however_many_events_it_has() {
+        let state = State {
+            events: vec![
+                event(date(2026, 8, 1), 9, "a", false),
+                event(date(2026, 8, 1), 11, "b", false),
+                event(date(2026, 8, 2), 9, "c", false),
+            ],
+            ..State::default()
+        };
+        let now = date(2026, 8, 1).at(8, 0, 0, 0).to_zoned(tz()).unwrap();
+        let rows = AgendaPanel::rows(&state, &now, true, 60);
+
+        let headings = rows.iter().filter(|r| matches!(r, Row::Day(_))).count();
+        assert_eq!(headings, 2, "one heading per day, not per event");
+        assert_eq!(rows.len(), 5);
+    }
+
+    #[test]
+    fn an_event_happening_now_is_marked() {
+        let state = State {
+            events: vec![event(date(2026, 8, 1), 9, "standup", false)],
+            ..State::default()
+        };
+        let during = date(2026, 8, 1).at(9, 30, 0, 0).to_zoned(tz()).unwrap();
+        let after = date(2026, 8, 1).at(10, 30, 0, 0).to_zoned(tz()).unwrap();
+
+        let marked = |now: &Zoned| match &AgendaPanel::rows(&state, now, true, 60)[1] {
+            Row::Event { in_progress, .. } => *in_progress,
+            Row::Day(_) => unreachable!("row 1 is the event"),
+        };
+        assert!(marked(&during), "the meeting you are in must stand out");
+        assert!(!marked(&after));
+    }
+
+    #[test]
+    fn an_all_day_event_says_so_instead_of_showing_midnight() {
+        let theme = crate::theme::Theme::default();
+        let e = event(date(2026, 8, 1), 0, "Holiday", true);
+        let line = event_line(&e, false, true, 60, &theme);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("all day"), "got `{text}`");
+        assert!(!text.contains("00:00"), "midnight is not a time here");
+    }
+
+    #[test]
+    fn a_row_never_outgrows_the_panel() {
+        // Invariant 9: the budget is display cells, and a CJK summary is the
+        // case that catches a `chars()` count.
+        let theme = crate::theme::Theme::default();
+        for summary in [
+            "short",
+            "an extremely long summary that will not fit in a narrow panel at all",
+            "日本語のとても長い予定のタイトルです",
+        ] {
+            for width in [10u16, 20, 40, 80] {
+                let mut e = event(date(2026, 8, 1), 9, summary, false);
+                e.location = Some("Room 12, second floor".into());
+                let line = event_line(&e, false, true, width, &theme);
+                let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                assert!(
+                    crate::grid::display_width(&text) <= usize::from(width),
+                    "{width} cells: `{text}` is {}",
+                    crate::grid::display_width(&text)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_location_is_dropped_rather_than_squeezing_the_summary_out() {
+        let theme = crate::theme::Theme::default();
+        let mut e = event(date(2026, 8, 1), 9, "Design review", false);
+        e.location = Some("The very long name of a meeting room".into());
+        let narrow: String = event_line(&e, false, true, 30, &theme)
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(narrow.contains("Design"), "the summary lost: `{narrow}`");
+        assert!(!narrow.contains("very long name"), "got `{narrow}`");
+
+        let wide: String = event_line(&e, false, true, 70, &theme)
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(wide.contains("meeting room"), "got `{wide}`");
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -4,6 +4,7 @@
 //! to [`WIDGET_NAMES`] and adding one arm to [`build`]. Nothing else in the
 //! codebase needs to know it exists.
 
+pub mod agenda;
 pub mod calendar;
 pub mod clocks;
 pub mod cpu;
@@ -21,7 +22,8 @@ use crate::panel::Panel;
 
 /// Every widget id accepted in the `[layout]` table.
 pub const WIDGET_NAMES: &[&str] = &[
-    "clocks", "weather", "todo", "notes", "stocks", "calendar", "pomodoro", "cpu", "network",
+    "clocks", "weather", "todo", "notes", "stocks", "calendar", "agenda", "pomodoro", "cpu",
+    "network",
 ];
 
 /// Whether `name` refers to a widget mirador knows how to build.
@@ -74,6 +76,10 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
             config.stocks_path()?,
         )?),
         "calendar" => Box::new(calendar::CalendarPanel::new(config.calendar.clone())),
+        "agenda" => Box::new(agenda::AgendaPanel::new(
+            &config.agenda,
+            config.agenda_path()?,
+        )),
         "pomodoro" => Box::new(pomodoro::PomodoroPanel::new(config.pomodoro.clone())),
         "cpu" => Box::new(cpu::CpuPanel::new(config.cpu.clone())),
         "network" => Box::new(network::NetworkPanel::new(config.network.clone())),


### PR DESCRIPTION
Closes the gap `CLAUDE.md` has called the biggest one since 0.1: tasks are self-paced and a meeting is not, so a dashboard that answered four questions and none of them was *"you are in a call in ten minutes"* was missing the one with a deadline attached.

```
╭┤5 Agenda├──────────────────────────────┤2 today├╮
│ TODAY                                           │
│   09:15  Standup  ·  Zoom                       │
│ ▸ 14:00  Quarterly planning  ·  Room 12         │
│ TOMORROW                                        │
│   all day Public holiday                        │
│ THURSDAY 30 Jul                                 │
│   09:00  Call with London                       │
╰─────────────────── r reload ────────────────────╯
```

## Offline, on purpose

mirador does not sign in to a calendar server and is not going to — that is an account, a token to refresh, and a background process with opinions about your credentials. Point `[agenda].file` at a calendar you already have; whatever keeps it current is your business.

## Parsed in-tree, and why

`icalendar` + `rrule` would add **30 transitive dependencies and 2.3 MB** to a 3.4 MB binary. Measured against a hello-world on the same release profile, not guessed.

Most of that is `chrono-tz` carrying a timezone database — and that is what decides it. `jiff` already ships one. Putting two in a prebuilt binary for four platforms, to read a text file, is the same trade this project already refused for audio.

`src/ical.rs` handles what the wild actually produces: line folding, the four TEXT escapes, `VALUE=DATE`, UTC `Z`, `TZID` with conversion to local, a quoted parameter containing a colon (`TZID="GMT+01:00"`), `DURATION` standing in for `DTEND`, and nested `VALARM` blocks — an alarm's own `DTSTART` is not the event's, and reading it as one puts every meeting on screen fifteen minutes early.

### Recurrence is a documented subset

`DAILY`, `WEEKLY` with `BYDAY`, `MONTHLY`, `YEARLY`, plus `INTERVAL`, `COUNT`, `UNTIL`, `EXDATE`.

Anything else — `BYSETPOS`, `BYMONTHDAY`, an ordinal `BYDAY` like `1MO` — yields **only the first occurrence**. Those parts all *narrow* the set, so expanding without them over-generates. A calendar that invents a meeting costs a wasted trip; one that misses a repeat costs a glance at the real thing.

## Two bugs found by looking at it, not by testing it

**The notice was painted over the list.** A full panel rendered `1 entry could not be readndred` — the tail of the event underneath showing through. The split is now a function, with a test asserting the two rects never overlap and the list always keeps at least one row.

**A half-read calendar looked merely empty.** Entries the parser cannot read are now counted at the foot of the panel.

## Testing

Mutation-checked, because a parser that passes its tests first time deserves suspicion:

- ignoring `TZID` → fails `a_zone_in_another_country_is_converted_rather_than_relabelled`
- treating an unsupported `RRULE` part as absent → fails `a_rule_outside_the_subset_yields_only_the_first_occurrence`

No test touches the filesystem or the network. Verified end to end under tmux against a fixture with recurrence, three timezone forms, a folded line, a `VALARM` and a deliberately broken entry — London 14:00 BST rendered as 09:00 EDT, the standup expanded Mon–Fri, and the broken entry counted.

## One real cost

**The default layout now places ten panels**, so the tenth has no number to jump to (`1`–`9` covers the rest; `Tab` reaches everything). `network` is the one that loses the shortcut.

I placed it in the default rather than leaving it out because `the_default_layout_places_every_widget` is right that a widget nobody can see is a widget nobody knows exists — that is how notes and stocks went unseen. Say the word if you would rather have the shortcut back and discover the agenda through `w`.

Nothing creates the calendar file. Unlike the task list, which seeds examples so a first run is not blank, an empty calendar mirador invented would be a lie about your day — so the unconfigured panel names the path it looked at and the key to set.

469 tests; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)