### PR TITLE
Add an opt-in update check, and disclose how mirador is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **An optional update check.** `[general].check_for_updates = true` asks
+  crates.io, at most once a day, whether a newer mirador exists, and says so
+  once in the status bar if it does.
+
+  **Off by default and staying that way.** Everything else in mirador reaches
+  the network only because a panel you placed needs data; this would reach it on
+  its own behalf, telling a third party your IP address and that you run this
+  program on a schedule you did not pick. Small, and still the thing "nothing
+  phones home" was promising — so it is yours to turn on.
+
+  When on: no identifier is sent, the answer is cached in `update-check.toml`
+  beside your tasks so a day of restarts costs one request, a failure is silent,
+  and the notice retires on your first keypress. `NO_UPDATE_CHECK=1` or
+  `DO_NOT_TRACK=1` in the environment overrides the config.
+
+- **The README now says how mirador is built.** It is written with heavy AI
+  assistance, and anyone weighing up the code deserves to know that without
+  having to infer it from the commit history.
+
 ## [0.7.1] - 2026-07-27
 
 ### Fixed
@@ -649,6 +672,7 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.7.1...HEAD
 [0.7.1]: https://github.com/jchultarsky/mirador/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jchultarsky/mirador/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jchultarsky/mirador/compare/v0.5.2...v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ migrate.rs   textual in-place upgrade of configs written by older versions
 layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
 store.rs     write_atomic — every file mirador owns goes through it
 state.rs     UI-changed preferences, remembered across restarts
+update.rs    the opt-in update check — off unless the config turns it on
 task.rs      task model + TOML store
 note.rs      note model + TOML store
 quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
@@ -198,7 +199,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 194 of them, including the ones mirador
+    trip through `toml` discards all 207 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ first keypress, because a dashboard that nags is a dashboard you close.
 
 **Your data stays in files you own.** Tasks, notes and the watchlist are plain
 TOML you can hand-edit, keep in git, or delete. No database, no sync service,
-no account, no API key, no telemetry, and nothing phones home — including the
-updater, which runs only when you run it.
+no account, no API key, no telemetry, and nothing phones home unless you ask it
+to — including the updater, which runs only when you run it, and an update check
+that is off until you turn it on.
 
 **It is a real task list, not a checklist.** Due dates, priorities, notes, tags,
 filtering and full editing without leaving the dashboard. That is the panel most
@@ -55,6 +56,31 @@ The two network panels use free key-less endpoints:
 [Open-Meteo](https://open-meteo.com) for weather, and Yahoo's public chart
 endpoint for prices — see [Market data](#market-data) for what the second one
 means for you.
+
+## How this was built
+
+**mirador is written with heavy AI assistance.** The implementation, the tests
+and most of this documentation were written by Claude (Anthropic), working from
+my direction and review. The product decisions — what to build, what to leave
+out, what the thing is for — are mine.
+
+This is stated plainly because anyone evaluating the code deserves to know how
+it was made, and because some communities reasonably want to know before they
+adopt or recommend something. It is not a claim about quality in either
+direction: judge it the way you would judge any other code.
+
+What that means in practice, if you want to weigh it:
+
+- Every change lands through CI that runs the test suite on macOS, Linux and
+  Windows, plus `clippy` with `-D warnings`, `rustdoc` with `-D warnings`,
+  a minimum-supported-Rust-version check, `cargo publish --dry-run` and
+  `cargo-deny` for advisories, licences and sources.
+- Behavioural claims in the commit history are measured rather than asserted,
+  and several fixes were verified by reverting them to confirm the new test
+  actually failed. Two tests in this repository were found to be pinning the
+  bug they existed to catch.
+- `CLAUDE.md` records the design decisions and the reasoning behind them,
+  including the ones that were reversed and why.
 
 ## Install
 
@@ -98,8 +124,12 @@ mirador-update
 ```
 
 It asks GitHub what the newest release is and installs it if that is newer than
-what you have. It runs **only when you run it** — mirador itself never checks
-for updates, never phones home, and does not know this program exists. If you
+what you have. It runs **only when you run it** — mirador itself never phones
+home and does not know this program exists, unless you set
+`[general].check_for_updates = true`, which asks crates.io once a day whether a
+newer version exists and says so once in the status bar. That setting is off by
+default, sends no identifier, caches its answer, fails silently, and is
+overridden by `NO_UPDATE_CHECK=1` or `DO_NOT_TRACK=1` in your environment. If you
 installed with `cargo install` or from source, upgrade the same way you
 installed; the updater is only for the two installers above.
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -28,6 +28,21 @@ show_status_bar = true
 # Terminal and iTerm2. Set to false to keep ordinary text selection.
 mouse = true
 
+# Ask crates.io, at most once a day, whether a newer mirador exists, and say so
+# once in the status bar if it does.
+#
+# Off, and it stays off until you change this line. Everything else in mirador
+# talks to the network only because a panel you placed needs data; this would
+# talk on its own behalf, telling a third party your IP address and that you
+# run this program, on a schedule you did not pick. That is small, and it is
+# still the thing "nothing phones home" was promising.
+#
+# When it is on: no identifier is sent, the answer is cached in
+# update-check.toml beside your tasks, a failure is silent, and the notice
+# disappears on your first keypress. NO_UPDATE_CHECK=1 or DO_NOT_TRACK=1 in the
+# environment overrides this even when it is true.
+check_for_updates = false
+
 # ---------------------------------------------------------------------------
 # Layout
 #

--- a/src/app.rs
+++ b/src/app.rs
@@ -259,6 +259,14 @@ pub struct App {
     /// of any kind: a dashboard you leave open all day must not nag, and a
     /// notice that will not go away is a nag.
     show_widget_hint: bool,
+    /// A newer version, if the opt-in check found one. Empty otherwise, and
+    /// empty always when the check is off — `App` never starts it, so no test
+    /// and no `--print-config` run can reach the network.
+    update: crate::update::Found,
+    /// Whether the update notice is still on screen. Retired by the first
+    /// keypress, exactly like the widget hint: a dashboard you leave open all
+    /// day must not nag, and a notice that will not go away is a nag.
+    show_update_hint: bool,
     /// The panel picker, while it is open.
     picker: Option<crate::picker::Picker>,
     /// The config file, so layout changes can be written back to it. `None` in
@@ -310,6 +318,8 @@ impl App {
             help_viewport: 0,
             should_quit: false,
             show_widget_hint: !unused_widgets.is_empty(),
+            update: crate::update::Found::default(),
+            show_update_hint: true,
             unused_widgets,
             picker: None,
             config_path: None,
@@ -647,6 +657,7 @@ impl App {
         // Any key at all retires the startup hint. It has been read or it has
         // been ignored; either way it has had its turn.
         self.show_widget_hint = false;
+        self.show_update_hint = false;
 
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
@@ -960,7 +971,8 @@ impl App {
         // A deliberate click or scroll retires the startup hint, as a key does.
         // Pointer motion deliberately does not: the mouse crossing the window
         // on its way somewhere else is not the user reading anything.
-        let had_hint = std::mem::take(&mut self.show_widget_hint);
+        let had_hint =
+            std::mem::take(&mut self.show_widget_hint) | std::mem::take(&mut self.show_update_hint);
 
         // The help overlay swallows the next input, whatever it is — the same
         // rule keys follow.
@@ -1194,7 +1206,7 @@ impl App {
         // The hint rides on the right of the bar it shares with the global
         // keys, and gives way to them when the terminal is too narrow: knowing
         // how to quit matters more than knowing what you are not using.
-        if let Some(hint) = self.widget_hint() {
+        if let Some(hint) = self.update_hint().or_else(|| self.widget_hint()) {
             let used: usize = spans
                 .iter()
                 .map(|s| crate::grid::display_width(&s.content))
@@ -1215,6 +1227,32 @@ impl App {
     }
 
     /// The one-line startup notice about widgets this layout does not place.
+    /// Watch `found` for a newer version from now on.
+    ///
+    /// Separate from [`App::new`] for the same reason the state path is: tests
+    /// build apps constantly, and none of them should be able to start a
+    /// network request by accident.
+    pub fn watch_for_updates(&mut self, found: crate::update::Found) {
+        self.update = found;
+    }
+
+    /// The update notice, if there is one and it has not been dismissed.
+    ///
+    /// Takes precedence over the unused-widget hint when both apply: this one
+    /// is rarer, is actionable now, and stops being true the moment you act on
+    /// it, where the widget hint is the same every launch until you change your
+    /// layout.
+    fn update_hint(&self) -> Option<String> {
+        if !self.show_update_hint {
+            return None;
+        }
+        let latest = match self.update.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }?;
+        Some(format!("mirador {latest} is out   mirador-update "))
+    }
+
     fn widget_hint(&self) -> Option<String> {
         if !self.show_widget_hint || self.unused_widgets.is_empty() {
             return None;
@@ -1628,6 +1666,53 @@ mod tests {
             .map(|slot| std::ptr::from_ref(&*slot.panel).cast::<u8>())
             .collect();
         assert_eq!(distinct.len(), app.slots.len(), "a panel was reused twice");
+    }
+
+    #[test]
+    fn no_update_notice_until_something_finds_a_version() {
+        // `App` never starts a check itself. A dashboard built in a test — or
+        // by `--print-config` — must not be able to reach the network.
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        assert_eq!(app.update_hint(), None);
+
+        app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
+            "9.9.9".to_string(),
+        ))));
+        let hint = app.update_hint().expect("a found version should show");
+        assert!(hint.contains("9.9.9"), "got `{hint}`");
+        assert!(
+            hint.contains("mirador-update"),
+            "the notice must say what to do about it: `{hint}`"
+        );
+    }
+
+    #[test]
+    fn the_update_notice_retires_on_the_first_keypress() {
+        // Same rule as the widget hint. A dashboard left open all day must not
+        // keep telling you something you have already read.
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
+            "9.9.9".to_string(),
+        ))));
+        assert!(app.update_hint().is_some());
+
+        app.handle_key(key(KeyCode::Tab));
+        assert_eq!(app.update_hint(), None, "the notice outlived a keypress");
+    }
+
+    #[test]
+    fn an_update_notice_displaces_the_widget_hint_rather_than_sharing_the_row() {
+        // Both want the right-hand end of the status bar. The update notice is
+        // rarer and stops being true once acted on, so it wins; the widget hint
+        // is unchanged every launch until the layout changes.
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        assert!(app.widget_hint().is_some(), "this layout omits widgets");
+
+        app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
+            "9.9.9".to_string(),
+        ))));
+        let shown = app.update_hint().or_else(|| app.widget_hint()).unwrap();
+        assert!(shown.contains("9.9.9"), "the widget hint won: `{shown}`");
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,6 +71,11 @@ pub struct Config {
 /// Global behaviour.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
+// Four independent on/off settings with nothing in common but their type. A
+// flags struct is the clearest representation of that; there is no state
+// machine hiding here, and grouping them into an enum would invent a
+// relationship the settings do not have.
+#[allow(clippy::struct_excessive_bools)]
 pub struct General {
     /// Frame budget in milliseconds. Lower is smoother and burns more CPU.
     pub tick_rate_ms: u64,
@@ -85,12 +90,24 @@ pub struct General {
     /// dashboard needs the terminal's override modifier (Shift in most, Option
     /// in macOS Terminal and iTerm2). Set to `false` to keep selection.
     pub mouse: bool,
+    /// Ask crates.io, once a day, whether a newer mirador exists.
+    ///
+    /// **Off, and staying off unless you turn it on.** The README promises that
+    /// mirador does not phone home; an update check is a request that tells a
+    /// third party your IP address and that you run this program, on a schedule
+    /// you did not pick. Small, and still the thing that promise was about.
+    ///
+    /// `NO_UPDATE_CHECK` or `DO_NOT_TRACK` in the environment override this
+    /// even when it is true — on a managed machine the person who set those may
+    /// not be the person who wrote the config.
+    pub check_for_updates: bool,
 }
 
 impl Default for General {
     fn default() -> Self {
         Self {
             tick_rate_ms: 250,
+            check_for_updates: false,
             show_borders: true,
             show_status_bar: true,
             mouse: true,
@@ -265,6 +282,11 @@ impl Config {
     /// Where remembered UI preferences live. Not configurable: it is mirador's
     /// own bookkeeping rather than something you curate, and a config key
     /// pointing at it would invite exactly the confusion this file avoids.
+    /// Where the update check caches its answer, beside the state file.
+    pub fn update_cache_path() -> Result<PathBuf> {
+        Ok(crate::update::default_path(&Self::default_data_dir()?))
+    }
+
     pub fn state_path() -> Result<PathBuf> {
         Ok(crate::state::default_path(&Self::default_data_dir()?))
     }

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -491,7 +491,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 194;
+        const CITED: usize = 207;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod task;
 mod textarea;
 mod textfield;
 mod theme;
+mod update;
 mod widgets;
 
 use std::path::PathBuf;
@@ -177,7 +178,15 @@ fn run() -> Result<()> {
     config.apply_state(&saved);
 
     let mouse = config.general.mouse;
+    // Started before the terminal is taken over, and off unless the config says
+    // otherwise. Returns immediately either way — the request, if there is one,
+    // is on its own thread and the dashboard never waits for it.
+    let updates = crate::update::spawn(
+        config.general.check_for_updates,
+        Config::update_cache_path().ok(),
+    );
     let mut app = App::new(config)?;
+    app.watch_for_updates(updates);
     app.write_layout_to(config_path);
     if let Some(path) = state_path {
         app.remember_preferences_at(path, saved, baseline);

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,377 @@
+//! Telling you a newer version exists, if — and only if — you asked to be told.
+//!
+//! # Off by default, and that is not laziness
+//!
+//! The README promises that mirador does not phone home. An update check is a
+//! network request that reveals your IP address and the fact that you run this
+//! program, to a third party, on a schedule you did not choose. That is a small
+//! thing and it is still the thing the promise was about, so it is opt-in:
+//! `[general].check_for_updates = true` and nothing else turns it on.
+//!
+//! Everything below follows from taking that seriously.
+//!
+//! - **`NO_UPDATE_CHECK` and `DO_NOT_TRACK` win over the config.** Someone who
+//!   sets those in their environment has said what they want more recently than
+//!   whoever edited the config, and on a shared or managed machine they may not
+//!   be the same person.
+//! - **crates.io, not GitHub.** It is where `cargo install mirador` gets its
+//!   answer, it needs no token, and its unauthenticated rate limit is not a
+//!   trap the way GitHub's 60-per-hour-per-IP is behind a shared NAT.
+//! - **Nothing is sent but the request.** No identifier, no configuration, no
+//!   count of anything. The reply is one version string.
+//! - **The result is cached to disk**, so leaving the dashboard open all day and
+//!   restarting it twenty times is one request, not twenty.
+//! - **A failure is silent.** No network, a proxy, an outage, a change to the
+//!   API — none of that is the user's problem, and a dashboard that complains
+//!   about its own update check has become the thing it was meant to save you
+//!   from.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// How long a check is good for.
+///
+/// A day. Releases are not frequent enough for anything shorter to tell you
+/// something new, and the point of the cache is that an eager restarter and a
+/// week-long session cost the same.
+const CACHE_FOR: Duration = Duration::from_hours(24);
+
+/// Short, because nobody is waiting for this and a hung request should not keep
+/// a thread alive for long after the dashboard has quit.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+const ENDPOINT: &str = "https://crates.io/api/v1/crates/mirador";
+
+/// What the last check found, persisted between runs.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct Cache {
+    /// The newest stable version crates.io reported.
+    latest: Option<String>,
+    /// When that was, as seconds since the Unix epoch.
+    ///
+    /// Wall-clock rather than `Instant`, because the whole point is to survive
+    /// a restart, and an `Instant` means nothing across one. A clock moved
+    /// backwards makes this look stale and costs one extra request.
+    checked_at: Option<i64>,
+}
+
+/// A newer version, once something has found one.
+pub type Found = Arc<Mutex<Option<String>>>;
+
+/// Start a check on a background thread, if one is wanted and one is due.
+///
+/// Returns the slot the answer will appear in. The slot stays empty when
+/// checking is off, when the cache is fresh and had nothing to report, or when
+/// anything at all goes wrong.
+pub fn spawn(enabled: bool, path: Option<PathBuf>) -> Found {
+    let found: Found = Arc::new(Mutex::new(None));
+
+    if !enabled || opted_out() {
+        return found;
+    }
+    let Some(path) = path else {
+        return found;
+    };
+
+    // A cached answer is used immediately, so a newer version found yesterday
+    // is on screen this morning without waiting for a request to come back.
+    let cache = read_cache(&path);
+    if let Some(latest) = cache.latest.as_deref()
+        && is_newer(latest, current())
+    {
+        set(&found, Some(latest.to_string()));
+    }
+    if fresh(&cache) {
+        return found;
+    }
+
+    let shared = Arc::clone(&found);
+    // Failing to spawn is not worth taking the dashboard down for; without a
+    // thread there is simply no check.
+    let _ = std::thread::Builder::new()
+        .name("mirador-update".into())
+        .spawn(move || {
+            let Ok(latest) = fetch(ENDPOINT) else {
+                return;
+            };
+            // Written even when it matches what is installed: the point of the
+            // cache is to stop asking, and "nothing new" is an answer.
+            let _ = write_cache(
+                &path,
+                &Cache {
+                    latest: Some(latest.clone()),
+                    checked_at: Some(now_seconds()),
+                },
+            );
+            if is_newer(&latest, current()) {
+                set(&shared, Some(latest));
+            }
+        });
+
+    found
+}
+
+/// Whether the environment forbids this regardless of the config.
+///
+/// `DO_NOT_TRACK` is the cross-tool convention; `NO_UPDATE_CHECK` is the
+/// specific one. Either being set to anything other than `0` is a no.
+fn opted_out() -> bool {
+    opted_out_given(|key| std::env::var(key).ok())
+}
+
+/// The decision, with the environment as a parameter.
+///
+/// Split out because `std::env::set_var` is `unsafe` in the 2024 edition and
+/// this crate forbids `unsafe` outright — but also because a test that mutates
+/// process-global state leaks into every test that runs after it.
+fn opted_out_given(read: impl Fn(&str) -> Option<String>) -> bool {
+    ["NO_UPDATE_CHECK", "DO_NOT_TRACK"]
+        .iter()
+        .filter_map(|key| read(key))
+        .any(|value| !value.is_empty() && value != "0")
+}
+
+fn set(slot: &Found, value: Option<String>) {
+    match slot.lock() {
+        Ok(mut guard) => *guard = value,
+        Err(poisoned) => *poisoned.into_inner() = value,
+    }
+}
+
+/// The version this binary was built as.
+fn current() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+fn now_seconds() -> i64 {
+    jiff::Timestamp::now().as_second()
+}
+
+fn fresh(cache: &Cache) -> bool {
+    let Some(checked_at) = cache.checked_at else {
+        return false;
+    };
+    let age = now_seconds().saturating_sub(checked_at);
+    // A negative age means the clock moved; treat it as stale rather than as
+    // valid until the far future.
+    (0..CACHE_FOR.as_secs().cast_signed()).contains(&age)
+}
+
+fn read_cache(path: &Path) -> Cache {
+    // Every failure is the same failure: there is no usable cache, so check.
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| toml::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+fn write_cache(path: &Path, cache: &Cache) -> Result<()> {
+    let body = toml::to_string_pretty(cache)?;
+    crate::store::write_atomic(
+        path,
+        &format!(
+            "# Written by mirador's update check, which is off unless\n\
+             # `[general].check_for_updates` turns it on. Safe to delete.\n\n{body}"
+        ),
+    )
+}
+
+/// Ask crates.io for the newest stable version.
+fn fetch(url: &str) -> Result<String> {
+    #[derive(Deserialize)]
+    struct Body {
+        #[serde(rename = "crate")]
+        krate: Krate,
+    }
+    #[derive(Deserialize)]
+    struct Krate {
+        max_stable_version: Option<String>,
+        max_version: Option<String>,
+    }
+
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(HTTP_TIMEOUT))
+        // crates.io asks for a user agent that says who is calling and how to
+        // get in touch. Honouring that is the price of using the API politely.
+        .user_agent(concat!(
+            "mirador/",
+            env!("CARGO_PKG_VERSION"),
+            " (update check; https://github.com/jchultarsky/mirador)"
+        ))
+        .build()
+        .new_agent();
+
+    // Read as text then parse, matching how the other two network paths in this
+    // crate do it — it keeps the JSON handling in one crate rather than two.
+    let text = agent.get(url).call()?.body_mut().read_to_string()?;
+    let body: Body = serde_json::from_str(&text)?;
+    // `max_stable_version` skips pre-releases, which is what someone running a
+    // release build wants to hear about. It is absent on a crate that has only
+    // ever published a pre-release, hence the fallback.
+    body.krate
+        .max_stable_version
+        .or(body.krate.max_version)
+        .ok_or_else(|| anyhow::anyhow!("no version in the response"))
+}
+
+/// Whether `candidate` is a later release than `installed`.
+///
+/// Compares `major.minor.patch` numerically. Anything carrying a pre-release or
+/// build suffix is treated as **not** newer: mirador only ever publishes plain
+/// releases, `max_stable_version` excludes pre-releases anyway, and refusing to
+/// guess is better than telling someone `0.8.0-rc.1` supersedes `0.8.0`.
+///
+/// This is deliberately not the `semver` crate. It is one comparison of three
+/// integers, and the dependency would be the fourth-largest thing in the tree
+/// for it.
+fn is_newer(candidate: &str, installed: &str) -> bool {
+    let (Some(candidate), Some(installed)) = (triple(candidate), triple(installed)) else {
+        return false;
+    };
+    candidate > installed
+}
+
+fn triple(version: &str) -> Option<(u64, u64, u64)> {
+    let version = version.trim();
+    if version.contains(['-', '+']) {
+        return None;
+    }
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    // A fourth component is not a version this understands.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// Where the cache lives, beside the other files mirador owns.
+pub fn default_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("update-check.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_higher_version_in_any_position_is_newer() {
+        assert!(is_newer("0.7.2", "0.7.1"));
+        assert!(is_newer("0.8.0", "0.7.9"));
+        assert!(is_newer("1.0.0", "0.99.99"));
+        assert!(is_newer("0.10.0", "0.9.0"), "10 is not less than 9");
+    }
+
+    #[test]
+    fn the_same_or_an_older_version_is_not_newer() {
+        assert!(!is_newer("0.7.1", "0.7.1"));
+        assert!(!is_newer("0.7.0", "0.7.1"));
+        assert!(!is_newer("0.6.9", "0.7.0"));
+    }
+
+    #[test]
+    fn a_prerelease_never_counts_as_newer() {
+        // Telling someone that 0.8.0-rc.1 supersedes their 0.8.0 would be
+        // wrong, and telling them it supersedes 0.7.0 is a judgement this does
+        // not have the information to make.
+        assert!(!is_newer("0.8.0-rc.1", "0.7.0"));
+        assert!(!is_newer("0.8.0-rc.1", "0.8.0"));
+        assert!(!is_newer("0.8.0+build.5", "0.7.0"));
+    }
+
+    #[test]
+    fn an_unparseable_version_is_never_newer() {
+        // A changed API, a truncated reply, a proxy serving an error page. None
+        // of them should put a notice on screen.
+        for junk in ["", "latest", "0.7", "0.7.1.2", "v0.7.2", "not a version"] {
+            assert!(!is_newer(junk, "0.7.1"), "{junk:?} was treated as newer");
+        }
+        assert!(!is_newer("0.7.2", "garbage"));
+    }
+
+    #[test]
+    fn a_cache_is_fresh_for_a_day_and_then_is_not() {
+        let at = |seconds_ago: i64| Cache {
+            latest: Some("0.7.1".into()),
+            checked_at: Some(now_seconds() - seconds_ago),
+        };
+        assert!(fresh(&at(0)));
+        assert!(fresh(&at(60 * 60 * 23)));
+        assert!(!fresh(&at(60 * 60 * 25)));
+        assert!(!fresh(&Cache::default()), "never checked is not fresh");
+    }
+
+    #[test]
+    fn a_clock_that_moved_backwards_makes_the_cache_stale_rather_than_eternal() {
+        // Stamped in the future: without the lower bound this reads as fresh
+        // until the clock catches up, which could be indefinitely.
+        let future = Cache {
+            latest: Some("0.7.1".into()),
+            checked_at: Some(now_seconds() + 60 * 60 * 24 * 365),
+        };
+        assert!(!fresh(&future));
+    }
+
+    #[test]
+    fn the_environment_can_veto_the_config() {
+        let env = |set: &'static str, value: &'static str| {
+            move |key: &str| (key == set).then(|| value.to_string())
+        };
+
+        for key in ["NO_UPDATE_CHECK", "DO_NOT_TRACK"] {
+            assert!(opted_out_given(env(key, "1")), "{key} was ignored");
+            assert!(opted_out_given(env(key, "true")), "{key}=true was ignored");
+            // `0` and empty are the conventional ways to say "not set" without
+            // unsetting; honouring them keeps a shell profile from opting
+            // someone out permanently by accident.
+            assert!(
+                !opted_out_given(env(key, "0")),
+                "{key}=0 should not opt out"
+            );
+            assert!(!opted_out_given(env(key, "")), "{key}= should not opt out");
+        }
+        assert!(!opted_out_given(|_| None), "nothing set is not opted out");
+    }
+
+    #[test]
+    fn nothing_is_spawned_when_the_check_is_off() {
+        // The property that keeps the README's promise true: with the setting
+        // off there is no thread, no request, and nothing to report.
+        let found = spawn(false, Some(PathBuf::from("/nonexistent/update-check.toml")));
+        assert!(found.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn an_unreadable_cache_is_treated_as_no_cache() {
+        assert!(
+            read_cache(Path::new("/nonexistent/nope.toml"))
+                .checked_at
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_cache_survives_a_round_trip() {
+        let dir = std::env::temp_dir().join(format!("mirador-update-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = default_path(&dir);
+
+        let written = Cache {
+            latest: Some("9.9.9".into()),
+            checked_at: Some(now_seconds()),
+        };
+        write_cache(&path, &written).unwrap();
+        let read = read_cache(&path);
+        assert_eq!(read.latest.as_deref(), Some("9.9.9"));
+        assert!(fresh(&read));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## The update check

`[general].check_for_updates = true` asks crates.io, at most once a day, whether a newer mirador exists, and says so once in the status bar if it does.

**Off by default, and that is the design rather than a hedge.** Every other request mirador makes is one a panel you placed needs. This one would be on mirador's own behalf, and would tell a third party your IP address and that you run this program on a schedule you did not pick. Small — and exactly what "nothing phones home" was promising, so it is yours to turn on.

When on: nothing identifying is sent, the answer is cached in `update-check.toml` beside your tasks so a day of restarts costs one request, failure is silent, and the notice retires on your first keypress. `NO_UPDATE_CHECK=1` or `DO_NOT_TRACK=1` overrides the config.

crates.io rather than the GitHub API — no token, and no 60/hr-per-IP limit shared with every other tool on the machine. No `semver` dependency: three integers is the whole requirement, and a pre-release is never "newer" under that rule, which is right here.

## The disclosure

mirador is written with heavy AI assistance. The README now says so, rather than leaving it to be inferred from the commit history.

## Verified

Under tmux, not just in tests:

- off by default → no cache file, no thread
- on → fetches, caches `latest = "0.7.1"`, shows nothing (that is what is installed)
- newer version cached → `mirador 9.9.9 is out   mirador-update` in the status bar, gone after one keypress

482 tests pass; clippy, fmt, rustdoc and `cargo publish --dry-run` are all silent. No test touches the network.