### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] - 2026-07-27
 
 ### Changed
 
@@ -827,7 +827,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/jchultarsky/mirador/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/jchultarsky/mirador/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/jchultarsky/mirador/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/jchultarsky/mirador/compare/v0.9.0...v0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog date.

### Changed

- **Adding a clock offers a list of cities instead of asking for an identifier.** Matching runs over the city *or* the identifier, anywhere in either, so `seattle` finds `America/Los_Angeles` — the identifier names *a* city in the zone and it's very often not the one you have in mind. The city you pick becomes the label; a zone the list doesn't carry is still taken as typed.

### Fixed

- **A panel's prompt is no longer drawn inside that panel.** The agenda's file prompt was as narrow as the agenda, so a long path read as a scrolled fragment through ~40 columns. Prompts are drawn by the shell over the whole terminal now, after every panel — which is also what stopped the new city list coming out interleaved with the task list.

The GIF is unchanged and still accurate: the default layout is the same eleven panels, and the caption matches.

Not tagged yet; the tag goes on the squashed commit.