### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-07-27
+
+### Fixed
+
+- The two links to dist's documentation pointed at `opensource.axo.dev`, which
+  no longer resolves. They point at `axodotdev.github.io` instead.
+
 ## [0.7.0] - 2026-07-27
 
 ### Added
@@ -642,6 +649,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
+[0.7.1]: https://github.com/jchultarsky/mirador/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jchultarsky/mirador/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jchultarsky/mirador/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/jchultarsky/mirador/compare/v0.5.1...v0.5.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,7 +455,7 @@ The `.ics` agenda that sat at the top of this list is built — `ical.rs` and
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.7.0` is released**, on crates.io and as a GitHub release with binaries
+- **`0.7.1` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ URL, and the manual route is below.
 
 The shell installer checks the archive against its published sha256; the
 PowerShell one does no verification, and neither verifies the updater binary.
-That is [dist](https://opensource.axo.dev/cargo-dist/)'s behaviour rather than
+That is [dist](https://axodotdev.github.io/cargo-dist/)'s behaviour rather than
 ours, and [SECURITY.md](SECURITY.md#verifying-a-download) says what it does and
 does not buy you. Every artifact carries a GitHub provenance attestation, which
 is the stronger check and the one to run if you care:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,7 +84,7 @@ Each archive also has a `.sha256` sibling, and the release carries a combined
 
 ### What the installers do not check
 
-The one-line installers come from [dist](https://opensource.axo.dev/cargo-dist/)
+The one-line installers come from [dist](https://axodotdev.github.io/cargo-dist/)
 and their verification is dist's, not ours. As of dist 0.32.0:
 
 - The shell installer verifies the sha256 of the archive it downloads, but


### PR DESCRIPTION
Fixes two dead links.

`https://opensource.axo.dev/cargo-dist/` no longer resolves — DNS failure, not a redirect. It appeared twice, in `README.md` and `SECURITY.md`. Both now point at `https://axodotdev.github.io/cargo-dist/`, which returns 200.

Found by walking every link in the documentation before submitting to the awesome-* lists, where a dead link in the README is exactly what gets an entry turned down.

Cut as a release rather than left on `main` because the README is packaged: crates.io renders each version's own copy, so the 0.7.0 page would carry the dead link until something replaced it.

Every other link in `README.md`, `SECURITY.md`, `CONTRIBUTING.md` and `CHANGELOG.md` was checked and resolves. The apparent 404s from `crates.io` are that site serving non-browser clients — `serde` and `ratatui` behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)