### PR TITLE
Add the watch log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **The watch log** — a placeable panel recording what happened while you were
+  not looking. It fills the third instrument the design thesis named
+  (*"chronometer, weather glass, watch log"*) and that nothing had ever
+  occupied.
+
+  Almost nothing qualifies for it, which is the point. The clock, the readings,
+  the prices and the graphs change continuously and none of it is news; your
+  notes and tasks change because you changed them. An entry is something that
+  happened *to* you rather than because of you, and that you would want to know
+  even if you never looked at the panel it came from. Out of the box that is two
+  things: an event appearing in your `.ics` that you did not add, and a task
+  crossing into overdue because the day turned.
+
+  **No counter, no unread state, no effect on any other panel.** Unread message
+  counts were considered for this dashboard and rejected as a doomscroll hook;
+  read closely, that objection is about the *badge* — a number that accumulates
+  and demands you zero it. This is a record you consult, not an inbox that
+  consults you, and nothing in it can be dismissed, because an entry you can
+  dismiss is an entry you are expected to dismiss.
+
+  A rule line marks where you were last seen. mirador now asks your terminal to
+  report window focus, which is the only honest signal for "the reader is here";
+  it falls back to your last keypress, and draws no line at all when neither has
+  fired, because a line in the wrong place makes a claim that a missing one does
+  not.
+
+  The log lives in memory and says when it started watching. One written to disk
+  would return after a restart with a gap it could not mark.
+
 ## [0.10.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
 store.rs     write_atomic — every file mirador owns goes through it
 state.rs     UI-changed preferences, remembered across restarts
 update.rs    the opt-in update check — off unless the config turns it on
+watch.rs     the watch log's events and the rule that decides what is one
 task.rs      task model + TOML store
 note.rs      note model + TOML store
 quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
@@ -134,7 +135,7 @@ textarea.rs  multi-line text editor used by note bodies
 dateinput.rs due-date entry
 ical.rs      enough RFC 5545 to answer "what is next"; no new dependencies
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
-             pomodoro, cpu, network
+             pomodoro, watchlog, cpu, network
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -203,7 +204,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 230 of them, including the ones mirador
+    trip through `toml` discards all 232 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -402,6 +403,43 @@ exactly the default. Hence two things: `check_palette_ordering` refuses such a
 file by name, and the drift test is paired with one that asserts a standalone
 theme *sets every key*, which is the property that can actually fail.
 
+## The watch log — built
+
+Fills the third instrument the design thesis named and nothing had ever
+occupied. `watch.rs` holds the log and the rule for what belongs in it;
+`widgets/watchlog.rs` draws it; panels report through `Panel::events()`,
+drained each tick beside `tick()`.
+
+**Three commitments are what keep it on the right side of the unread-count
+rejection, and all three are presentational:** no counter in the frame, no
+unread state, and no effect on any other panel's appearance. Read the original
+objection closely — "looks like information, is a doomscroll hook, turns a calm
+dashboard into a nagging one" — and it is about the *badge*, not about
+surfacing change. Give this panel a `3 new` counter and it becomes the feature
+that was turned down. There is a test whose failure message says so.
+
+**"Since I last looked" is unknowable and the design admits it.** The dashboard
+cannot see you looking, and the moments it most needs to be right are the
+glances that touch nothing. mirador enables terminal focus reporting, which is
+the closest honest signal, and falls back to the last keypress. Where neither
+has fired it draws *no* rule line — a line in the wrong place makes a claim,
+where a missing one merely says nothing.
+
+**Focus reporting is unverified in practice.** It could not be tested here: a
+headless tmux server has no attached client to have focus, so the probe could
+not distinguish "unsupported" from "nothing is focused". The keypress fallback
+carries the feature until someone confirms it on a real terminal, and tmux
+needs `focus-events on` regardless.
+
+**The log does not persist, on purpose.** A file would come back after a restart
+with a hole in it — the hours mirador was not running and observed nothing —
+and it cannot mark that hole. Same discipline as weather showing a reading's
+age rather than implying it is current.
+
+**The first read of a calendar is not news.** `AgendaPanel::known` is `None`
+until the first successful read, so a startup does not announce every event in
+your `.ics`. A log that opens with forty entries is a log nobody reads twice.
+
 ## Recently settled, so it is not re-litigated
 
 **The layout grid stays two levels** — `rows: Vec<Row{height, panels}>` — rather
@@ -435,14 +473,20 @@ The mode's legend names both keys, so there is nothing to guess.
 Only things that are actually open. A "decided and built" entry in a list called
 open work is how the list stops being read.
 
-1. **"What changed since I last looked" markers.** No design yet.
-2. **A single "is anything on fire" signal.** No design yet. Named as a gap
-   alongside the other two and then quietly dropped from this list; it is back.
+1. **A single "is anything on fire" signal.** No design yet. It is the same
+   notion as the watch log seen from the other end — the log is notable things
+   in the past, this is a notable condition in the present — so whatever
+   defines "notable" for one should serve the other. `watch::Event` has no
+   severity today; that is where it would go.
 
-Both of these are the last two gaps from the original four-questions analysis,
-and both are structurally attention-grabbing mechanisms — which is the thing
-the unread-email-count rejection was about. Whatever they become has to earn
-its way past that rule rather than around it.
+   It is also structurally an attention-grabbing mechanism, which is the thing
+   the unread-email-count rejection was about, and it has to earn its way past
+   that rule rather than around it. See how the watch log did: the commitment
+   that made it acceptable was presentational — no count, no unread state, no
+   effect on any other panel.
+
+The "what changed since I last looked" markers that sat at the top of this list
+are built, as the watch log; see below.
 
 Named themes sat at the top of this list and is built; see the section above.
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,45 @@ where one that misses a repeat costs you a glance at the real thing.
 An entry the parser cannot read is counted at the bottom of the panel rather
 than dropped silently, so a half-read calendar does not just look empty.
 
+### Watch log
+
+What happened while you were not looking.
+
+```
+╭┤7 Watch log├──────────────────────────────────╮
+│ 14:02  Standup appeared in your calendar      │
+│ ──────────────────── since you were here ──── │
+│ 13:30  Renew the domain went overdue          │
+│ watching from 08:12                           │
+╰───────────────────────────────────────────────╯
+```
+
+Almost nothing qualifies, and that is the point. The clock, the readings, the
+prices and the graphs change continuously and none of it is news; your notes and
+tasks change because you changed them. An entry is something that happened *to*
+you rather than because of you, and that you would want to know even if you
+never looked at the panel it came from. Out of the box that means two things: an
+event appearing in your `.ics` that you did not put there, and a task crossing
+into overdue because the day turned.
+
+**It has no counter, no unread state, and no effect on any other panel.** Unread
+message counts were considered for this dashboard and rejected — a number that
+accumulates is a number demanding you zero it. This is a record you consult, not
+an inbox that consults you, and nothing in it can be dismissed or acknowledged
+because an entry you can dismiss is an entry you are expected to dismiss.
+
+The rule line marks where you were last seen. mirador asks your terminal to
+report window focus, which is the only honest signal for "the reader is here" —
+every other one measures interaction, and a dashboard you glance at is precisely
+one you do not touch. Where the terminal does not report it (and under tmux
+unless `focus-events on` is set) it falls back to your last keypress, and where
+neither has happened it draws no line at all rather than one in the wrong place.
+
+The log lives in memory and says when it started watching. One written to disk
+would come back after a restart with a gap it could not mark — the hours mirador
+was not running — and a log that implies a completeness it does not have is
+worse than one that admits where it begins.
+
 ### Pomodoro
 
 A focus timer, in the same block numerals the clock uses.

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -62,11 +62,14 @@ rows = [
     { widget = "weather",  width = 40 },
   ] },
   { height = 42, panels = [
-    { widget = "todo",     width = 40 },
+    { widget = "todo",     width = 30 },
     # What is next, from [agenda].file. Says how to point it at your .ics
     # until you do.
-    { widget = "agenda",   width = 32 },
-    { widget = "notes",    width = 28 },
+    { widget = "agenda",   width = 26 },
+    { widget = "notes",    width = 22 },
+    # What happened while you were not looking. Empty most of the time, which
+    # is the point.
+    { widget = "watchlog", width = 22 },
   ] },
   { height = 24, panels = [
     # The timer draws block numerals when it has the width for them and falls

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,6 +271,13 @@ pub struct App {
     /// keypress, exactly like the widget hint: a dashboard you leave open all
     /// day must not nag, and a notice that will not go away is a nag.
     show_update_hint: bool,
+    /// What has happened since mirador started.
+    ///
+    /// Lives here rather than in the watch log panel because the panel may not
+    /// be placed, may be toggled off and on, and is rebuilt whenever the layout
+    /// changes. Events would be lost every time, and a log that forgets when
+    /// you rearrange the dashboard is not a log.
+    watch: crate::watch::WatchLog,
     /// The panel picker, while it is open.
     picker: Option<crate::picker::Picker>,
     /// The layout as it stood when arrange mode opened, kept so that `Esc` can
@@ -339,6 +346,7 @@ impl App {
             update: crate::update::Found::default(),
             show_update_hint: true,
             unused_widgets,
+            watch: crate::watch::WatchLog::default(),
             picker: None,
             arranging: None,
             config_path: None,
@@ -544,11 +552,21 @@ impl App {
                     // Resize re-runs layout against the new frame size, which
                     // is the next draw's job — but that draw has to happen.
                     Event::Resize(_, _) => dirty = true,
+                    // The closest thing to "the reader is looking" that a
+                    // terminal will tell us. Not every terminal sends it and
+                    // tmux forwards it only with `focus-events on`, so it is
+                    // an improvement where available rather than the mechanism
+                    // — the keypress below carries it everywhere else.
+                    // Both, not just one: gaining focus means they are here
+                    // now, and losing it means they were here until this
+                    // moment. Either way the line belongs at this point.
+                    Event::FocusGained | Event::FocusLost => self.watch.mark_seen(),
                     _ => {}
                 }
             }
 
             dirty |= self.tick_panels();
+            dirty |= self.collect_events();
 
             // Resizes are batched rather than written per keystroke —
             // `Ctrl+arrow` auto-repeats, and rewriting the config on every
@@ -632,6 +650,22 @@ impl App {
         }
     }
 
+    /// Drain what the panels have noticed into the log.
+    ///
+    /// Returns whether anything was recorded, so the dashboard redraws: a new
+    /// entry is a visible change if the watch log is on screen, and cheaper to
+    /// report unconditionally than to ask whether it is placed.
+    fn collect_events(&mut self) -> bool {
+        let mut recorded = false;
+        for slot in &mut self.slots {
+            for event in slot.panel.events() {
+                self.watch.push(event);
+                recorded = true;
+            }
+        }
+        recorded
+    }
+
     /// Tick any panel whose refresh interval has elapsed.
     ///
     /// Returns whether any panel ticked, and so whether the screen may now be
@@ -677,6 +711,10 @@ impl App {
         // been ignored; either way it has had its turn.
         self.show_widget_hint = false;
         self.show_update_hint = false;
+        // A keypress is weaker evidence than a focus event — the moments this
+        // most wants to be right are the glances that touch nothing — but it is
+        // the only evidence available on a terminal that does not report focus.
+        self.watch.mark_seen();
 
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
@@ -1280,6 +1318,7 @@ impl App {
                     theme: &theme,
                     gradients: &self.gradients,
                     focused,
+                    watch: &self.watch,
                 },
             );
         }
@@ -2219,7 +2258,11 @@ mod tests {
             (0..width).map(|x| buf[(x, 5)].symbol()).collect()
         };
 
-        let wide = row_text(&mut app, 160);
+        // Wide enough for the global keys *and* a hint naming every widget
+        // this layout leaves out — which grows by a word every time a widget is
+        // added, so this figure is a floor rather than a round number. It was
+        // 160 until the watch log made the list one name longer than that.
+        let wide = row_text(&mut app, 200);
         assert!(wide.contains("unused"), "wide enough for both: `{wide}`");
 
         let narrow = row_text(&mut app, 44);

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -38,7 +38,15 @@ impl Default for Layout {
         Self {
             rows: vec![
                 row(34, &[("clocks", 26), ("calendar", 34), ("weather", 40)]),
-                row(42, &[("todo", 40), ("agenda", 32), ("notes", 28)]),
+                row(
+                    42,
+                    &[
+                        ("todo", 30),
+                        ("agenda", 26),
+                        ("notes", 22),
+                        ("watchlog", 22),
+                    ],
+                ),
                 row(
                     24,
                     &[

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -804,7 +804,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 230;
+        const CITED: usize = 232;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod textfield;
 mod theme;
 mod themes;
 mod update;
+mod watch;
 mod widgets;
 mod zones;
 
@@ -36,7 +37,9 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use ratatui::crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use ratatui::crossterm::event::{
+    DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture,
+};
 use ratatui::crossterm::execute;
 
 use crate::app::App;
@@ -200,6 +203,24 @@ fn run() -> Result<()> {
     // panic leaves the user with a working shell rather than a broken one.
     let mut terminal = ratatui::init();
 
+    // Asks the terminal to say when its window gains or loses focus, which is
+    // the only signal there is for "the reader is actually here" — everything
+    // else measures interaction, and a dashboard you glance at is precisely one
+    // you do not touch. Failure is ignored on purpose: plenty of terminals do
+    // not implement it, and the watch log falls back to the last keypress.
+    let _ = execute!(std::io::stdout(), EnableFocusChange);
+
+    // Released on the way out, and on a panic, for the same reason mouse
+    // capture is: a terminal left reporting focus writes escape sequences into
+    // the user's shell every time they switch windows.
+    {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let _ = execute!(std::io::stdout(), DisableFocusChange);
+            previous(info);
+        }));
+    }
+
     if mouse {
         // ratatui's hook knows nothing about mouse capture, and a terminal
         // left holding the mouse turns every later click in the user's shell
@@ -217,6 +238,7 @@ fn run() -> Result<()> {
     if mouse {
         let _ = execute!(std::io::stdout(), DisableMouseCapture);
     }
+    let _ = execute!(std::io::stdout(), DisableFocusChange);
     ratatui::restore();
     result
 }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -64,6 +64,12 @@ pub struct RenderContext<'a> {
     pub gradients: &'a Gradients,
     /// Whether this panel currently has keyboard focus.
     pub focused: bool,
+    /// What has happened since mirador started.
+    ///
+    /// Handed to every panel rather than only the watch log, because it is
+    /// read-only from here and threading it to exactly one panel would mean a
+    /// second context type. Nothing else reads it today.
+    pub watch: &'a crate::watch::WatchLog,
 }
 
 /// A single dashboard widget.
@@ -149,6 +155,28 @@ pub trait Panel {
     /// laziness.
     fn tick(&mut self) -> bool {
         false
+    }
+
+    /// Notable things that have happened since this was last called.
+    ///
+    /// Drained every tick and handed to the watch log. Distinct from [`tick`]
+    /// on purpose: `tick` answers "did the screen change", which is true
+    /// constantly, and this answers "did something happen that a reader would
+    /// want to know about", which is true almost never.
+    ///
+    /// The bar is deliberately high. An event is something that happened **to**
+    /// the user rather than because of them, and that they would want to know
+    /// even if they never looked at this panel. A price moving, a graph
+    /// scrolling and a clock ticking are all changes and none of them qualify;
+    /// nor does anything the user did themselves, because they were there.
+    ///
+    /// Returning something every tick would make the log unreadable, which
+    /// costs the feature rather than the panel: a log nobody can scan is worse
+    /// than no log.
+    ///
+    /// [`tick`]: Panel::tick
+    fn events(&mut self) -> Vec<crate::watch::Event> {
+        Vec::new()
     }
 
     /// Draw the panel's contents. `area` is already inside the frame and its

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,211 @@
+//! Notable things that happened, and when.
+//!
+//! The design thesis names three instruments — chronometer, weather glass,
+//! **watch log** — and for a long time only two of them existed. This is the
+//! third: a record of what happened while you were not looking.
+//!
+//! ## What counts
+//!
+//! Almost nothing does, and that is the point. The clock, the readings, the
+//! prices and the graphs change continuously and none of it is news; the notes
+//! and tasks change because *you* changed them. An event is something that
+//! happened **to** you rather than because of you, and that you would want to
+//! know about even if you never looked at the panel it came from. That leaves a
+//! very short list, which is the correct size for it.
+//!
+//! ## Why it is not a badge
+//!
+//! Unread message counts were considered for this dashboard and rejected —
+//! "looks like information, is a doomscroll hook, turns a calm dashboard into a
+//! nagging one". Read closely, that objection is about the *badge*: a number
+//! that accumulates and demands you zero it.
+//!
+//! So the log has no count, no unread state, and no effect on any other panel's
+//! appearance. It is a record you consult, not an inbox that consults you. If
+//! you never place the panel, nothing about mirador changes. Breaking any of
+//! those three is how this feature turns into the one that was rejected.
+//!
+//! ## Why it does not persist
+//!
+//! A log written to disk would come back after a restart with a hole in it —
+//! the hours mirador was not running, during which it observed nothing and
+//! cannot say so. Weather shows the age of its reading rather than pretending
+//! it is current, and this follows the same rule: the log starts when mirador
+//! does and says so, rather than implying a completeness it does not have.
+
+use std::collections::VecDeque;
+
+use jiff::Zoned;
+
+/// How many entries are kept. Beyond this the oldest fall off the end.
+///
+/// A day of ordinary use produces a handful, so this is a bound on pathology
+/// rather than a limit anyone should meet.
+const CAPACITY: usize = 200;
+
+/// Something worth recording.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Event {
+    /// When it happened.
+    pub at: Zoned,
+    /// The panel that noticed, for grouping and for the reader's orientation.
+    pub source: &'static str,
+    /// One line, in the past tense, naming the thing rather than the panel.
+    pub text: String,
+}
+
+impl Event {
+    pub fn new(source: &'static str, text: impl Into<String>) -> Self {
+        Self {
+            at: Zoned::now(),
+            source,
+            text: text.into(),
+        }
+    }
+}
+
+/// The log itself: newest first, bounded, and aware of when it started.
+#[derive(Debug)]
+pub struct WatchLog {
+    entries: VecDeque<Event>,
+    /// When mirador started watching, shown as the last line so the log never
+    /// implies it knows about anything earlier.
+    since: Zoned,
+    /// The last moment the reader was known to be present.
+    ///
+    /// `None` until something says otherwise, and a rule line is drawn only
+    /// when it is `Some` *and* has entries on both sides — a line in the wrong
+    /// place is worse than no line, because it makes a claim.
+    seen_at: Option<Zoned>,
+}
+
+impl Default for WatchLog {
+    fn default() -> Self {
+        Self {
+            entries: VecDeque::new(),
+            since: Zoned::now(),
+            seen_at: None,
+        }
+    }
+}
+
+impl WatchLog {
+    /// Record an event.
+    pub fn push(&mut self, event: Event) {
+        self.entries.push_front(event);
+        while self.entries.len() > CAPACITY {
+            self.entries.pop_back();
+        }
+    }
+
+    /// Newest first.
+    pub fn entries(&self) -> impl Iterator<Item = &Event> {
+        self.entries.iter()
+    }
+
+    pub fn since(&self) -> &Zoned {
+        &self.since
+    }
+
+    /// Note that the reader is here now.
+    ///
+    /// Called on terminal focus where the terminal reports it, and on a
+    /// keypress otherwise. Both are proxies: the dashboard cannot see you
+    /// looking, and the moments you most want this to be right are the ones
+    /// where you glanced without touching anything.
+    pub fn mark_seen(&mut self) {
+        self.seen_at = Some(Zoned::now());
+    }
+
+    /// How many of the newest entries arrived after the reader was last here.
+    ///
+    /// `None` means no line should be drawn: either nothing says when they were
+    /// last here, everything is newer, or nothing is. A rule line at the very
+    /// top or the very bottom separates nothing from something and reads as a
+    /// glitch.
+    pub fn unseen(&self) -> Option<usize> {
+        let seen_at = self.seen_at.as_ref()?;
+        let fresh = self
+            .entries
+            .iter()
+            .take_while(|entry| &entry.at > seen_at)
+            .count();
+        (fresh > 0 && fresh < self.entries.len()).then_some(fresh)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jiff::Span;
+
+    fn at(log: &WatchLog, minutes: i64) -> Event {
+        Event {
+            at: log
+                .since
+                .checked_add(Span::new().minutes(minutes))
+                .expect("in range"),
+            source: "test",
+            text: format!("thing {minutes}"),
+        }
+    }
+
+    #[test]
+    fn the_newest_entry_comes_first() {
+        let mut log = WatchLog::default();
+        log.push(at(&log, 1));
+        log.push(at(&log, 2));
+
+        let texts: Vec<&str> = log.entries().map(|e| e.text.as_str()).collect();
+        assert_eq!(texts, ["thing 2", "thing 1"]);
+    }
+
+    #[test]
+    fn the_oldest_entries_fall_off_rather_than_growing_without_bound() {
+        let mut log = WatchLog::default();
+        for minute in 0..i64::try_from(CAPACITY + 20).expect("fits") {
+            log.push(at(&log, minute));
+        }
+        assert_eq!(log.entries().count(), CAPACITY);
+        // The newest survived, the oldest did not.
+        assert_eq!(
+            log.entries().next().unwrap().text,
+            format!("thing {}", CAPACITY + 19)
+        );
+    }
+
+    /// A rule line makes a claim — "you have not seen these" — so it is only
+    /// drawn when it can be true. At the very top or the very bottom it
+    /// separates nothing from something, which reads as a rendering fault.
+    #[test]
+    fn no_rule_line_is_offered_when_it_would_sit_at_either_end() {
+        let mut log = WatchLog::default();
+        assert_eq!(log.unseen(), None, "nothing says when they were last here");
+
+        log.mark_seen();
+        log.push(at(&log, 10));
+        assert_eq!(
+            log.unseen(),
+            None,
+            "everything is new; the line would top it"
+        );
+
+        let mut log = WatchLog::default();
+        log.push(at(&log, 1));
+        log.push(at(&log, 2));
+        log.seen_at = Some(log.since.checked_add(Span::new().minutes(5)).unwrap());
+        assert_eq!(log.unseen(), None, "nothing is new; the line would foot it");
+    }
+
+    #[test]
+    fn the_line_falls_between_what_arrived_before_and_after() {
+        let mut log = WatchLog::default();
+        log.push(at(&log, 1));
+        log.push(at(&log, 2));
+        log.seen_at = Some(log.since.checked_add(Span::new().minutes(3)).unwrap());
+        log.push(at(&log, 4));
+        log.push(at(&log, 5));
+
+        assert_eq!(log.unseen(), Some(2), "the two that arrived after");
+    }
+}

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -98,6 +98,15 @@ pub struct AgendaPanel {
     list_area: Option<Rect>,
     /// The `f` dialog, while it is open.
     asking: Option<crate::prompt::Prompt>,
+    /// What the calendar held at the last read, so a new entry can be spotted.
+    ///
+    /// `None` until the first successful read. That is what stops the whole
+    /// calendar being announced at startup: on a first read there is nothing to
+    /// have changed *from*, and a log opening with forty entries is a log
+    /// nobody reads twice.
+    known: Option<std::collections::HashSet<String>>,
+    /// Events waiting to be drained by the watch log.
+    pending: Vec<crate::watch::Event>,
 }
 
 impl Drop for AgendaPanel {
@@ -158,6 +167,8 @@ impl AgendaPanel {
             status: None,
             list_area: None,
             asking: None,
+            known: None,
+            pending: Vec::new(),
         }
     }
 
@@ -190,6 +201,45 @@ impl AgendaPanel {
                 self.status = Some("reloading…".into());
             }
         }
+    }
+
+    /// Record anything in the calendar that was not there at the last read.
+    ///
+    /// This is the clearest case the watch log has: an entry you did not add,
+    /// which appeared because somebody else put it in a calendar you sync. It
+    /// is worth knowing whether or not you were looking at this panel, which is
+    /// the whole test for whether something belongs in the log.
+    fn note_new_entries(&mut self) {
+        let state = self.snapshot();
+        // A failed read publishes no events; treating that as "everything was
+        // cancelled" and then "everything is new" would fill the log with a
+        // network blip.
+        if state.error.is_some() {
+            return;
+        }
+
+        let current: std::collections::HashSet<String> = state
+            .events
+            .iter()
+            .map(|event| format!("{}@{}", event.summary, event.start.timestamp()))
+            .collect();
+
+        if let Some(known) = self.known.take() {
+            for event in &state.events {
+                let key = format!("{}@{}", event.summary, event.start.timestamp());
+                if !known.contains(&key) {
+                    self.pending.push(crate::watch::Event::new(
+                        "agenda",
+                        format!(
+                            "{} appeared in your calendar, {}",
+                            event.summary,
+                            event.start.strftime("%a %d %b at %H:%M")
+                        ),
+                    ));
+                }
+            }
+        }
+        self.known = Some(current);
     }
 
     /// Point the panel at a different calendar and read it now.
@@ -419,7 +469,14 @@ impl Panel for AgendaPanel {
         let now = self.generation.load(Ordering::Acquire);
         let moved = now != self.seen;
         self.seen = now;
+        if moved {
+            self.note_new_entries();
+        }
         moved
+    }
+
+    fn events(&mut self) -> Vec<crate::watch::Event> {
+        std::mem::take(&mut self.pending)
     }
 
     fn captures_input(&self) -> bool {

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -13,6 +13,7 @@ pub mod notes;
 pub mod pomodoro;
 pub mod stocks;
 pub mod todo;
+pub mod watchlog;
 pub mod weather;
 
 use anyhow::Result;
@@ -22,8 +23,8 @@ use crate::panel::Panel;
 
 /// Every widget id accepted in the `[layout]` table.
 pub const WIDGET_NAMES: &[&str] = &[
-    "clocks", "weather", "todo", "notes", "stocks", "calendar", "agenda", "pomodoro", "cpu",
-    "network",
+    "clocks", "weather", "todo", "notes", "stocks", "calendar", "agenda", "pomodoro", "watchlog",
+    "cpu", "network",
 ];
 
 /// Whether `name` refers to a widget mirador knows how to build.
@@ -79,6 +80,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
             config.stocks_path()?,
         )?),
         "calendar" => Box::new(calendar::CalendarPanel::new(config.calendar.clone())),
+        "watchlog" => Box::new(watchlog::WatchLogPanel::new()),
         "agenda" => Box::new(agenda::AgendaPanel::new(
             &config.agenda,
             config.agenda_path()?,
@@ -151,6 +153,7 @@ mod tests {
                                 theme: &config.theme,
                                 gradients: &gradients,
                                 focused: true,
+                                watch: &crate::watch::WatchLog::default(),
                             },
                         );
                     })

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -1167,6 +1167,7 @@ mod tests {
                             theme: &config.theme,
                             gradients: &gradients,
                             focused: true,
+                            watch: &crate::watch::WatchLog::default(),
                         },
                     );
                 })

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -240,6 +240,8 @@ pub struct TodoPanel {
     /// back into the row it landed on. `None` until the first draw, and while
     /// the list is empty — there is no row to hit in either case.
     list_area: Option<Rect>,
+    /// Events waiting to be drained by the watch log.
+    pending: Vec<crate::watch::Event>,
 }
 
 impl TodoPanel {
@@ -263,6 +265,7 @@ impl TodoPanel {
             status: None,
             today,
             list_area: None,
+            pending: Vec::new(),
         };
         panel.refresh_view();
         Ok(panel)
@@ -903,11 +906,41 @@ impl Panel for TodoPanel {
         if today == self.today {
             return false;
         }
+
+        // A task that went overdue because the day turned is the clearest
+        // example of something that happened *to* the reader: nobody did it,
+        // and it is true whether or not they were looking at this panel.
+        //
+        // Deliberately only on the rollover. Editing a due date into the past
+        // also makes a task overdue, and that is the reader's own doing — they
+        // were there, and telling them about it would be the log repeating
+        // their own keystrokes back at them.
+        for task in self.store.tasks() {
+            if task.done {
+                continue;
+            }
+            let was = matches!(
+                task.due_state(self.today),
+                crate::task::DueState::Overdue(_)
+            );
+            let now = matches!(task.due_state(today), crate::task::DueState::Overdue(_));
+            if !was && now {
+                self.pending.push(crate::watch::Event::new(
+                    "tasks",
+                    format!("{} went overdue", task.title),
+                ));
+            }
+        }
+
         self.today = today;
         // Overdue rows are coloured by date, so a day boundary restyles the
         // list even when no task moved.
         self.refresh_view();
         true
+    }
+
+    fn events(&mut self) -> Vec<crate::watch::Event> {
+        std::mem::take(&mut self.pending)
     }
 
     fn remember(&self, state: &mut crate::state::UiState) {

--- a/src/widgets/watchlog.rs
+++ b/src/widgets/watchlog.rs
@@ -1,0 +1,246 @@
+//! The watch log: what happened while you were not looking.
+//!
+//! The reasoning about *what belongs in it* is in [`crate::watch`]; this is
+//! only how it is drawn. Three things about the drawing are load-bearing and
+//! none of them is decoration:
+//!
+//! - **No counter in the frame.** Every other list panel here carries one —
+//!   `4 open`, `3`, `2 today` — and this one deliberately does not. A number in
+//!   the border is a badge, a badge accumulates, and an accumulating badge is
+//!   precisely the unread-message count this dashboard turned down.
+//! - **The rule line is a position, not a quantity.** It says "you have not
+//!   been here since this point", which is a fact about the list, rather than
+//!   "you have 4 unread", which is a demand.
+//! - **The foot says when watching began.** The log cannot know what happened
+//!   before mirador started, and a list that quietly begins mid-story implies
+//!   otherwise.
+
+use jiff::Zoned;
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+
+use crate::frame::Binding;
+use crate::panel::{KeyOutcome, Panel, RenderContext};
+
+const BINDINGS: &[Binding] = &[
+    Binding::extra("↑ / ↓", "scroll"),
+    Binding::extra("j / k", "scroll"),
+    Binding::extra("g / G", "first / last"),
+];
+
+/// Interior width past which the panel gains nothing: a time, a source and a
+/// sentence with room to breathe.
+const USEFUL_WIDTH: u16 = 56;
+
+pub struct WatchLogPanel {
+    scroll: ListState,
+    /// Entries drawn last frame, so `tick` can answer honestly.
+    drawn: usize,
+}
+
+impl WatchLogPanel {
+    pub fn new() -> Self {
+        Self {
+            scroll: ListState::default(),
+            drawn: 0,
+        }
+    }
+}
+
+impl Panel for WatchLogPanel {
+    fn title(&self) -> String {
+        "Watch log".into()
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn max_width(&self) -> Option<u16> {
+        Some(USEFUL_WIDTH + crate::frame::FRAME_WIDTH)
+    }
+
+    /// Deliberately `None`.
+    ///
+    /// Every other panel that returns a figure here does so because more rows
+    /// buy it nothing. This one is the opposite: rows *are* the content, and a
+    /// log tall enough to hold a day of events is the difference between
+    /// scrolling and glancing.
+    fn max_height(&self) -> Option<u16> {
+        None
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        // The log is read, never edited: nothing here dismisses, acknowledges
+        // or clears an entry. An entry you can dismiss is an entry you are
+        // expected to dismiss, which is the obligation this panel exists
+        // without.
+        match key.code {
+            KeyCode::Down | KeyCode::Char('j') => {
+                crate::selection::down(&mut self.scroll, 1, self.drawn);
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                crate::selection::up(&mut self.scroll, 1, self.drawn);
+            }
+            KeyCode::PageDown => crate::selection::down(&mut self.scroll, 10, self.drawn),
+            KeyCode::PageUp => crate::selection::up(&mut self.scroll, 10, self.drawn),
+            KeyCode::Char('G') | KeyCode::End => {
+                crate::selection::down(&mut self.scroll, usize::MAX, self.drawn);
+            }
+            KeyCode::Char('g') | KeyCode::Home => {
+                crate::selection::up(&mut self.scroll, usize::MAX, self.drawn);
+            }
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> KeyOutcome {
+        match event.kind {
+            MouseEventKind::ScrollDown => crate::selection::down(&mut self.scroll, 1, self.drawn),
+            MouseEventKind::ScrollUp => crate::selection::up(&mut self.scroll, 1, self.drawn),
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        let theme = ctx.theme;
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let log = ctx.watch;
+        let unseen = log.unseen();
+        let mut items: Vec<ListItem> = Vec::new();
+
+        for (index, entry) in log.entries().enumerate() {
+            // Drawn *before* the entry it precedes, so it sits between the
+            // newer entries above and the older ones below.
+            if unseen == Some(index) {
+                items.push(ListItem::new(rule_line(
+                    area.width,
+                    "since you were here",
+                    theme,
+                )));
+            }
+            items.push(ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{} ", entry.at.strftime("%H:%M")),
+                    Style::default().fg(theme.muted),
+                ),
+                Span::styled(entry.text.clone(), Style::default().fg(theme.text)),
+            ])));
+        }
+
+        if items.is_empty() {
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from(Span::styled(
+                        "Nothing has happened",
+                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(Span::styled(
+                        format!("since {}.", started(log.since())),
+                        Style::default().fg(theme.muted),
+                    )),
+                ]),
+                area,
+            );
+            self.drawn = 0;
+            return;
+        }
+
+        // The foot, always last: the log begins where mirador did and says so
+        // rather than looking like a complete history that happens to be short.
+        items.push(ListItem::new(Line::from(Span::styled(
+            format!("watching from {}", started(log.since())),
+            Style::default().fg(theme.muted),
+        ))));
+
+        self.drawn = items.len();
+        frame.render_stateful_widget(List::new(items), area, &mut self.scroll);
+    }
+}
+
+/// `08:12`, or `Sat 08:12` once the log has been running past midnight.
+fn started(since: &Zoned) -> String {
+    if since.date() == Zoned::now().date() {
+        since.strftime("%H:%M").to_string()
+    } else {
+        since.strftime("%a %H:%M").to_string()
+    }
+}
+
+/// `──────── label ────`, filling the width.
+fn rule_line(width: u16, label: &str, theme: &crate::theme::Theme) -> Line<'static> {
+    let style = Style::default().fg(theme.rule);
+    let label_width = crate::grid::display_width(label) + 2;
+    let dashes = usize::from(width).saturating_sub(label_width);
+    // Weighted towards the right so the label sits near the entries it
+    // separates rather than floating in the middle of the panel.
+    let left = dashes.saturating_sub(dashes / 3);
+    Line::from(vec![
+        Span::styled("─".repeat(left), style),
+        Span::styled(format!(" {label} "), Style::default().fg(theme.muted)),
+        Span::styled("─".repeat(dashes - left), style),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_rule_line_fills_its_width_exactly() {
+        let theme = crate::theme::Theme::default();
+        for width in 24..90u16 {
+            let line = rule_line(width, "since you were here", &theme);
+            let drawn: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            assert_eq!(
+                crate::grid::display_width(&drawn),
+                usize::from(width),
+                "at {width}"
+            );
+        }
+    }
+
+    /// The frame carries no counter, and that is a decision rather than an
+    /// omission. Every other list panel here has one — `4 open`, `2 today` —
+    /// so the obvious "improvement" is to give this one `3 new`. That number is
+    /// a badge, a badge accumulates, and an accumulating badge is exactly the
+    /// unread-message count this dashboard turned down. If this assertion ever
+    /// fails, the question to ask is not how to fix the test.
+    #[test]
+    fn the_panel_never_offers_a_counter() {
+        assert_eq!(WatchLogPanel::new().counter(), None);
+    }
+
+    /// The log is read, never edited. A key that dismissed an entry would make
+    /// the log something you are expected to keep up with, which is the
+    /// obligation this panel is designed to avoid.
+    #[test]
+    fn nothing_dismisses_acknowledges_or_clears_an_entry() {
+        let mut panel = WatchLogPanel::new();
+        panel.drawn = 5;
+        for code in [
+            KeyCode::Char('d'),
+            KeyCode::Char('c'),
+            KeyCode::Char('x'),
+            KeyCode::Delete,
+            KeyCode::Backspace,
+            KeyCode::Enter,
+            KeyCode::Char(' '),
+        ] {
+            assert_eq!(
+                panel.handle_key(KeyEvent::from(code)),
+                KeyOutcome::Ignored,
+                "{code:?} must not be a way to act on an entry"
+            );
+        }
+    }
+}


### PR DESCRIPTION
The design thesis names three instruments — *"chronometer, weather glass, watch log"* — and only two of them existed. This is the third, and "what changed since I last looked" is what it was always for.

## Three findings shaped this more than the request did

**"Since I last looked" is unknowable.** The dashboard cannot see you looking, and the moments it most needs to be right are the glances that touch nothing — which is the entire point of a panel you read without focusing. So mirador enables terminal focus reporting (the closest honest signal), falls back to last keypress, and draws **no** rule line when neither has fired. A line in the wrong place makes a claim; a missing one says nothing.

**Almost nothing that changes is news.** Readings, prices and graphs move continuously; notes and tasks move because you moved them. What survives is small: an entry appearing in a calendar someone else writes to, and a task going overdue because the day turned. The bar is written into the trait doc — the failure mode is a log nobody can scan, which costs the feature rather than the panel.

**Why this isn't the feature already rejected.** Unread counts were turned down as a doomscroll hook. Read closely, that objection is about the *badge* — a number that accumulates and demands you zero it. So: no counter in the frame, no unread state, no effect on any other panel, and nothing can be dismissed or acknowledged, because an entry you can dismiss is an entry you're expected to dismiss. Two tests pin it, and one says in its failure message that the answer is not to fix the test.

## Two decisions that went against my instinct

**It ships in the default layout.** I wanted it opt-in, but the project's own invariant is that the default places every widget — citing notes and stocks having gone unseen — and leaving it out would make the startup hint nag about it every launch, which is worse for calm than placing it. Measured at 150x42 and 120x40 before choosing where.

**It doesn't persist.** A file would return from a restart with a hole in it — the hours mirador wasn't running and observed nothing — which it can't mark. The log begins when the process does and says so. Same discipline as weather showing a reading's age. For the same reason the first read of a calendar isn't news: `AgendaPanel::known` is `None` until one read succeeds, so startup doesn't announce forty events.

## Verified end to end

Under tmux with a real `.ics`: the first read was silent, adding an event logged `09:45 Budget sync appeared in your calendar`, a keypress then a second event produced exactly the intended shape —

```
│ 09:45 Retro appeared i │
│ ─ since you were here  │
│ 09:45 Budget sync appe │
│ watching from 09:44    │
```

**One caveat I could not resolve:** focus reporting is unverified. A headless tmux server has no attached client to *have* focus, so my probe couldn't distinguish "unsupported" from "nothing is focused here". The keypress fallback carries the feature until someone confirms it on a real terminal; tmux also needs `focus-events on`.

536 tests; clippy, fmt, rustdoc all silent.