### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-07-27
 
 ### Added
 
@@ -771,7 +771,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/jchultarsky/mirador/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/jchultarsky/mirador/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/jchultarsky/mirador/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jchultarsky/mirador/compare/v0.7.1...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog date.

### Added

- **Named themes** — `theme = "high-contrast"` in place of the `[theme]` table. Four bundled (`default`, `default-light`, `high-contrast`, `ansi`); anything in `themes/<name>.toml` beside your config wins over them. `inherits` and `[palette]` make a variant short.

  The existing `[theme]` table keeps working, and keeps its error messages — the compat shim is a hand-written visitor rather than an untagged enum precisely so the misspelled-key report and the `rx`/`tx` migration hint survive.

- **A theme file with its colour keys after `[palette]` is refused by name.** TOML puts them inside the table, where they set nothing — silently. mirador's own `default.toml` was written that way during development and the test comparing it to the built-in default passed, because a file that sets nothing resolves to exactly the default.

Not tagged yet; the tag goes on the squashed commit this produces.