### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-07-27
 
 ### Added
 
@@ -672,7 +672,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/jchultarsky/mirador/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/jchultarsky/mirador/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jchultarsky/mirador/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jchultarsky/mirador/compare/v0.5.2...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog date for 0.8.0. `v0.8.0` is tagged and the release build is running.

### Added

- **An optional update check.** `[general].check_for_updates = true` asks crates.io, at most once a day, whether a newer mirador exists. Off by default — every other request mirador makes is one a panel needs; this one would be on mirador's own behalf.
- **The README now says how mirador is built** — with heavy AI assistance.