### PR TITLE
Pick a clock from a list of cities, not from an identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Adding a clock offers a list of cities instead of asking for an identifier.**
+  Type to narrow it, `↑↓` to choose. Matching runs over the city *and* the
+  identifier, anywhere in either, so `seattle` finds `America/Los_Angeles` —
+  which is the whole point: the identifier names *a* city in the zone and it is
+  very often not the one you have in mind. Bengaluru is `Asia/Kolkata`, Boston
+  is `America/New_York`.
+
+  The city you picked becomes the clock's label, and the identifier is shown
+  beside it so what lands in `zones.toml` is never a surprise. A zone the list
+  does not carry is still taken as typed.
+
+### Fixed
+
+- **A panel's prompt is no longer drawn inside that panel.** The agenda's file
+  prompt was as narrow as the agenda, which for a long path meant reading a
+  scrolled fragment through about forty columns. Prompts are drawn by the shell
+  over the whole terminal now, after every panel — which is also what stopped
+  the new city list coming out interleaved with the task list.
+
 ## [0.11.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,9 @@ config/      mod.rs: paths, loading, validation; widgets.rs: one settings
              struct per panel; layout.rs: the grid
 picker.rs    the `w` dialog — owns its cursor, returns an Action to the shell
 arrange.rs   the `m` mode's arithmetic: where a panel goes when you move it
-prompt.rs    the one-line question a panel asks for a path, place or zone
-zones.rs     world clocks as a data file, the watchlist trick again
+prompt.rs    the one-line question a panel asks for a path, place or zone,
+             with an optional list to choose from
+zones.rs     world clocks as a data file, plus the city→zone table
 migrate.rs   textual in-place upgrade of configs written by older versions
 layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
 store.rs     write_atomic — every file mirador owns goes through it
@@ -439,6 +440,18 @@ age rather than implying it is current.
 **The first read of a calendar is not news.** `AgendaPanel::known` is `None`
 until the first successful read, so a startup does not announce every event in
 your `.ics`. A log that opens with forty entries is a log nobody reads twice.
+
+## A panel dialog is drawn by the shell, not the panel
+
+`Panel::overlay` returns the open prompt and `App::render` draws it after every
+panel, beside the help overlay and the picker. This is not tidiness: panels are
+drawn in order, so anything a panel paints outside its own rectangle is painted
+over by the panels after it. The zone picker was first written to draw itself
+and came out interleaved with the task list, because the clock is panel one and
+nine panels are drawn on top of it.
+
+The corollary is that a panel's `render` must stay inside the rectangle it is
+given. Nothing enforces it; the failure looks like a corrupt terminal.
 
 ## Recently settled, so it is not re-litigated
 

--- a/README.md
+++ b/README.md
@@ -361,13 +361,24 @@ offset *relative to that zone*, which is the number you actually want when
 scheduling across one. The calendar prints month grids in the shape `cal`
 does, with today marked.
 
-`a` adds a clock and `d` removes the selected one. Type a timezone —
-`Europe/Lisbon` — and `Tab` completes it as far as the candidates agree; the
-city becomes the label. Write `HQ = Europe/Berlin` to name it yourself. Like
-the watchlist, the live list is a data file (`zones.toml`) rather than config,
-which is what lets the panel own it; `[clocks].zones` seeds your first run. The
-large clock is not removable, because a clock panel with nothing to draw large
-is not a clock panel.
+`a` adds a clock and `d` removes the selected one. Adding one opens a list of
+cities; type to narrow it, `↑↓` to choose, `Enter` to add.
+
+**Search by the city you mean, not the one in the identifier.** Seattle keeps
+time in `America/Los_Angeles`, Bengaluru in `Asia/Kolkata`, Boston in
+`America/New_York` — and nobody should have to know that before they can add a
+clock. Typing matches the city *or* the identifier, anywhere in either, so
+`seattle`, `los_angeles` and `america/` all find the same zone. The city you
+picked becomes the clock's label, and the identifier is shown beside it so what
+ends up in your config is never a surprise.
+
+Anything not on the list still works: type a zone it does not carry and it is
+taken as written, with `HQ = Europe/Berlin` naming it yourself.
+
+Like the watchlist, the live list is a data file (`zones.toml`) rather than
+config, which is what lets the panel own it; `[clocks].zones` seeds your first
+run. The large clock is not removable, because a clock panel with nothing to
+draw large is not a clock panel.
 
 ```
 ╭┤1 Calendar├───────────────────╮

--- a/src/app.rs
+++ b/src/app.rs
@@ -1323,6 +1323,15 @@ impl App {
             );
         }
 
+        // Panel dialogs, before the shell's own overlays and after every
+        // panel: drawn any earlier and the panels following the one that owns
+        // the dialog paint straight over it.
+        for slot in &self.slots {
+            if let Some(prompt) = slot.panel.overlay() {
+                prompt.render(frame, area, &self.config.theme);
+            }
+        }
+
         if self.show_help {
             self.render_help(frame, area);
         }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -179,6 +179,23 @@ pub trait Panel {
         Vec::new()
     }
 
+    /// A dialog this panel wants drawn over the whole screen.
+    ///
+    /// Returned rather than drawn in [`render`] because the shell draws panels
+    /// in order, so anything a panel paints outside its own rectangle is
+    /// immediately painted over by the panels after it. The first version of
+    /// the zone picker did exactly that and came out interleaved with the task
+    /// list. The shell draws these last, alongside the help overlay and the
+    /// panel picker, which are screen-wide for the same reason.
+    ///
+    /// A panel with a dialog open also returns `true` from
+    /// [`captures_input`](Panel::captures_input), so at most one is ever open.
+    ///
+    /// [`render`]: Panel::render
+    fn overlay(&self) -> Option<&crate::prompt::Prompt> {
+        None
+    }
+
     /// Draw the panel's contents. `area` is already inside the frame and its
     /// padding.
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -32,8 +32,12 @@ pub enum Completion {
     None,
     /// Filesystem paths, for the agenda file.
     Paths,
-    /// A fixed list the caller supplies, for timezone names.
-    Names(&'static [&'static str]),
+    /// A list to choose from, shown under the field and narrowed as you type.
+    ///
+    /// For a value the reader is not expected to know by heart. A timezone is
+    /// the case that prompted it: the identifier names a city, and it is very
+    /// often not the city the reader means.
+    Places(&'static [crate::zones::Place]),
 }
 
 /// What a keypress did.
@@ -43,8 +47,17 @@ pub enum Outcome {
     Editing,
     /// Backed out; the panel should close the prompt and change nothing.
     Cancelled,
-    /// The user pressed Enter. The panel decides whether to accept it.
+    /// Enter, with nothing selected from a list: whatever was typed. The panel
+    /// decides whether to accept it.
     Submitted(String),
+    /// Enter, on a row of the list. Carries the label the reader recognised as
+    /// well as the value, because the two differ and the label is the better
+    /// name for the thing — someone who picked Seattle wants a clock that says
+    /// Seattle, not one that says Los Angeles.
+    Chose {
+        label: &'static str,
+        value: &'static str,
+    },
 }
 
 /// An open prompt.
@@ -55,6 +68,8 @@ pub struct Prompt {
     field: TextField,
     error: Option<String>,
     completion: Completion,
+    /// Which row of the filtered list is selected, if any.
+    selected: usize,
 }
 
 impl Prompt {
@@ -71,7 +86,30 @@ impl Prompt {
             field: TextField::with_value(value),
             error: None,
             completion,
+            selected: 0,
         }
+    }
+
+    /// The list rows matching what has been typed so far.
+    ///
+    /// Matched against the city *and* the identifier, case-insensitively and
+    /// anywhere in either — so `seattle` finds `America/Los_Angeles`, `asia`
+    /// finds every Asian zone, and `kolkata` finds the identifier directly.
+    /// Prefix-only matching would answer half these and is the reason a plain
+    /// completion was not enough.
+    pub fn matches(&self) -> Vec<&'static crate::zones::Place> {
+        let Completion::Places(places) = self.completion else {
+            return Vec::new();
+        };
+        let needle = self.field.trimmed().to_lowercase();
+        places
+            .iter()
+            .filter(|place| {
+                needle.is_empty()
+                    || place.city.to_lowercase().contains(&needle)
+                    || place.tz.to_lowercase().contains(&needle)
+            })
+            .collect()
     }
 
     /// Refuse the answer and say why, leaving the text in place to be fixed.
@@ -90,15 +128,35 @@ impl Prompt {
         // complaint goes.
         self.error = None;
 
+        let listed = self.matches();
         match key.code {
             KeyCode::Esc => Outcome::Cancelled,
-            KeyCode::Enter => Outcome::Submitted(self.field.trimmed().to_string()),
+            KeyCode::Down => {
+                self.selected = (self.selected + 1).min(listed.len().saturating_sub(1));
+                Outcome::Editing
+            }
+            KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+                Outcome::Editing
+            }
+            KeyCode::Enter => match listed.get(self.selected) {
+                Some(place) => Outcome::Chose {
+                    label: place.city,
+                    value: place.tz,
+                },
+                // Nothing matched, so the reader knows something the list does
+                // not. Hand back what they typed rather than refusing it.
+                None => Outcome::Submitted(self.field.trimmed().to_string()),
+            },
             KeyCode::Tab => {
                 self.complete();
                 Outcome::Editing
             }
             _ => {
                 self.field.handle_key(key);
+                // Typing narrows the list under the cursor, so a selection two
+                // rows down would otherwise land on something unrelated.
+                self.selected = 0;
                 Outcome::Editing
             }
         }
@@ -113,12 +171,13 @@ impl Prompt {
     fn complete(&mut self) {
         let typed = self.field.value().to_string();
         let (fixed, stem) = match self.completion {
-            Completion::None => return,
+            // A list is chosen from rather than completed into, so neither of
+            // these has anything for Tab to do.
+            Completion::None | Completion::Places(_) => return,
             Completion::Paths => match typed.rfind('/') {
                 Some(cut) => (typed[..=cut].to_string(), typed[cut + 1..].to_string()),
                 None => (String::new(), typed.clone()),
             },
-            Completion::Names(_) => (String::new(), typed.clone()),
         };
 
         let candidates = self.candidates(&fixed, &stem);
@@ -135,14 +194,7 @@ impl Prompt {
 
     fn candidates(&self, fixed: &str, stem: &str) -> Vec<String> {
         match self.completion {
-            Completion::None => Vec::new(),
-            Completion::Names(names) => names
-                .iter()
-                .filter(|name| {
-                    name.len() >= stem.len() && name[..stem.len()].eq_ignore_ascii_case(stem)
-                })
-                .map(|name| (*name).to_string())
-                .collect(),
+            Completion::None | Completion::Places(_) => Vec::new(),
             Completion::Paths => {
                 let directory = expand_tilde(if fixed.is_empty() { "./" } else { fixed });
                 let Ok(entries) = std::fs::read_dir(&directory) else {
@@ -165,19 +217,59 @@ impl Prompt {
         }
     }
 
-    /// Draw the prompt over the middle of `area`.
-    pub fn render(&self, frame: &mut ratatui::Frame, area: Rect, theme: &Theme) {
-        let width = area.width.clamp(20, 64);
-        let popup = crate::frame::centred(area, width, 3 + crate::frame::FRAME_HEIGHT);
+    /// Draw the prompt over the middle of `screen`.
+    ///
+    /// `screen` is the whole terminal rather than the calling panel's slice of
+    /// it. A dialog confined to its panel is as narrow as the panel, which for
+    /// the agenda meant a long path scrolled inside about forty columns.
+    pub fn render(&self, frame: &mut ratatui::Frame, screen: Rect, theme: &Theme) {
+        let listed = self.matches();
+        let rows = u16::try_from(listed.len().min(10)).unwrap_or(0);
+
+        let width = screen.width.clamp(20, 64);
+        let height = 3 + rows + crate::frame::FRAME_HEIGHT;
+        let popup = crate::frame::centred(screen, width, height);
 
         // Room for the text, inside the border and its padding.
         let inner = usize::from(width).saturating_sub(usize::from(crate::frame::FRAME_WIDTH));
         let (visible, cursor) = self.field.visible(inner);
 
-        let mut lines = vec![
-            Line::from(Span::styled(visible, Style::default().fg(theme.text))),
-            Line::from(""),
-        ];
+        let mut lines = vec![Line::from(Span::styled(
+            visible,
+            Style::default().fg(theme.text),
+        ))];
+
+        // The list, if there is one, between the field and the help line.
+        let city_width = listed
+            .iter()
+            .map(|p| p.city.len())
+            .max()
+            .unwrap_or(0)
+            .min(18);
+        for (index, place) in listed.iter().take(usize::from(rows)).enumerate() {
+            let here = index == self.selected;
+            lines.push(Line::from(vec![
+                Span::styled(
+                    if here { "▸ " } else { "  " },
+                    Style::default().fg(theme.accent),
+                ),
+                Span::styled(
+                    format!("{:<city_width$}  ", place.city),
+                    if here {
+                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(theme.text)
+                    },
+                ),
+                // The identifier is shown as well as the city, because it is
+                // what ends up in your config and in zones.toml — picking
+                // Seattle and finding `America/Los_Angeles` written down later
+                // should not be a surprise.
+                Span::styled(place.tz, Style::default().fg(theme.muted)),
+            ]));
+        }
+
+        lines.push(Line::from(""));
         lines.push(match &self.error {
             Some(error) => Line::from(Span::styled(
                 crate::grid::truncate(error, inner),
@@ -246,15 +338,27 @@ fn common_prefix(candidates: &[String]) -> Option<String> {
 mod tests {
     use super::*;
 
-    const ZONES: &[&str] = &[
-        "Europe/London",
-        "Europe/Lisbon",
-        "Europe/Madrid",
-        "Asia/Tokyo",
+    const PLACES: &[crate::zones::Place] = &[
+        crate::zones::Place {
+            city: "London",
+            tz: "Europe/London",
+        },
+        crate::zones::Place {
+            city: "Lisbon",
+            tz: "Europe/Lisbon",
+        },
+        crate::zones::Place {
+            city: "Seattle",
+            tz: "America/Los_Angeles",
+        },
+        crate::zones::Place {
+            city: "Tokyo",
+            tz: "Asia/Tokyo",
+        },
     ];
 
     fn prompt(value: &str) -> Prompt {
-        Prompt::new("ZONE", "help", value, Completion::Names(ZONES))
+        Prompt::new("ZONE", "help", value, Completion::Places(PLACES))
     }
 
     fn press(prompt: &mut Prompt, code: KeyCode) -> Outcome {
@@ -262,33 +366,81 @@ mod tests {
     }
 
     #[test]
-    fn enter_submits_the_trimmed_text_and_esc_abandons_it() {
-        let mut p = prompt("  Asia/Tokyo  ");
-        assert_eq!(
-            press(&mut p, KeyCode::Enter),
-            Outcome::Submitted("Asia/Tokyo".into())
-        );
+    fn esc_abandons_it() {
         assert_eq!(press(&mut prompt("x"), KeyCode::Esc), Outcome::Cancelled);
     }
 
-    /// Completing to the first match would pick Lisbon over London with nothing
-    /// on screen saying a choice had been made.
+    /// The headline case, and the reason a plain completion was not enough:
+    /// Seattle keeps time in `America/Los_Angeles`, and nobody should have to
+    /// know that before they can add a clock. Prefix matching cannot answer it.
     #[test]
-    fn tab_stops_where_the_candidates_stop_agreeing() {
-        let mut p = prompt("Europe/L");
-        press(&mut p, KeyCode::Tab);
-        assert_eq!(p.value(), "Europe/L", "London and Lisbon differ here");
+    fn a_city_finds_the_zone_it_is_actually_in() {
+        let mut p = prompt("");
+        for c in "seattle".chars() {
+            p.handle_key(KeyEvent::from(KeyCode::Char(c)));
+        }
+        let found: Vec<&str> = p.matches().iter().map(|place| place.tz).collect();
+        assert_eq!(found, ["America/Los_Angeles"]);
+    }
 
-        let mut p = prompt("Europe/Lo");
-        press(&mut p, KeyCode::Tab);
-        assert_eq!(p.value(), "Europe/London", "only one candidate left");
+    /// And the identifier still works, for someone who knows it.
+    #[test]
+    fn the_identifier_matches_as_well_as_the_city() {
+        let mut p = prompt("");
+        for c in "europe/".chars() {
+            p.handle_key(KeyEvent::from(KeyCode::Char(c)));
+        }
+        let found: Vec<&str> = p.matches().iter().map(|place| place.city).collect();
+        assert_eq!(found, ["London", "Lisbon"]);
+    }
+
+    /// Choosing carries the label as well as the value, because they differ:
+    /// someone who picked Seattle wants a clock that says Seattle.
+    #[test]
+    fn choosing_a_row_returns_the_city_as_the_label() {
+        let mut p = prompt("seattle");
+        assert_eq!(
+            press(&mut p, KeyCode::Enter),
+            Outcome::Chose {
+                label: "Seattle",
+                value: "America/Los_Angeles"
+            }
+        );
+    }
+
+    /// A reader who types a zone the list has never heard of knows something
+    /// the list does not. Refusing them would make a convenience into a cage.
+    #[test]
+    fn text_matching_nothing_is_handed_back_rather_than_refused() {
+        let mut p = prompt("  Antarctica/Troll  ");
+        assert!(p.matches().is_empty(), "nothing in the list matches");
+        assert_eq!(
+            press(&mut p, KeyCode::Enter),
+            Outcome::Submitted("Antarctica/Troll".into())
+        );
     }
 
     #[test]
-    fn tab_on_nothing_matching_leaves_the_text_alone() {
-        let mut p = prompt("Mars/");
+    fn the_selection_clamps_and_returns_to_the_top_when_the_list_narrows() {
+        let mut p = prompt("");
+        for _ in 0..20 {
+            press(&mut p, KeyCode::Down);
+        }
+        assert_eq!(p.selected, PLACES.len() - 1, "clamped at the end");
+
+        // Typing narrows the list under the cursor, so a stale index would
+        // leave the highlight on something unrelated — or past the end.
+        p.handle_key(KeyEvent::from(KeyCode::Char('l')));
+        assert_eq!(p.selected, 0);
+    }
+
+    /// A list is chosen from, not completed into — `Tab` would be a second
+    /// way to do what the arrows already do, and a worse one.
+    #[test]
+    fn tab_does_nothing_when_the_prompt_offers_a_list() {
+        let mut p = prompt("Lis");
         press(&mut p, KeyCode::Tab);
-        assert_eq!(p.value(), "Mars/");
+        assert_eq!(p.value(), "Lis");
     }
 
     /// The whole reason a rejection keeps the text: a path is long, and being

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -186,7 +186,10 @@ impl AgendaPanel {
             return;
         };
         match prompt.handle_key(key) {
-            crate::prompt::Outcome::Editing => {}
+            // `Chose` cannot arise: this prompt offers no list. It is grouped
+            // with `Editing` rather than given its own empty arm because an
+            // arm that does nothing invites someone to make it do something.
+            crate::prompt::Outcome::Editing | crate::prompt::Outcome::Chose { .. } => {}
             crate::prompt::Outcome::Cancelled => self.asking = None,
             crate::prompt::Outcome::Submitted(answer) => {
                 let path = crate::prompt::expand_tilde(&answer);
@@ -479,6 +482,10 @@ impl Panel for AgendaPanel {
         std::mem::take(&mut self.pending)
     }
 
+    fn overlay(&self) -> Option<&crate::prompt::Prompt> {
+        self.asking.as_ref()
+    }
+
     fn captures_input(&self) -> bool {
         self.asking.is_some()
     }
@@ -538,9 +545,6 @@ impl Panel for AgendaPanel {
             return;
         }
 
-        // Kept before the area is divided up, so the prompt can be drawn over
-        // the whole panel at the end.
-        let whole = area;
         let state = self.snapshot();
         let now = Zoned::now();
 
@@ -573,12 +577,6 @@ impl Panel for AgendaPanel {
 
         if notice_area.height > 0 {
             frame.render_widget(Paragraph::new(notices), notice_area);
-        }
-
-        // Last, and across the whole panel rather than the list: a dialog drawn
-        // before the list and the notices would be painted over by both.
-        if let Some(prompt) = &self.asking {
-            prompt.render(frame, whole, theme);
         }
     }
 

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -156,6 +156,18 @@ impl ClocksPanel {
         match prompt.handle_key(key) {
             crate::prompt::Outcome::Editing => {}
             crate::prompt::Outcome::Cancelled => self.asking = None,
+            // Picked from the list: the city the reader recognised becomes
+            // the clock's label, which is the whole reason the outcome carries
+            // both. Nothing needs validating — the list only holds zones that
+            // resolve, and a test holds it to that.
+            crate::prompt::Outcome::Chose { label, value } => {
+                if self.zones.add(label, value) {
+                    self.asking = None;
+                    self.reload();
+                } else if let Some(prompt) = self.asking.as_mut() {
+                    prompt.reject("that clock is already on the panel");
+                }
+            }
             crate::prompt::Outcome::Submitted(answer) => {
                 // `Label = Zone` if you want to name it, otherwise just the
                 // zone and the city out of it becomes the label.
@@ -284,6 +296,10 @@ impl Panel for ClocksPanel {
         moved
     }
 
+    fn overlay(&self) -> Option<&crate::prompt::Prompt> {
+        self.asking.as_ref()
+    }
+
     fn captures_input(&self) -> bool {
         self.asking.is_some()
     }
@@ -303,9 +319,9 @@ impl Panel for ClocksPanel {
             KeyCode::Char('a') => {
                 self.asking = Some(crate::prompt::Prompt::new(
                     "ADD A CLOCK",
-                    "Zone, or Label = Zone · Tab completes · Enter adds",
+                    "Type to narrow · ↑↓ to choose · Enter adds · Esc cancels",
                     "",
-                    crate::prompt::Completion::Names(crate::zones::COMMON),
+                    crate::prompt::Completion::Places(crate::zones::PLACES),
                 ));
             }
             KeyCode::Char('d') => {
@@ -338,9 +354,6 @@ impl Panel for ClocksPanel {
         if area.width == 0 || area.height == 0 {
             return;
         }
-        // Kept before the area is carved up, so the prompt can be drawn across
-        // the whole panel at the end.
-        let whole = area;
 
         let now = jiff::Timestamp::now();
         let primary_zone = match &self.primary.zone {
@@ -551,10 +564,6 @@ impl Panel for ClocksPanel {
                 Rect::new(area.x, area.y + area.height - 1, area.width, 1),
             );
         }
-
-        if let Some(prompt) = &self.asking {
-            prompt.render(frame, whole, theme);
-        }
     }
 }
 
@@ -664,7 +673,9 @@ mod tests {
         assert_eq!(labels(&panel), before, "and nothing was added");
     }
 
-    /// `Label = Zone` names the clock; a bare zone takes the city out of it.
+    /// Picking from the list names the clock after the city you recognised,
+    /// and the `Label = Zone` form still works for anyone typing a zone the
+    /// list does not carry.
     #[test]
     fn a_clock_can_be_added_with_or_without_a_label() {
         let (mut panel, _guard) = panel_from_named(
@@ -676,18 +687,22 @@ mod tests {
         );
 
         press(&mut panel, KeyCode::Char('a'));
-        for c in "Asia/Kolkata".chars() {
+        for c in "Bengaluru".chars() {
             panel.handle_key(KeyEvent::from(KeyCode::Char(c)));
         }
         press(&mut panel, KeyCode::Enter);
-        assert_eq!(labels(&panel), ["Kolkata"], "named after its city");
+        assert_eq!(
+            labels(&panel),
+            ["Bengaluru"],
+            "the city you picked, not the one in the identifier"
+        );
 
         press(&mut panel, KeyCode::Char('a'));
         for c in "HQ = Europe/Berlin".chars() {
             panel.handle_key(KeyEvent::from(KeyCode::Char(c)));
         }
         press(&mut panel, KeyCode::Enter);
-        assert_eq!(labels(&panel), ["Kolkata", "HQ"], "or named by you");
+        assert_eq!(labels(&panel), ["Bengaluru", "HQ"], "or named by you");
     }
 
     #[test]

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -271,7 +271,10 @@ impl WeatherPanel {
             return;
         };
         match prompt.handle_key(key) {
-            crate::prompt::Outcome::Editing => {}
+            // `Chose` cannot arise: this prompt offers no list. It is grouped
+            // with `Editing` rather than given its own empty arm because an
+            // arm that does nothing invites someone to make it do something.
+            crate::prompt::Outcome::Editing | crate::prompt::Outcome::Chose { .. } => {}
             crate::prompt::Outcome::Cancelled => self.asking = None,
             crate::prompt::Outcome::Submitted(answer) => {
                 if answer.is_empty() {
@@ -820,6 +823,10 @@ impl Panel for WeatherPanel {
         moved
     }
 
+    fn overlay(&self) -> Option<&crate::prompt::Prompt> {
+        self.asking.as_ref()
+    }
+
     fn captures_input(&self) -> bool {
         self.asking.is_some()
     }
@@ -940,12 +947,6 @@ impl Panel for WeatherPanel {
 
         if rows[2].height > 0 {
             render_forecast(frame, rows[2], theme, &data);
-        }
-
-        // Over everything, and last: a dialog drawn earlier would be painted
-        // over by the forecast beneath it.
-        if let Some(prompt) = &self.asking {
-            prompt.render(frame, area, theme);
         }
     }
 }

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -15,74 +15,601 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ClockZone;
 
-/// Timezone names offered for completion.
+/// Cities offered when adding a clock, and the zone each one is in.
 ///
-/// Deliberately a short list of the ones people actually type rather than the
-/// six hundred in the IANA database. Completion exists so you do not have to
-/// remember whether it is `Asia/Calcutta` or `Asia/Kolkata`; it is not a
-/// browser, and a list this size fits in the binary for nothing.
+/// Many cities to one zone, deliberately — that is the entire point. The IANA
+/// identifier names *a* city in the zone, and it is very often not the one the
+/// reader has in mind: Seattle is `America/Los_Angeles`, Bengaluru is
+/// `Asia/Kolkata`, Boston is `America/New_York`. Asking someone to know that
+/// before they can add a clock is asking the wrong question.
 ///
-/// Anything else still works — the name is handed to jiff, which knows the
-/// whole database. This only decides what `Tab` can finish for you.
-pub const COMMON: &[&str] = &[
-    "Africa/Cairo",
-    "Africa/Johannesburg",
-    "Africa/Lagos",
-    "Africa/Nairobi",
-    "America/Argentina/Buenos_Aires",
-    "America/Bogota",
-    "America/Chicago",
-    "America/Denver",
-    "America/Halifax",
-    "America/Los_Angeles",
-    "America/Mexico_City",
-    "America/New_York",
-    "America/Phoenix",
-    "America/Sao_Paulo",
-    "America/Toronto",
-    "America/Vancouver",
-    "Asia/Bangkok",
-    "Asia/Dubai",
-    "Asia/Hong_Kong",
-    "Asia/Jakarta",
-    "Asia/Jerusalem",
-    "Asia/Kolkata",
-    "Asia/Manila",
-    "Asia/Seoul",
-    "Asia/Shanghai",
-    "Asia/Singapore",
-    "Asia/Taipei",
-    "Asia/Tokyo",
-    "Australia/Brisbane",
-    "Australia/Melbourne",
-    "Australia/Perth",
-    "Australia/Sydney",
-    "Europe/Amsterdam",
-    "Europe/Athens",
-    "Europe/Berlin",
-    "Europe/Brussels",
-    "Europe/Bucharest",
-    "Europe/Copenhagen",
-    "Europe/Dublin",
-    "Europe/Helsinki",
-    "Europe/Istanbul",
-    "Europe/Lisbon",
-    "Europe/London",
-    "Europe/Madrid",
-    "Europe/Moscow",
-    "Europe/Oslo",
-    "Europe/Paris",
-    "Europe/Prague",
-    "Europe/Rome",
-    "Europe/Stockholm",
-    "Europe/Vienna",
-    "Europe/Warsaw",
-    "Europe/Zurich",
-    "Pacific/Auckland",
-    "Pacific/Honolulu",
-    "UTC",
-    "local",
+/// Curated rather than generated. The tz database has around six hundred zones
+/// and no city labels beyond the identifiers themselves, so generating this
+/// would reproduce exactly the problem it exists to solve.
+///
+/// Anything not here still works: the prompt falls back to whatever was typed,
+/// and jiff knows the whole database.
+pub const PLACES: &[Place] = &[
+    Place {
+        city: "Auckland",
+        tz: "Pacific/Auckland",
+    },
+    Place {
+        city: "Wellington",
+        tz: "Pacific/Auckland",
+    },
+    Place {
+        city: "Sydney",
+        tz: "Australia/Sydney",
+    },
+    Place {
+        city: "Canberra",
+        tz: "Australia/Sydney",
+    },
+    Place {
+        city: "Melbourne",
+        tz: "Australia/Melbourne",
+    },
+    Place {
+        city: "Brisbane",
+        tz: "Australia/Brisbane",
+    },
+    Place {
+        city: "Perth",
+        tz: "Australia/Perth",
+    },
+    Place {
+        city: "Adelaide",
+        tz: "Australia/Adelaide",
+    },
+    Place {
+        city: "Tokyo",
+        tz: "Asia/Tokyo",
+    },
+    Place {
+        city: "Osaka",
+        tz: "Asia/Tokyo",
+    },
+    Place {
+        city: "Seoul",
+        tz: "Asia/Seoul",
+    },
+    Place {
+        city: "Taipei",
+        tz: "Asia/Taipei",
+    },
+    Place {
+        city: "Shanghai",
+        tz: "Asia/Shanghai",
+    },
+    Place {
+        city: "Beijing",
+        tz: "Asia/Shanghai",
+    },
+    Place {
+        city: "Shenzhen",
+        tz: "Asia/Shanghai",
+    },
+    Place {
+        city: "Hong Kong",
+        tz: "Asia/Hong_Kong",
+    },
+    Place {
+        city: "Singapore",
+        tz: "Asia/Singapore",
+    },
+    Place {
+        city: "Manila",
+        tz: "Asia/Manila",
+    },
+    Place {
+        city: "Jakarta",
+        tz: "Asia/Jakarta",
+    },
+    Place {
+        city: "Bangkok",
+        tz: "Asia/Bangkok",
+    },
+    Place {
+        city: "Hanoi",
+        tz: "Asia/Bangkok",
+    },
+    Place {
+        city: "Ho Chi Minh City",
+        tz: "Asia/Ho_Chi_Minh",
+    },
+    Place {
+        city: "Kuala Lumpur",
+        tz: "Asia/Kuala_Lumpur",
+    },
+    Place {
+        city: "Yangon",
+        tz: "Asia/Yangon",
+    },
+    Place {
+        city: "Dhaka",
+        tz: "Asia/Dhaka",
+    },
+    Place {
+        city: "Kathmandu",
+        tz: "Asia/Kathmandu",
+    },
+    Place {
+        city: "Mumbai",
+        tz: "Asia/Kolkata",
+    },
+    Place {
+        city: "Delhi",
+        tz: "Asia/Kolkata",
+    },
+    Place {
+        city: "Bengaluru",
+        tz: "Asia/Kolkata",
+    },
+    Place {
+        city: "Chennai",
+        tz: "Asia/Kolkata",
+    },
+    Place {
+        city: "Hyderabad",
+        tz: "Asia/Kolkata",
+    },
+    Place {
+        city: "Kolkata",
+        tz: "Asia/Kolkata",
+    },
+    Place {
+        city: "Karachi",
+        tz: "Asia/Karachi",
+    },
+    Place {
+        city: "Lahore",
+        tz: "Asia/Karachi",
+    },
+    Place {
+        city: "Islamabad",
+        tz: "Asia/Karachi",
+    },
+    Place {
+        city: "Tashkent",
+        tz: "Asia/Tashkent",
+    },
+    Place {
+        city: "Almaty",
+        tz: "Asia/Almaty",
+    },
+    Place {
+        city: "Dubai",
+        tz: "Asia/Dubai",
+    },
+    Place {
+        city: "Abu Dhabi",
+        tz: "Asia/Dubai",
+    },
+    Place {
+        city: "Muscat",
+        tz: "Asia/Dubai",
+    },
+    Place {
+        city: "Tehran",
+        tz: "Asia/Tehran",
+    },
+    Place {
+        city: "Baku",
+        tz: "Asia/Baku",
+    },
+    Place {
+        city: "Tbilisi",
+        tz: "Asia/Tbilisi",
+    },
+    Place {
+        city: "Yerevan",
+        tz: "Asia/Yerevan",
+    },
+    Place {
+        city: "Riyadh",
+        tz: "Asia/Riyadh",
+    },
+    Place {
+        city: "Doha",
+        tz: "Asia/Qatar",
+    },
+    Place {
+        city: "Kuwait City",
+        tz: "Asia/Kuwait",
+    },
+    Place {
+        city: "Baghdad",
+        tz: "Asia/Baghdad",
+    },
+    Place {
+        city: "Jerusalem",
+        tz: "Asia/Jerusalem",
+    },
+    Place {
+        city: "Tel Aviv",
+        tz: "Asia/Jerusalem",
+    },
+    Place {
+        city: "Amman",
+        tz: "Asia/Amman",
+    },
+    Place {
+        city: "Beirut",
+        tz: "Asia/Beirut",
+    },
+    Place {
+        city: "Nicosia",
+        tz: "Asia/Nicosia",
+    },
+    Place {
+        city: "Istanbul",
+        tz: "Europe/Istanbul",
+    },
+    Place {
+        city: "Ankara",
+        tz: "Europe/Istanbul",
+    },
+    Place {
+        city: "Moscow",
+        tz: "Europe/Moscow",
+    },
+    Place {
+        city: "Saint Petersburg",
+        tz: "Europe/Moscow",
+    },
+    Place {
+        city: "Kyiv",
+        tz: "Europe/Kyiv",
+    },
+    Place {
+        city: "Minsk",
+        tz: "Europe/Minsk",
+    },
+    Place {
+        city: "Athens",
+        tz: "Europe/Athens",
+    },
+    Place {
+        city: "Bucharest",
+        tz: "Europe/Bucharest",
+    },
+    Place {
+        city: "Sofia",
+        tz: "Europe/Sofia",
+    },
+    Place {
+        city: "Helsinki",
+        tz: "Europe/Helsinki",
+    },
+    Place {
+        city: "Tallinn",
+        tz: "Europe/Tallinn",
+    },
+    Place {
+        city: "Riga",
+        tz: "Europe/Riga",
+    },
+    Place {
+        city: "Vilnius",
+        tz: "Europe/Vilnius",
+    },
+    Place {
+        city: "Cairo",
+        tz: "Africa/Cairo",
+    },
+    Place {
+        city: "Johannesburg",
+        tz: "Africa/Johannesburg",
+    },
+    Place {
+        city: "Cape Town",
+        tz: "Africa/Johannesburg",
+    },
+    Place {
+        city: "Nairobi",
+        tz: "Africa/Nairobi",
+    },
+    Place {
+        city: "Addis Ababa",
+        tz: "Africa/Addis_Ababa",
+    },
+    Place {
+        city: "Lagos",
+        tz: "Africa/Lagos",
+    },
+    Place {
+        city: "Accra",
+        tz: "Africa/Accra",
+    },
+    Place {
+        city: "Casablanca",
+        tz: "Africa/Casablanca",
+    },
+    Place {
+        city: "Berlin",
+        tz: "Europe/Berlin",
+    },
+    Place {
+        city: "Munich",
+        tz: "Europe/Berlin",
+    },
+    Place {
+        city: "Frankfurt",
+        tz: "Europe/Berlin",
+    },
+    Place {
+        city: "Hamburg",
+        tz: "Europe/Berlin",
+    },
+    Place {
+        city: "Paris",
+        tz: "Europe/Paris",
+    },
+    Place {
+        city: "Madrid",
+        tz: "Europe/Madrid",
+    },
+    Place {
+        city: "Barcelona",
+        tz: "Europe/Madrid",
+    },
+    Place {
+        city: "Rome",
+        tz: "Europe/Rome",
+    },
+    Place {
+        city: "Milan",
+        tz: "Europe/Rome",
+    },
+    Place {
+        city: "Amsterdam",
+        tz: "Europe/Amsterdam",
+    },
+    Place {
+        city: "Brussels",
+        tz: "Europe/Brussels",
+    },
+    Place {
+        city: "Vienna",
+        tz: "Europe/Vienna",
+    },
+    Place {
+        city: "Zurich",
+        tz: "Europe/Zurich",
+    },
+    Place {
+        city: "Geneva",
+        tz: "Europe/Zurich",
+    },
+    Place {
+        city: "Prague",
+        tz: "Europe/Prague",
+    },
+    Place {
+        city: "Warsaw",
+        tz: "Europe/Warsaw",
+    },
+    Place {
+        city: "Budapest",
+        tz: "Europe/Budapest",
+    },
+    Place {
+        city: "Stockholm",
+        tz: "Europe/Stockholm",
+    },
+    Place {
+        city: "Oslo",
+        tz: "Europe/Oslo",
+    },
+    Place {
+        city: "Copenhagen",
+        tz: "Europe/Copenhagen",
+    },
+    Place {
+        city: "London",
+        tz: "Europe/London",
+    },
+    Place {
+        city: "Edinburgh",
+        tz: "Europe/London",
+    },
+    Place {
+        city: "Manchester",
+        tz: "Europe/London",
+    },
+    Place {
+        city: "Dublin",
+        tz: "Europe/Dublin",
+    },
+    Place {
+        city: "Lisbon",
+        tz: "Europe/Lisbon",
+    },
+    Place {
+        city: "Porto",
+        tz: "Europe/Lisbon",
+    },
+    Place {
+        city: "Reykjavik",
+        tz: "Atlantic/Reykjavik",
+    },
+    Place {
+        city: "Sao Paulo",
+        tz: "America/Sao_Paulo",
+    },
+    Place {
+        city: "Rio de Janeiro",
+        tz: "America/Sao_Paulo",
+    },
+    Place {
+        city: "Buenos Aires",
+        tz: "America/Argentina/Buenos_Aires",
+    },
+    Place {
+        city: "Montevideo",
+        tz: "America/Montevideo",
+    },
+    Place {
+        city: "Santiago",
+        tz: "America/Santiago",
+    },
+    Place {
+        city: "Lima",
+        tz: "America/Lima",
+    },
+    Place {
+        city: "Bogota",
+        tz: "America/Bogota",
+    },
+    Place {
+        city: "Caracas",
+        tz: "America/Caracas",
+    },
+    Place {
+        city: "Halifax",
+        tz: "America/Halifax",
+    },
+    Place {
+        city: "New York",
+        tz: "America/New_York",
+    },
+    Place {
+        city: "Boston",
+        tz: "America/New_York",
+    },
+    Place {
+        city: "Washington DC",
+        tz: "America/New_York",
+    },
+    Place {
+        city: "Atlanta",
+        tz: "America/New_York",
+    },
+    Place {
+        city: "Miami",
+        tz: "America/New_York",
+    },
+    Place {
+        city: "Philadelphia",
+        tz: "America/New_York",
+    },
+    Place {
+        city: "Toronto",
+        tz: "America/Toronto",
+    },
+    Place {
+        city: "Montreal",
+        tz: "America/Toronto",
+    },
+    Place {
+        city: "Ottawa",
+        tz: "America/Toronto",
+    },
+    Place {
+        city: "Detroit",
+        tz: "America/Detroit",
+    },
+    Place {
+        city: "Chicago",
+        tz: "America/Chicago",
+    },
+    Place {
+        city: "Dallas",
+        tz: "America/Chicago",
+    },
+    Place {
+        city: "Houston",
+        tz: "America/Chicago",
+    },
+    Place {
+        city: "Austin",
+        tz: "America/Chicago",
+    },
+    Place {
+        city: "Minneapolis",
+        tz: "America/Chicago",
+    },
+    Place {
+        city: "Mexico City",
+        tz: "America/Mexico_City",
+    },
+    Place {
+        city: "Winnipeg",
+        tz: "America/Winnipeg",
+    },
+    Place {
+        city: "Denver",
+        tz: "America/Denver",
+    },
+    Place {
+        city: "Salt Lake City",
+        tz: "America/Denver",
+    },
+    Place {
+        city: "Calgary",
+        tz: "America/Edmonton",
+    },
+    Place {
+        city: "Edmonton",
+        tz: "America/Edmonton",
+    },
+    Place {
+        city: "Phoenix",
+        tz: "America/Phoenix",
+    },
+    Place {
+        city: "Los Angeles",
+        tz: "America/Los_Angeles",
+    },
+    Place {
+        city: "San Francisco",
+        tz: "America/Los_Angeles",
+    },
+    Place {
+        city: "Seattle",
+        tz: "America/Los_Angeles",
+    },
+    Place {
+        city: "Portland",
+        tz: "America/Los_Angeles",
+    },
+    Place {
+        city: "San Diego",
+        tz: "America/Los_Angeles",
+    },
+    Place {
+        city: "Las Vegas",
+        tz: "America/Los_Angeles",
+    },
+    Place {
+        city: "Vancouver",
+        tz: "America/Vancouver",
+    },
+    Place {
+        city: "Anchorage",
+        tz: "America/Anchorage",
+    },
+    Place {
+        city: "Honolulu",
+        tz: "Pacific/Honolulu",
+    },
+    Place {
+        city: "UTC",
+        tz: "UTC",
+    },
+    Place {
+        city: "Local time",
+        tz: "local",
+    },
 ];
+
+/// A city and the zone it keeps time in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Place {
+    pub city: &'static str,
+    pub tz: &'static str,
+}
 
 /// The clocks on screen, in order.
 #[derive(Debug)]
@@ -243,17 +770,20 @@ mod tests {
         assert_eq!(zones.zones().len(), 2);
     }
 
-    /// Every name offered for completion has to be one jiff will actually
-    /// accept, or `Tab` would help you type something that is then rejected.
+    /// Every zone in the picker has to be one jiff will actually accept.
+    /// Choosing a city from a list and being told the zone is unknown would be
+    /// the list's fault, and there is nothing the reader could do about it.
     #[test]
     fn every_offered_timezone_resolves() {
-        for name in COMMON {
-            if *name == "local" {
+        for place in PLACES {
+            if place.tz == "local" {
                 continue;
             }
             assert!(
-                jiff::tz::TimeZone::get(name).is_ok(),
-                "`{name}` is offered for completion but does not resolve"
+                jiff::tz::TimeZone::get(place.tz).is_ok(),
+                "`{}` is offered for {} but does not resolve",
+                place.tz,
+                place.city
             );
         }
     }


### PR DESCRIPTION
Adding a clock meant typing `Europe/Lisbon` — which assumes you know the identifier, and the identifier's city is very often not the one you have in mind:

| You mean | You had to type |
| --- | --- |
| Seattle | `America/Los_Angeles` |
| Bengaluru | `Asia/Kolkata` |
| Boston | `America/New_York` |

Now `a` opens a list of cities. Type to narrow, `↑↓` to choose, `Enter` to add.

Matching runs over the city **or** the identifier, anywhere in either — not by prefix. That's precisely what lets `seattle` find a zone with no "seattle" anywhere in its name, and it's why a better completion wouldn't have done.

The city you picked becomes the clock's label (someone who picked Seattle wants a clock saying Seattle), and the identifier is shown beside it so finding `America/Los_Angeles` in `zones.toml` later isn't a surprise. A zone the list doesn't carry is still taken as typed — someone who knows `Antarctica/Troll` knows something the list doesn't.

143 places, many-to-one by design. Curated rather than generated: the tz database has no city labels beyond the identifiers, so generating it would reproduce the exact problem it exists to solve. A test asserts every offered zone resolves in jiff.

## Two things found by running it

**The dialog was drawn by the panel that owned it**, and panels are drawn in order — so the clock's picker was painted over by the nine panels after it and came out interleaved with the task list. Panels return their prompt through a new `Panel::overlay` now and the shell draws it last, beside the help overlay and the `w` picker, which are screen-wide for the same reason.

**That also fixes something already shipped:** the agenda's file prompt was confined to the agenda panel, so a long path was read as a scrolled fragment through ~40 columns.

## Verified

Under tmux: picking Seattle wrote `label = "Seattle"` / `timezone = "America/Los_Angeles"` and the clock read 12:14 against 19:14 UTC. Typing `Antarctica/Troll` — not in the list — fell through and was written as given.

540 tests; clippy, fmt and rustdoc silent.