### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-07-27
 
 ### Added
 
@@ -29,8 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would have added 30 crates and **2.3 MB** to a 3.4 MB binary — measured — most
   of it `chrono-tz` carrying a second timezone database.
 
+  An unconfigured panel says "No agenda file" and how to set one, in ordinary
+  colours — that is a panel nobody has set up, not a fault. A file that exists
+  and cannot be read is the fault, and says so.
+
   **The default layout now places ten panels**, so the last of them has no
-  number to jump to; `1`–`9` covers the rest and `Tab` reaches everything.
+  number to jump to; `1`–`9` covers the rest and `Tab` reaches everything. The
+  bottom row is reordered so the pomodoro keeps the width its numerals need.
 
 ## [0.6.0] - 2026-07-27
 
@@ -637,7 +642,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.6.0...HEAD
+[0.7.0]: https://github.com/jchultarsky/mirador/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jchultarsky/mirador/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/jchultarsky/mirador/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jchultarsky/mirador/compare/v0.5.0...v0.5.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,7 +455,7 @@ The `.ics` agenda that sat at the top of this list is built — `ical.rs` and
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.6.0` is released**, on crates.io and as a GitHub release with binaries
+- **`0.7.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ there are no backports. In practice that means whatever is on the
 
 | Version | Supported |
 | --- | --- |
-| 0.6.x | Yes |
-| < 0.6 | No — upgrade |
+| 0.7.x | Yes |
+| < 0.7 | No — upgrade |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
An **agenda panel** that reads a local `.ics`, closing the gap `CLAUDE.md` has called the biggest one since 0.1: tasks are self-paced and a meeting is not.

## Why a minor

A new widget, and the default layout grows from nine panels to ten. That changes what a first run looks like, and leaves the tenth panel without a number to jump to (`1`–`9` covers the rest; `Tab` reaches everything).

Nothing breaks and no config stops loading. An existing `config.toml` keeps the layout it already has and gets the usual status-bar note that `agenda` is available and `w` will place it.

## Also in it

- An unconfigured agenda says "No agenda file" and how to set one, in ordinary colours — a panel nobody has set up is not a fault. A file that exists and cannot be read *is*, and says so separately.
- The demo is re-recorded at 200×50 with the graphs given a hundred seconds of history first, so it shows the dashboard rather than its fallbacks.
- The bottom row is reordered so the pomodoro keeps the 42 columns its block numerals need.

Parsed in-tree with `jiff`. `icalendar` + `rrule` would have added 30 crates and **2.3 MB** to a 3.4 MB binary, most of it a second timezone database.

## Verified

- `dist plan --tag=v0.7.0` announces `v0.7.0` and plans all four targets, both installers, the updaters, checksums and `sha256.sum`
- `cargo publish --locked --dry-run` packages 53 files (up two: `ical.rs` and `agenda.rs`)
- 469 tests, fmt, clippy, docs, cargo-deny all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)