### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-07-27
 
 ### Added
 
@@ -720,7 +720,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/jchultarsky/mirador/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jchultarsky/mirador/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/jchultarsky/mirador/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jchultarsky/mirador/compare/v0.6.0...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog date.

### Added

- **Arrange mode** — `m`, then arrows. Panels move as you press; `Enter` keeps, `Esc` reverts. Past the outer edge a panel takes a row of its own, so the row count is a gesture rather than a shipped guess.
- **`Ctrl+arrow` resize is discoverable** — it had shipped and only ever appeared in the `?` overlay.
- **Panels can ask for a setting** — agenda file (`f`), weather location (`L`), world clocks (`a`/`d`), with `Tab` completion. Weather location closes the oldest item on the open-work list.
- **World clocks are a data file** (`zones.toml`), like the watchlist.

### Fixed

- A narrow panel no longer eats the bracket closing its title.
- Reordering panels in the config actually works — it used to fail silently.

Not tagged yet. The tag goes on the squashed commit this merge produces, which is the thing 0.8.0 got wrong.