### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-07-27
+
+### Changed
+
+- **Arrange mode says that rows can be opened.** The legend read
+  `↑↓ move rows`, which a reader reasonably took to mean "move between the rows
+  you have" — and then asked how to make a new one, which the mode had been
+  able to do all along. It now reads `↑↓ at the edge opens a new row`, paid for
+  by collapsing the two movement hints into one: which arrow goes which way is
+  obvious the moment you press it, because the panels move.
+
+  The legend also drops hints whole rather than clipping them when the terminal
+  is narrow, keeping `Enter keep` and `Esc cancel` longest. Half a hint reads as
+  a rendering fault; a missing one reads as a narrow terminal, which is what it
+  is.
+
+- The README now answers "how do I manage rows" directly instead of leaving it
+  inside a sentence about moving panels.
+
 ## [0.9.0] - 2026-07-27
 
 ### Added
@@ -720,7 +739,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/jchultarsky/mirador/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/jchultarsky/mirador/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jchultarsky/mirador/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/jchultarsky/mirador/compare/v0.7.0...v0.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -541,9 +541,20 @@ rather than a cap on what a wider panel can draw.
 
 Press `m`, then move the focused panel with the arrow keys. `←` and `→` swap it
 with its neighbour; `↑` and `↓` move it between rows, landing it under wherever
-it already was rather than at the same index. Push it past the top or bottom
-edge and it gets a row of its own — which is how you end up with four rows
-without opening an editor. The last panel out of a row closes that row.
+it already was rather than at the same index.
+
+**Rows are managed through the panels, not separately.** There is no "add row"
+command because there is nothing useful an empty row could do:
+
+- **To open a row**, push a panel past the top or bottom edge. Hold `↑` and the
+  panel climbs through the rows; press it once more from the top row and the
+  panel takes a row of its own. The height comes out of the row it left, so
+  nothing else on screen resizes.
+- **To close one**, move its last panel into a neighbour. The row closes behind
+  it and hands its height to the row that took the panel.
+
+A panel that already has a row to itself will not take another, so holding `↑`
+at the edge stops rather than spawning a row per keypress.
 
 The panels themselves move as you press, so what you see is what you will get.
 `Enter` keeps the arrangement and `Esc` puts everything back exactly as it was.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1318,13 +1318,31 @@ impl App {
                     .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),
             )];
+            // Which arrow moves along the row and which moves between rows is
+            // self-evident the moment you press one, because the panels move.
+            // What is *not* evident is that there is a row past the last one,
+            // so the width saved by collapsing the first two entries into
+            // "move" is spent saying so. Someone had to ask.
+            //
+            // Ordered so that the two that matter most survive a narrow
+            // terminal: knowing how to get out of a mode beats knowing every
+            // trick inside it.
+            let mut used = crate::grid::display_width(" ARRANGE");
             for (key, action) in [
-                ("←→", "move in row"),
-                ("↑↓", "move rows"),
-                ("Ctrl+arrows", "resize"),
+                ("←→↑↓", "move"),
                 ("Enter", "keep"),
                 ("Esc", "cancel"),
+                ("Ctrl+arrows", "resize"),
+                ("↑↓ at the edge", "opens a new row"),
             ] {
+                // Dropped whole rather than clipped: half a hint reads as a
+                // rendering fault, where a missing one just reads as a narrow
+                // terminal.
+                let width = 3 + crate::grid::display_width(key) + 1 + action.len();
+                if used + width > usize::from(area.width) {
+                    break;
+                }
+                used += width;
                 spans.push(Span::styled("   ", muted));
                 spans.push(Span::styled(key, key_style));
                 spans.push(Span::styled(format!(" {action}"), muted));
@@ -1626,6 +1644,21 @@ mod tests {
         }
     }
 
+    /// The status bar as drawn at `width`, with styling dropped.
+    fn status_bar_at(app: &mut App, width: u16) -> String {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut terminal = Terminal::new(TestBackend::new(width, 1)).expect("backend");
+        terminal
+            .draw(|frame| app.render_status_bar(frame, Rect::new(0, 0, width, 1)))
+            .expect("draws");
+        let buffer = terminal.backend().buffer();
+        (0..width)
+            .map(|x| buffer[(x, 0)].symbol())
+            .collect::<String>()
+    }
+
     fn widths(app: &App) -> Vec<u16> {
         app.config.layout.rows[0]
             .panels
@@ -1723,6 +1756,42 @@ mod tests {
     /// reason the resize keys are claimed: the calendar binds plain arrows and
     /// does not inspect modifiers, so a left arrow meant to move a panel would
     /// scroll a month instead.
+    /// The mode has to say that there is a row past the last one. Someone read
+    /// `↑↓ move rows`, took it to mean "move between the rows that exist", and
+    /// asked how to make a new one — which the mode had done all along.
+    #[test]
+    fn the_arrange_legend_says_a_row_can_be_opened() {
+        let mut app = App::new(resizable()).expect("builds");
+        app.handle_key(KeyEvent::from(KeyCode::Char('m')));
+
+        let bar = status_bar_at(&mut app, 110);
+        assert!(bar.contains("ARRANGE"), "the mode names itself: {bar}");
+        assert!(
+            bar.contains("opens a new row"),
+            "and says rows can be opened: {bar}"
+        );
+    }
+
+    /// A terminal too narrow for every hint keeps the ones that get you out.
+    /// Half a hint reads as a rendering fault; a missing one reads as a narrow
+    /// terminal, which is what it is.
+    #[test]
+    fn a_narrow_arrange_legend_drops_whole_hints_and_keeps_the_way_out() {
+        let mut app = App::new(resizable()).expect("builds");
+        app.handle_key(KeyEvent::from(KeyCode::Char('m')));
+
+        for width in 40..110u16 {
+            let bar = status_bar_at(&mut app, width);
+            assert!(
+                crate::grid::display_width(bar.trim_end()) <= usize::from(width),
+                "the bar overflowed at {width}: {bar}"
+            );
+            if width >= 46 {
+                assert!(bar.contains("Esc cancel"), "no way out at {width}: {bar}");
+            }
+        }
+    }
+
     #[test]
     fn arrange_claims_the_arrows_the_focused_panel_would_otherwise_take() {
         let mut app = App::new(resizable()).expect("builds");


### PR DESCRIPTION
The arrange legend read `↑↓ move rows`, which reads as "move between the rows you have". A user moved panels around happily and then asked how to create a row — which the mode had done all along, by pushing a panel past the edge.

It now reads `↑↓ at the edge opens a new row`, paid for by collapsing the two movement hints into `←→↑↓ move`. Which arrow goes which way is obvious the moment you press one; that there is a row past the last one is not.

The legend also drops hints whole rather than clipping them when the terminal is narrow, keeping `Enter keep` and `Esc cancel` longest.

Checked at three widths: 140 and 100 show everything, 70 drops the new-row hint and keeps the way out.

Docs-and-wording only — no behaviour changed.