### PR TITLE
Add named themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Named themes.** `theme = "high-contrast"` in place of the `[theme]` table.
+  Four ship inside the binary — `default`, `default-light`, `high-contrast` and
+  `ansi` — and anything in `themes/<name>.toml` beside your config is found
+  first, so a bundled theme can be replaced without renaming it.
+
+  A theme file may `inherits` another, so a variant is the lines that differ
+  rather than a copy of all eighteen keys, and may define a `[palette]` of named
+  colours. Redefining a palette entry in a child recolours the keys its *parent*
+  set with it.
+
+  The same key does both jobs and TOML decides which: a quoted string is a name,
+  a table is colours written out. Your existing `[theme]` table keeps working
+  and keeps its error messages — the misspelled-key report and the
+  `--migrate-config` hint for the pre-0.1.0 `rx`/`tx` keys both survive, which
+  an untagged enum would have flattened into "data did not match any variant".
+
+  Not built, deliberately: dotted-scope fallback (sized for Helix's hundreds of
+  syntax scopes, where mirador has thirteen flat semantic keys) and per-key
+  style objects with fg/bg/modifiers (every theme read takes a flat colour, and
+  emphasis belongs to the widget that knows what it is emphasising).
+
+- **A theme file with its colour keys after `[palette]` is refused by name.**
+  TOML puts every key following a table header *inside* that table, so those
+  keys set nothing — without failing, without a typo, and with the theme quietly
+  coming out as the defaults. mirador's own `default.toml` was written that way
+  during development and the test comparing it against the built-in default
+  passed, because a file that sets nothing resolves to exactly the default.
+
 ## [0.9.1] - 2026-07-27
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ grid.rs      shared column grid with named headers
 chart.rs     braille graphs + baked colour gradients
 glyphs.rs    block numerals, bold-uppercase labels, weather art
 theme.rs     colours and gradient stops
+themes.rs    `theme = "name"`: bundled themes, inherits, palettes
 config/      mod.rs: paths, loading, validation; widgets.rs: one settings
              struct per panel; layout.rs: the grid
 picker.rs    the `w` dialog — owns its cursor, returns an Action to the shell
@@ -202,7 +203,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 214 of them, including the ones mirador
+    trip through `toml` discards all 230 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -362,30 +363,44 @@ costs exactly one request. **Requires a browser `User-Agent`** or you get HTTP
 - `parse_chart` is split from the HTTP call so it is tested against captured
   JSON. **No test in this repo touches the network** — keep it that way.
 
-## Named themes — decided, not yet built
+## Named themes — built
 
-The `[theme]` table itself **is** built and shipping: every colour the dashboard
-draws with is configurable, gradients included, with names, hex and 256-colour
-indices accepted and bad values rejected at parse time. What is not built is
-*named* themes — `theme = "nord"` and a themes directory.
+`theme = "name"` resolves through `themes.rs`. Four themes are `include_str!`-
+baked (`default`, `default-light`, `high-contrast`, `ansi`) and anything in
+`<config>/mirador/themes/<name>.toml` is found first, so a bundled theme can be
+replaced without renaming it. `inherits` chains with cycle detection; `[palette]`
+names colours once, and a child redefining a palette entry recolours the keys
+its *parent* set with it — which is why palettes are merged separately from the
+colour keys rather than as each document is read.
 
-Follow Helix. `theme = "name"` plus theme files in
-`<config>/mirador/themes/<name>.toml`, with:
+**Two items from the original design were deliberately not built**, and the
+reasons matter more than the decision:
 
-1. **Dotted-scope fallback** (`ui.border.focused` → `ui.border` → `ui`) via
-   `iter::successors`. ~15 lines, makes a two-line theme valid, and makes
-   `border_focused` stop being a special case.
-2. **`[palette]`** with `"default"` → `Color::Reset` and the 16 ANSI names
-   pre-seeded. Literal colour names live *only* in the palette; every other key
-   is semantic.
-3. **`inherits`** with cycle detection and depth-2 palette merge.
-4. Full style objects (fg/bg/modifiers).
+- **Dotted-scope fallback** (`ui.border.focused` → `ui.border` → `ui`). Helix
+  needs it because it has hundreds of syntax scopes and no theme can name them
+  all. mirador has thirteen flat semantic keys that a theme can reasonably set
+  in full, and `inherits` already covers the rest. The stated benefit — that it
+  "makes `border_focused` stop being a special case" — is one field.
+- **Full style objects** (fg/bg/modifiers per key). All ~240 theme reads take a
+  flat `Color`, nothing wants a themed background (invariant 8), and bold and
+  reversed are decided by the widget that knows what it is emphasising.
 
-Ship bundled: `ansi` (ANSI names only, safest default), `default` (true-colour
-dark, `inherits = "ansi"`), `default-light`, `high-contrast`. Nobody downsamples
-colour — the universal strategy is a separate low-colour theme picked on
-`COLORTERM`. Keep a compat shim for one release (TOML type distinguishes an
-inline `[theme]` table from a `theme = "name"` string).
+Both are additions if wanted, not corrections.
+
+**The compat shim is a hand-written visitor, not `#[serde(untagged)]`,** and it
+has to stay that way. An untagged enum reports "data did not match any variant"
+for every failure, which would destroy both the misspelled-key report and the
+`--migrate-config` hint for the pre-0.1.0 `rx`/`tx` keys. The map arm delegates
+to the derived impl, so all of that survives; two tests pin it.
+
+**The TOML ordering trap is real and is guarded.** Colour keys written *after*
+`[palette]` land inside it and set nothing — nothing is misspelled, nothing
+fails to parse, and the theme silently comes out as the defaults. The shipped
+`default.toml` was written that way and the test comparing it against
+`Theme::default()` **passed**, because a file that sets nothing resolves to
+exactly the default. Hence two things: `check_palette_ordering` refuses such a
+file by name, and the drift test is paired with one that asserts a standalone
+theme *sets every key*, which is the property that can actually fail.
 
 ## Recently settled, so it is not re-litigated
 
@@ -420,11 +435,16 @@ The mode's legend names both keys, so there is nothing to guess.
 Only things that are actually open. A "decided and built" entry in a list called
 open work is how the list stops being read.
 
-1. **Named themes**, per the section above. The `[theme]` table is built; the
-   `theme = "nord"` layer over it is not.
-2. **"What changed since I last looked" markers.**
-3. **A single "is anything on fire" signal.** Named as a gap alongside the other
-   two and then quietly dropped from this list; it is back.
+1. **"What changed since I last looked" markers.** No design yet.
+2. **A single "is anything on fire" signal.** No design yet. Named as a gap
+   alongside the other two and then quietly dropped from this list; it is back.
+
+Both of these are the last two gaps from the original four-questions analysis,
+and both are structurally attention-grabbing mechanisms — which is the thing
+the unread-email-count rejection was about. Whatever they become has to earn
+its way past that rule rather than around it.
+
+Named themes sat at the top of this list and is built; see the section above.
 
 Editing `[weather].location` from the panel sat at the top of this list and is
 built — `prompt.rs`, reached with `L`. The same prompt does the agenda file

--- a/README.md
+++ b/README.md
@@ -690,12 +690,60 @@ working; copying a value off the dashboard needs the terminal's override
 modifier, which is Shift in most terminals and Option in macOS Terminal and
 iTerm2. Set `[general].mouse = false` to keep ordinary selection instead.
 
-### Colours
+### Colours and themes
 
 Every colour the dashboard draws with lives under `[theme]`, and the graph
 gradients under `[theme.rx_gradient]` and friends. A colour accepts a name
 (`red`, `light-blue`), a hex string (`#ff8800`), or a 256-colour index (`12`).
 `reset` uses your terminal's own default.
+
+You can also name a theme instead, and drop the table entirely:
+
+```toml
+theme = "high-contrast"
+```
+
+Four ship inside the binary:
+
+| Theme | For |
+| --- | --- |
+| `default` | The shipped look — true colour, dark background |
+| `default-light` | Light backgrounds. Not the dark theme inverted: the hues are deepened so they keep their contrast on paper-coloured terminals |
+| `high-contrast` | Bright rooms, projectors, low vision. `muted` is deliberately *not* dim — faint grey is the first thing to vanish on a washed-out screen, so de-emphasis is carried by hue instead |
+| `ansi` | The sixteen ANSI colours and nothing else, so it follows whatever palette your terminal already uses and works with no true-colour support |
+
+The same key does both jobs, and TOML decides which: a quoted string is a theme
+name, a table is colours written out. You cannot do both, because one key cannot
+be both types.
+
+#### Writing your own
+
+Put `<name>.toml` in `themes/` beside your config — `mirador --config-path` will
+tell you where that is. A file there wins over a bundled theme of the same name,
+so you can replace `default` without renaming it.
+
+```toml
+# themes/nord.toml
+inherits = "ansi"
+
+accent         = "frost"
+border_focused = "frost"
+title          = "frost"
+
+[palette]
+frost = "#88c0d0"
+```
+
+`inherits` starts from another theme, so a variant is the handful of lines that
+differ rather than a copy of all eighteen keys. `[palette]` names colours once,
+after which any key can use the name — and redefining a palette entry in a child
+theme recolours the keys its *parent* set with it.
+
+**The colour keys have to come before `[palette]`, not after.** In TOML every
+key following a table header belongs to that table, so keys written underneath
+`[palette]` end up inside it and set nothing. mirador refuses a theme file that
+does this and says which keys are affected, because the alternative is a theme
+that quietly comes out as the defaults.
 
 ### When something is wrong with your config
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -89,6 +89,22 @@ rows = [
 # The shipped palette is an aged instrument panel: brass for the instruments,
 # verdigris for engraved labels, slate for chrome. Body text is `reset` so it
 # inherits whatever foreground you have already tuned your terminal to.
+#
+# There are two ways to write this, and they use the same key.
+#
+# Name a theme, and this whole table goes away:
+#
+#     theme = "high-contrast"
+#
+# Four ship inside the binary — `default` (this), `default-light`,
+# `high-contrast` and `ansi` — and anything in themes/<name>.toml beside this
+# file is found first, so a bundled theme can be replaced without renaming it.
+# A theme file may `inherits` another and may define a `[palette]` of named
+# colours; see the README.
+#
+# Or keep the table below and set colours here. Naming a theme and writing the
+# table are mutually exclusive: TOML will not let one key be both a string and
+# a table, which is exactly the distinction being used.
 # ---------------------------------------------------------------------------
 [theme]
 border         = "#3a3a3a"   # frame of an unfocused panel

--- a/assets/themes/ansi.toml
+++ b/assets/themes/ansi.toml
@@ -1,0 +1,48 @@
+# The safest theme there is: the sixteen ANSI colours and nothing else.
+#
+# Every one of them is whatever your terminal says it is, so this follows a
+# palette you have already chosen and works on a console with no true-colour
+# support at all. It is also the theme to inherit from when you want a starting
+# point that cannot look wrong anywhere.
+#
+# Nobody downsamples true colour at runtime — the universal strategy is a
+# separate low-colour theme, and this is it.
+
+border         = "dark-gray"
+border_focused = "yellow"
+rule           = "dark-gray"
+title          = "yellow"
+text           = "reset"
+muted          = "gray"
+label          = "cyan"
+accent         = "yellow"
+key            = "yellow"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "dark-gray"
+
+[cpu_gradient]
+start = "green"
+mid   = "yellow"
+end   = "red"
+
+[rx_gradient]
+start = "green"
+mid   = "green"
+end   = "light-green"
+
+[tx_gradient]
+start = "magenta"
+mid   = "magenta"
+end   = "light-magenta"
+
+[gain_gradient]
+start = "green"
+mid   = "green"
+end   = "light-green"
+
+[loss_gradient]
+start = "red"
+mid   = "red"
+end   = "light-red"

--- a/assets/themes/default-light.toml
+++ b/assets/themes/default-light.toml
@@ -1,0 +1,60 @@
+# The instrument panel in daylight.
+#
+# Not the dark theme with the colours flipped: on a light background the same
+# hues have to go *darker* to keep their contrast, and the greys invert
+# entirely. Brass in particular becomes unreadable if it is merely reused, so it
+# is deepened to a bronze.
+#
+# `text` stays `reset` for the same reason it does everywhere — your terminal's
+# own foreground is already the right one for your background.
+
+border         = "paper"
+border_focused = "bronze"
+rule           = "paper"
+title          = "bronze"
+text           = "reset"
+muted          = "ink"
+label          = "teal"
+accent         = "bronze"
+key            = "bronze"
+success        = "moss"
+warning        = "amber"
+error          = "rust"
+track          = "pencil"
+
+[palette]
+bronze    = "#875f00"
+teal      = "#005f5f"
+paper     = "#c6c6c6"
+pencil    = "#949494"
+ink       = "#585858"
+moss      = "#5f8700"
+amber     = "#af5f00"
+rust      = "#af0000"
+# The ramps start light rather than dark, so an idle graph recedes *into* a
+# pale background instead of standing out as a dark smudge on it.
+
+[cpu_gradient]
+start = "#afd7af"
+mid   = "#af8700"
+end   = "#af0000"
+
+[rx_gradient]
+start = "#afd7af"
+mid   = "#5f8700"
+end   = "#005f00"
+
+[tx_gradient]
+start = "#d7afd7"
+mid   = "#875f87"
+end   = "#5f005f"
+
+[gain_gradient]
+start = "#afd7af"
+mid   = "#5f8700"
+end   = "#005f00"
+
+[loss_gradient]
+start = "#d7afaf"
+mid   = "#af5f5f"
+end   = "#870000"

--- a/assets/themes/default.toml
+++ b/assets/themes/default.toml
@@ -1,0 +1,60 @@
+# mirador's shipped look: an aged instrument panel.
+#
+# Brass for the instruments, verdigris for engraved labels, slate for chrome.
+# `text` is `reset` on purpose — body text inherits whatever foreground you have
+# already tuned your terminal to, rather than fighting it.
+#
+# This file and `Theme::default()` in src/theme.rs describe the same thing and
+# are reached by different routes: a config with no `theme` key takes the Rust
+# one, `theme = "default"` takes this. A test pins them together.
+
+border         = "slate"
+border_focused = "brass"
+rule           = "graphite"
+title          = "brass"
+text           = "reset"
+muted          = "ash"
+label          = "verdigris"
+accent         = "brass"
+key            = "brass"
+success        = "moss"
+warning        = "amber"
+error          = "rust"
+track          = "graphite"
+
+[palette]
+brass      = "#d7af87"
+verdigris  = "#5f8787"
+slate      = "#3a3a3a"
+graphite   = "#303030"
+ash        = "#707070"
+moss       = "#87af5f"
+amber      = "#d7af5f"
+rust       = "#d75f5f"
+# Ramps run dark and desaturated at the cool end to bright at the hot one, so an
+# idle graph recedes and a busy one comes forward without any per-frame decision.
+
+[cpu_gradient]
+start = "#3f5f4f"
+mid   = "#d7af5f"
+end   = "#d75f5f"
+
+[rx_gradient]
+start = "#2f4f3f"
+mid   = "#6f9f5f"
+end   = "#afd787"
+
+[tx_gradient]
+start = "#4a3a5a"
+mid   = "#8a6f9f"
+end   = "#c7afd7"
+
+[gain_gradient]
+start = "#3f5f3f"
+mid   = "#6f9f5f"
+end   = "#afd787"
+
+[loss_gradient]
+start = "#5f3a3a"
+mid   = "#af5f5f"
+end   = "#d78787"

--- a/assets/themes/high-contrast.toml
+++ b/assets/themes/high-contrast.toml
@@ -1,0 +1,31 @@
+# Maximum separation, for bright rooms, projectors and low-vision use.
+#
+# Inherits `ansi`, so anything not named below is still a colour your terminal
+# has agreed to — the point of this theme is contrast, and reaching for
+# true-colour hex to get it would trade away the one thing ansi guarantees.
+#
+# The deliberate difference from every other theme: `muted` is not muted. Dim
+# grey is the first thing to disappear on a washed-out screen, so the
+# de-emphasised text here is merely a different colour rather than a fainter
+# one, and emphasis is carried by weight and case instead.
+
+inherits = "ansi"
+
+border         = "gray"
+border_focused = "white"
+rule           = "gray"
+title          = "white"
+text           = "white"
+muted          = "light-cyan"
+label          = "light-cyan"
+accent         = "light-yellow"
+key            = "light-yellow"
+success        = "light-green"
+warning        = "light-yellow"
+error          = "light-red"
+track          = "gray"
+
+[cpu_gradient]
+start = "light-green"
+mid   = "light-yellow"
+end   = "light-red"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,6 +54,13 @@ pub use widgets::{
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub general: General,
+    /// The resolved theme.
+    ///
+    /// Holds whatever `[theme]` said, or — when the config named one with
+    /// `theme = "nord"` — a placeholder carrying only that name until
+    /// [`Config::load`] resolves it. Nothing but `load` should ever see the
+    /// placeholder; `--print-config` and the tests go through it too.
+    #[serde(deserialize_with = "crate::theme::de_theme")]
     pub theme: Theme,
     pub layout: Layout,
     pub clocks: ClocksConfig,
@@ -130,9 +137,24 @@ impl Config {
 
         let raw = std::fs::read_to_string(&path)
             .with_context(|| format!("reading config {}", path.display()))?;
-        let config: Self = toml::from_str(&raw).map_err(|e| stale_config_hint(&e, &path))?;
+        let mut config: Self = toml::from_str(&raw).map_err(|e| stale_config_hint(&e, &path))?;
+        config.resolve_theme(&path)?;
         config.validate()?;
         Ok((config, path))
+    }
+
+    /// Turn `theme = "name"` into the colours it stands for.
+    ///
+    /// Separate from deserializing because that must not touch the filesystem,
+    /// and because the themes directory is not known until the config's own
+    /// path is — a `--config` somewhere unusual looks for its themes beside it.
+    fn resolve_theme(&mut self, config_path: &Path) -> Result<()> {
+        let Some(name) = self.theme.name.clone() else {
+            return Ok(());
+        };
+        let dir = crate::themes::user_dir(config_path);
+        self.theme = crate::themes::resolve(&name, dir.as_deref())?;
+        Ok(())
     }
 
     /// Platform-appropriate config location.

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -804,7 +804,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 214;
+        const CITED: usize = 230;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod task;
 mod textarea;
 mod textfield;
 mod theme;
+mod themes;
 mod update;
 mod widgets;
 mod zones;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -141,6 +141,15 @@ pub struct Theme {
     pub gain_gradient: GradientStops,
     /// Ramp for a falling position.
     pub loss_gradient: GradientStops,
+
+    /// The theme this came from, when the config named one.
+    ///
+    /// Skipped by serde in both directions. On the way in it is set by
+    /// [`de_theme`] from a bare `theme = "name"`, which the derived field
+    /// deserializer never sees; on the way out it is not a colour and has no
+    /// business in a theme file.
+    #[serde(skip)]
+    pub name: Option<String>,
 }
 
 impl Default for Theme {
@@ -191,8 +200,48 @@ impl Default for Theme {
                 (0xaf, 0x5f, 0x5f),
                 (0xd7, 0x87, 0x87),
             ),
+            name: None,
         }
     }
+}
+
+/// Accept either `theme = "name"` or an inline `[theme]` table.
+///
+/// Written by hand rather than as an untagged enum, and the reason is the
+/// error messages. An untagged enum reports "data did not match any variant"
+/// for *every* failure, which would have thrown away both the misspelled-key
+/// report and the `--migrate-config` hint for the pre-0.1.0 `rx`/`tx` keys —
+/// two things this crate has tests for precisely because they were hard-won.
+/// Delegating the map arm to the derived impl keeps all of it.
+pub fn de_theme<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Theme, D::Error> {
+    use serde::de::value::MapAccessDeserializer;
+    use serde::de::{MapAccess, Visitor};
+
+    struct Either;
+
+    impl<'de> Visitor<'de> for Either {
+        type Value = Theme;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("a theme name in quotes, or a table of colours")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, name: &str) -> Result<Theme, E> {
+            // Resolved after the config is parsed: deserializing must not go
+            // looking for files, and the themes directory is not known until
+            // the config's own path is.
+            Ok(Theme {
+                name: Some(name.to_string()),
+                ..Theme::default()
+            })
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Theme, A::Error> {
+            Theme::deserialize(MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(Either)
 }
 
 /// Gradients baked once at startup, so drawing a frame is array lookups.
@@ -210,6 +259,91 @@ pub struct Gradients {
 }
 
 impl Theme {
+    /// Every key a theme file may set.
+    ///
+    /// Used to catch a TOML mistake that is otherwise silent — see
+    /// [`crate::themes`]. Kept honest by
+    /// `every_named_key_is_one_a_theme_file_can_actually_set`, which parses
+    /// each one on its own; an entry that is not a real field fails there.
+    /// A *field* missing from this list only weakens the check, so the cost of
+    /// forgetting one is a trap that goes unguarded rather than a wrong theme.
+    pub const KEYS: &'static [&'static str] = &[
+        "border",
+        "border_focused",
+        "rule",
+        "title",
+        "text",
+        "muted",
+        "label",
+        "accent",
+        "key",
+        "success",
+        "warning",
+        "error",
+        "track",
+        "cpu_gradient",
+        "rx_gradient",
+        "tx_gradient",
+        "gain_gradient",
+        "loss_gradient",
+    ];
+
+    /// Deserialize from an already-parsed table, for [`crate::themes`].
+    ///
+    /// Goes through the derived impl, so a theme file gets the same
+    /// unknown-key and bad-colour reporting a `[theme]` table has always had.
+    pub fn deserialize_table(table: toml::Table) -> anyhow::Result<Self> {
+        Ok(toml::Value::Table(table).try_into()?)
+    }
+
+    /// The same theme, tagged with where it came from.
+    #[must_use]
+    pub fn named(mut self, name: &str) -> Self {
+        self.name = Some(name.to_string());
+        self
+    }
+
+    /// Every colour, for comparing two themes without their names.
+    ///
+    /// A theme resolved from a file carries its name and the built-in one does
+    /// not, so comparing whole themes would report a difference that is not
+    /// about colour at all.
+    #[cfg(test)]
+    pub fn colours(&self) -> Vec<Color> {
+        let stops = |s: &GradientStops| {
+            vec![
+                s.start,
+                s.mid.unwrap_or(Color::Reset),
+                s.end.unwrap_or(Color::Reset),
+            ]
+        };
+        let mut out = vec![
+            self.border,
+            self.border_focused,
+            self.rule,
+            self.title,
+            self.text,
+            self.muted,
+            self.label,
+            self.accent,
+            self.key,
+            self.success,
+            self.warning,
+            self.error,
+            self.track,
+        ];
+        for gradient in [
+            &self.cpu_gradient,
+            &self.rx_gradient,
+            &self.tx_gradient,
+            &self.gain_gradient,
+            &self.loss_gradient,
+        ] {
+            out.extend(stops(gradient));
+        }
+        out
+    }
+
     /// Bake every configured ramp.
     pub fn gradients(&self) -> Gradients {
         Gradients {

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -1,0 +1,430 @@
+//! Resolving `theme = "name"` into a [`Theme`].
+//!
+//! The `[theme]` table has always let you set every colour. What it could not
+//! do is let you *keep* more than one set of them, or hand one to somebody
+//! else. A theme is a file now: four ship inside the binary, and anything in
+//! `<config>/mirador/themes/<name>.toml` is found first, so a bundled theme can
+//! be replaced without editing it in place.
+//!
+//! Two things make a theme file short. `inherits` names another theme to start
+//! from, so a variant is the handful of lines that differ rather than a copy of
+//! all eighteen keys. And `[palette]` names colours once — `brass = "#d7af87"` —
+//! after which any key can say `brass`, which is the difference between a theme
+//! you can adjust and a theme you have to search and replace.
+//!
+//! Deliberately *not* built, and worth saying why rather than leaving the next
+//! reader to wonder:
+//!
+//! - **Dotted-scope fallback** (`ui.border.focused` → `ui.border` → `ui`).
+//!   Helix needs it because it has hundreds of syntax scopes and no chance of
+//!   a theme naming them all. mirador has thirteen flat semantic keys, every
+//!   one of which a theme can reasonably set, and `inherits` already covers the
+//!   ones it does not. The machinery would be larger than the problem.
+//! - **Full style objects** (`fg`/`bg`/modifiers per key). Every one of the
+//!   ~240 places that reads a theme reads a flat `Color`, and nothing in the
+//!   dashboard wants a themed background: panels draw on the terminal's own,
+//!   which is what invariant 8 is about. Bold and reversed are decided by the
+//!   widget that knows what it is emphasising, not by the palette.
+//!
+//! Both are additions rather than corrections if they are ever wanted.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::theme::Theme;
+
+/// Themes compiled into the binary, so a fresh install has something to name.
+///
+/// `include_str!`-baked, with the same trap as `assets/default_config.toml`:
+/// editing one does nothing until you rebuild.
+const BUNDLED: &[(&str, &str)] = &[
+    ("default", include_str!("../assets/themes/default.toml")),
+    (
+        "default-light",
+        include_str!("../assets/themes/default-light.toml"),
+    ),
+    (
+        "high-contrast",
+        include_str!("../assets/themes/high-contrast.toml"),
+    ),
+    ("ansi", include_str!("../assets/themes/ansi.toml")),
+];
+
+/// How deep an `inherits` chain may go before it is treated as a mistake.
+///
+/// Cycles are caught by name, so this only bounds the honest-but-silly case.
+const MAX_DEPTH: usize = 16;
+
+/// The names that ship, for error messages.
+pub fn bundled_names() -> Vec<&'static str> {
+    BUNDLED.iter().map(|(name, _)| *name).collect()
+}
+
+/// Where a user's own themes live.
+pub fn user_dir(config_path: &Path) -> Option<PathBuf> {
+    config_path.parent().map(|dir| dir.join("themes"))
+}
+
+/// Resolve `name` into a theme, following `inherits` and applying `[palette]`.
+///
+/// `themes_dir` is searched before the bundled set, so a theme called `default`
+/// on disk wins — replacing a shipped theme should not require a different name
+/// for it.
+pub fn resolve(name: &str, themes_dir: Option<&Path>) -> Result<Theme> {
+    // Root first, so that each document in turn overwrites what it inherited.
+    let mut chain: Vec<toml::Table> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut next = Some(name.to_string());
+
+    while let Some(current) = next.take() {
+        if !seen.insert(current.clone()) {
+            bail!(
+                "theme `{current}` inherits from itself, directly or through \
+                 another theme. Break the loop by removing one `inherits`."
+            );
+        }
+        if chain.len() >= MAX_DEPTH {
+            bail!("theme `{name}` inherits through more than {MAX_DEPTH} files");
+        }
+
+        let mut table = read(&current, themes_dir)?;
+        check_palette_ordering(&current, &table)?;
+        if let Some(parent) = table.remove("inherits") {
+            let toml::Value::String(parent) = parent else {
+                bail!("`inherits` in theme `{current}` must be a theme name in quotes");
+            };
+            next = Some(parent);
+        }
+        chain.push(table);
+    }
+    chain.reverse();
+
+    // Merge, child over parent, keeping palettes separate until the end: a
+    // child that redefines `brass` must recolour the keys its *parent* set with
+    // it, which merging them together as we go would not do.
+    let mut palette: BTreeMap<String, toml::Value> = BTreeMap::new();
+    let mut merged = toml::Table::new();
+    for mut table in chain {
+        if let Some(toml::Value::Table(entries)) = table.remove("palette") {
+            palette.extend(entries);
+        }
+        merged.extend(table);
+    }
+
+    substitute(&mut merged, &palette);
+
+    Theme::deserialize_table(merged)
+        .with_context(|| format!("in theme `{name}`"))
+        .map(|theme| theme.named(name))
+}
+
+/// Read one theme document, preferring the user's copy.
+fn read(name: &str, themes_dir: Option<&Path>) -> Result<toml::Table> {
+    if let Some(path) = themes_dir.map(|dir| dir.join(format!("{name}.toml")))
+        && path.exists()
+    {
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading theme {}", path.display()))?;
+        return toml::from_str(&raw).with_context(|| format!("parsing theme {}", path.display()));
+    }
+
+    if let Some((_, raw)) = BUNDLED.iter().find(|(bundled, _)| *bundled == name) {
+        return toml::from_str(raw).with_context(|| format!("parsing the bundled `{name}` theme"));
+    }
+
+    let mut known = bundled_names();
+    known.sort_unstable();
+    let where_to_put_it = themes_dir.map_or_else(
+        || "your themes directory".to_string(),
+        |dir| dir.display().to_string(),
+    );
+    bail!(
+        "no theme called `{name}`. Built in: {}. For anything else, put \
+         `{name}.toml` in {where_to_put_it}.",
+        known.join(", ")
+    )
+}
+
+/// Catch colour keys that have fallen inside `[palette]`.
+///
+/// In TOML every key after a table header belongs to that table, so a file
+/// written in the obvious order —
+///
+/// ```text
+/// [palette]
+/// brass = "#d7af87"
+///
+/// accent = "brass"
+/// ```
+///
+/// puts `accent` *in the palette*, where it sets nothing. Nothing is
+/// misspelled and nothing fails to parse; the theme simply comes out as the
+/// defaults, which is the silent-ignore failure this crate refuses to ship.
+///
+/// I wrote the shipped `default.toml` this way and did not notice, because the
+/// test comparing it against `Theme::default()` passed: with no keys set, the
+/// result *was* the default. Hence both this check and a drift test that can
+/// actually fail.
+fn check_palette_ordering(name: &str, table: &toml::Table) -> Result<()> {
+    let Some(toml::Value::Table(palette)) = table.get("palette") else {
+        return Ok(());
+    };
+    let mut stray: Vec<&str> = palette
+        .keys()
+        .map(String::as_str)
+        .filter(|key| Theme::KEYS.contains(key))
+        .collect();
+    if stray.is_empty() {
+        return Ok(());
+    }
+    stray.sort_unstable();
+    bail!(
+        "theme `{name}` has {} inside `[palette]`, where {} nothing. In TOML \
+         every key after a table header belongs to that table, so the colour \
+         keys have to come *before* `[palette]`, not after it.",
+        stray.join(", "),
+        if stray.len() == 1 {
+            "it sets"
+        } else {
+            "they set"
+        }
+    )
+}
+
+/// Replace palette names with the colours they stand for.
+///
+/// Only strings that are palette *keys* change; everything else is left for the
+/// colour parser to accept or reject, so a typo still produces "`brss` is not a
+/// colour" rather than being silently dropped.
+fn substitute(table: &mut toml::Table, palette: &BTreeMap<String, toml::Value>) {
+    for (_, value) in table.iter_mut() {
+        // Taken by value and put back, because a palette hit replaces the whole
+        // entry rather than editing the string in place.
+        let replacement = match value {
+            toml::Value::String(text) => palette.get(text.as_str()).cloned(),
+            // One level down is enough: gradients are the only nested tables a
+            // theme has, and their stops are plain strings.
+            toml::Value::Table(nested) => {
+                substitute(nested, palette);
+                None
+            }
+            _ => None,
+        };
+        if let Some(resolved) = replacement {
+            *value = resolved;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempDir(PathBuf);
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn themes_dir(name: &str) -> (PathBuf, TempDir) {
+        let dir =
+            std::env::temp_dir().join(format!("mirador-themes-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("test directory");
+        (dir.clone(), TempDir(dir))
+    }
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(format!("{name}.toml")), body).expect("writing a theme");
+    }
+
+    #[test]
+    fn every_bundled_theme_resolves() {
+        for name in bundled_names() {
+            resolve(name, None).unwrap_or_else(|e| panic!("bundled `{name}` failed: {e:#}"));
+        }
+    }
+
+    /// The Rust `Theme::default()` and the shipped `default.toml` are reached
+    /// by different routes — a config with no `theme` key takes the first, and
+    /// `theme = "default"` takes the second — so they have to be pinned
+    /// together. The layout has the same hazard and the same kind of test; when
+    /// those two drifted, a config without a `[layout]` section silently lost
+    /// three panels.
+    #[test]
+    fn the_bundled_default_theme_matches_the_rust_default() {
+        let from_file = resolve("default", None).expect("resolves");
+        let built_in = Theme::default();
+        assert_eq!(
+            from_file.colours(),
+            built_in.colours(),
+            "assets/themes/default.toml has drifted from Theme::default()"
+        );
+    }
+
+    /// The comparison above cannot fail on its own, and for a while it did not.
+    /// Every colour key in `default.toml` had fallen inside `[palette]`, so the
+    /// file set *nothing*, the resolved theme was therefore the default, and
+    /// the equality passed while the file was meaningless. Comparing against
+    /// the default cannot detect that — the file resolving to the default is
+    /// the whole point — so the property has to be checked on the file: a
+    /// standalone theme names every key it is responsible for.
+    #[test]
+    fn a_standalone_theme_sets_every_key_rather_than_leaning_on_defaults() {
+        // `high-contrast` is excluded on purpose: it inherits `ansi` and is
+        // meant to be the handful of lines that differ.
+        for name in ["default", "default-light", "ansi"] {
+            let (_, raw) = BUNDLED
+                .iter()
+                .find(|(bundled, _)| *bundled == name)
+                .expect("bundled");
+            let table: toml::Table = toml::from_str(raw).expect("parses");
+
+            let missing: Vec<&str> = Theme::KEYS
+                .iter()
+                .copied()
+                .filter(|key| !table.contains_key(*key))
+                .collect();
+            assert!(
+                missing.is_empty(),
+                "`{name}.toml` never sets: {}",
+                missing.join(", ")
+            );
+        }
+    }
+
+    /// The trap that produced the bug above. It is silent by construction —
+    /// nothing is misspelled and nothing fails to parse — so it has to be
+    /// caught rather than left for the theme author to puzzle over.
+    #[test]
+    fn colour_keys_that_fell_inside_the_palette_are_reported() {
+        let (dir, _g) = themes_dir("ordering");
+        write(
+            &dir,
+            "t",
+            "[palette]\nbrass = \"#d7af87\"\naccent = \"brass\"\nborder = \"brass\"\n",
+        );
+
+        let err = format!("{:#}", resolve("t", Some(&dir)).expect_err("must fail"));
+        assert!(err.contains("accent"), "names the key: {err}");
+        assert!(err.contains("border"), "and every key: {err}");
+        assert!(err.contains("before"), "and says what to do: {err}");
+    }
+
+    /// A palette entry that merely *shares a name* with nothing in the theme is
+    /// fine; the check must not fire on an ordinary palette.
+    #[test]
+    fn an_ordinary_palette_is_left_alone() {
+        let (dir, _g) = themes_dir("ordinary");
+        write(
+            &dir,
+            "t",
+            "accent = \"brass\"\n\n[palette]\nbrass = \"#010203\"\n",
+        );
+        resolve("t", Some(&dir)).expect("a well-ordered theme resolves");
+    }
+
+    #[test]
+    fn a_theme_on_disk_wins_over_the_bundled_one_of_the_same_name() {
+        let (dir, _g) = themes_dir("override");
+        write(&dir, "default", "accent = \"#010203\"\n");
+
+        let theme = resolve("default", Some(&dir)).expect("resolves");
+        assert_eq!(theme.accent, ratatui::style::Color::Rgb(1, 2, 3));
+    }
+
+    #[test]
+    fn inherits_starts_from_the_parent_and_the_child_overrides_it() {
+        let (dir, _g) = themes_dir("inherits");
+        write(
+            &dir,
+            "child",
+            "inherits = \"default\"\naccent = \"#010203\"\n",
+        );
+
+        let child = resolve("child", Some(&dir)).expect("resolves");
+        let parent = Theme::default();
+        assert_eq!(
+            child.accent,
+            ratatui::style::Color::Rgb(1, 2, 3),
+            "overridden"
+        );
+        assert_eq!(child.border, parent.border, "and the rest is inherited");
+    }
+
+    /// Without this the loop runs until the depth cap and reports the wrong
+    /// thing, which sends someone looking for a file that is fine.
+    #[test]
+    fn a_cycle_is_named_rather_than_run_until_it_gives_up() {
+        let (dir, _g) = themes_dir("cycle");
+        write(&dir, "a", "inherits = \"b\"\n");
+        write(&dir, "b", "inherits = \"a\"\n");
+
+        let err = format!("{:#}", resolve("a", Some(&dir)).expect_err("must fail"));
+        assert!(err.contains("inherits from itself"), "got: {err}");
+    }
+
+    /// A child that redefines a palette entry has to recolour the keys its
+    /// *parent* set with it. Merging each document's palette as it is read
+    /// would leave the parent's keys holding the parent's colour.
+    #[test]
+    fn a_redefined_palette_colour_reaches_the_keys_the_parent_set_with_it() {
+        let (dir, _g) = themes_dir("palette");
+        // The parent sets `accent` from the palette; the child changes only
+        // what `brass` means.
+        write(
+            &dir,
+            "base",
+            "accent = \"brass\"\n\n[palette]\nbrass = \"#d7af87\"\n",
+        );
+        write(
+            &dir,
+            "child",
+            "inherits = \"base\"\n\n[palette]\nbrass = \"#010203\"\n",
+        );
+
+        let theme = resolve("child", Some(&dir)).expect("resolves");
+        assert_eq!(
+            theme.accent,
+            ratatui::style::Color::Rgb(1, 2, 3),
+            "the parent's `accent = brass` follows the child's redefinition"
+        );
+    }
+
+    #[test]
+    fn an_unknown_name_lists_what_is_available() {
+        let err = format!("{:#}", resolve("nord", None).expect_err("must fail"));
+        assert!(err.contains("no theme called `nord`"), "got: {err}");
+        for name in bundled_names() {
+            assert!(err.contains(name), "`{name}` missing from: {err}");
+        }
+    }
+
+    /// A palette name that is not in the palette must still reach the colour
+    /// parser, so the message names the offending word.
+    #[test]
+    fn a_misspelled_palette_name_is_reported_as_a_bad_colour() {
+        let (dir, _g) = themes_dir("typo");
+        write(
+            &dir,
+            "t",
+            "accent = \"brss\"\n\n[palette]\nbrass = \"#d7af87\"\n",
+        );
+
+        let err = format!("{:#}", resolve("t", Some(&dir)).expect_err("must fail"));
+        assert!(err.contains("brss"), "the message names the typo: {err}");
+    }
+
+    #[test]
+    fn a_misspelled_key_in_a_theme_file_is_refused() {
+        let (dir, _g) = themes_dir("badkey");
+        write(&dir, "t", "acent = \"#010203\"\n");
+
+        let err = format!("{:#}", resolve("t", Some(&dir)).expect_err("must fail"));
+        assert!(err.contains("acent"), "the message names the key: {err}");
+    }
+}


### PR DESCRIPTION
`theme = "high-contrast"` instead of eighteen keys in a table.

Four ship inside the binary — `default`, `default-light`, `high-contrast`, `ansi` — and anything in `themes/<name>.toml` beside your config wins over them, so replacing a shipped theme doesn't mean renaming it. `inherits` makes a variant the lines that differ; `[palette]` names colours once, and redefining a palette entry in a child recolours the keys its *parent* set with it.

## The compat shim is deliberately not an untagged enum

An untagged enum answers every failure with "data did not match any variant", which would have taken out both the misspelled-key report and the `--migrate-config` hint for the pre-0.1.0 `rx`/`tx` keys — two things this crate has tests for because they were hard-won. The map arm delegates to the derived impl instead, so all of it survives. Both tests still pass.

## Two design items deliberately skipped

- **Dotted-scope fallback** — sized for Helix's hundreds of syntax scopes. mirador has thirteen flat semantic keys a theme can set in full, and `inherits` covers the rest. The stated benefit was "makes `border_focused` stop being a special case", which is one field.
- **Per-key style objects (fg/bg/modifiers)** — all ~240 theme reads take a flat `Color`, nothing wants a themed background (invariant 8), and bold/reversed belong to the widget that knows what it's emphasising.

Both are additions if ever wanted, not corrections. Recorded in CLAUDE.md with reasons.

## The bug worth reading about

TOML puts every key after a table header *inside* that table. So colour keys written under `[palette]` set nothing — no typo, no parse failure, and the theme quietly comes out as the defaults.

I wrote the shipped `default.toml` exactly that way and didn't notice, **because the test comparing it against `Theme::default()` passed**: a file that sets nothing resolves to precisely the default, so the comparison could not fail. Every colour key in the shipped theme was inside `[palette]` and the suite was green.

Two changes come out of that, not one:

- `check_palette_ordering` refuses such a file and names the affected keys.
- The drift test is paired with one asserting a standalone theme *sets every key* — the property that can actually go red.

## Verified

Rendered all three under tmux and read the escape sequences: `default` emits true-colour RGB (`38;2;215;175;135`), `high-contrast` emits 256-colour indices inherited from `ansi` (`38;5;15`), `ansi` plain (`38;5;3`). A user theme in `themes/` inheriting `ansi` applied its own `#88c0d0` and took the rest from the parent. An unknown name fails at startup naming what's built in and where to put a custom one.

`cargo package --list` confirms all four `assets/themes/*.toml` are in the crate — `include_str!` means a missing one is a crate that won't compile.

529 tests; clippy, fmt, rustdoc and `cargo publish --dry-run` all silent.