### PR TITLE
Scroll the city list, and say which version this is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   over the whole terminal now, after every panel — which is also what stopped
   the new city list coming out interleaved with the task list.
 
+## [Unreleased]
+
+### Added
+
+- **The version is shown in the `?` overlay**, right-aligned in its border the
+  way every panel shows a counter. `?` is where you go to find out what the
+  thing does, so it is where you look for what version it is.
+
+- The command-line `--help` now leads with the version, and lists `w`, `m` and
+  `Ctrl+arrows`, which it had never been told about.
+
+### Fixed
+
+- **The city list scrolls.** It draws ten rows, and moving the selection past
+  the bottom kept moving a cursor nobody could see — the highlight vanished and
+  the row `Enter` would take was anybody's guess. The window follows the
+  selection now, `PageUp`/`PageDown`/`Home`/`End` work, and the help line says
+  how much of the list is on screen so ten of a hundred and forty-three does not
+  read as all of it.
+
 ## [0.11.0] - 2026-07-27
 
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -1565,7 +1565,22 @@ impl App {
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("├", Style::default().fg(theme.border_focused)),
-            ]));
+            ]))
+            // Right-aligned in the border, the way every panel shows its
+            // counter — `?` is where someone goes to find out what the thing
+            // does, so it is also where they will look for what version it is,
+            // and the border costs no rows to say so.
+            .title_top(
+                Line::from(vec![
+                    Span::styled("┤", Style::default().fg(theme.border_focused)),
+                    Span::styled(
+                        concat!("v", env!("CARGO_PKG_VERSION")),
+                        Style::default().fg(theme.muted),
+                    ),
+                    Span::styled("├", Style::default().fg(theme.border_focused)),
+                ])
+                .right_aligned(),
+            );
         let inner = block.inner(popup);
         frame.render_widget(block, popup);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,10 @@ use ratatui::crossterm::execute;
 use crate::app::App;
 use crate::config::Config;
 
-const HELP: &str = "\
-mirador — a personal information dashboard for your terminal
+const HELP: &str = concat!(
+    "mirador ",
+    env!("CARGO_PKG_VERSION"),
+    " — a personal information dashboard for your terminal
 
 USAGE:
     mirador [OPTIONS]
@@ -62,12 +64,16 @@ OPTIONS:
 KEYS:
     Tab / Shift+Tab        Move focus between panels
     1 - 9                  Jump straight to a panel
-    ?                      Show all key bindings
+    w                      Choose which panels are shown
+    m                      Rearrange the panels
+    Ctrl+arrows            Resize the focused panel
+    ?                      Show all key bindings, and the version
     q / Ctrl+C             Quit
 
 On first run mirador writes a commented config file you can edit. Run
 `mirador --config-path` to find it.
-";
+"
+);
 
 /// Parsed command line.
 // A flags struct is exactly the case where several bools are the clearest

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -60,6 +60,14 @@ pub enum Outcome {
     },
 }
 
+/// Rows of the list shown at once.
+///
+/// The list is drawn inside a dialog rather than a panel, so this is a fixed
+/// window rather than something the layout decides — and it has to be a
+/// constant both `handle_key` and `render` can see, because the first has to
+/// know how far it may scroll and the second has to draw the same window.
+const LIST_ROWS: usize = 10;
+
 /// An open prompt.
 #[derive(Debug)]
 pub struct Prompt {
@@ -70,6 +78,9 @@ pub struct Prompt {
     completion: Completion,
     /// Which row of the filtered list is selected, if any.
     selected: usize,
+    /// The first row on screen. Without it the cursor walked off the bottom of
+    /// the window and kept going, invisibly.
+    offset: usize,
 }
 
 impl Prompt {
@@ -87,6 +98,7 @@ impl Prompt {
             error: None,
             completion,
             selected: 0,
+            offset: 0,
         }
     }
 
@@ -133,10 +145,32 @@ impl Prompt {
             KeyCode::Esc => Outcome::Cancelled,
             KeyCode::Down => {
                 self.selected = (self.selected + 1).min(listed.len().saturating_sub(1));
+                self.scroll_into_view();
                 Outcome::Editing
             }
             KeyCode::Up => {
                 self.selected = self.selected.saturating_sub(1);
+                self.scroll_into_view();
+                Outcome::Editing
+            }
+            KeyCode::PageDown => {
+                self.selected = (self.selected + LIST_ROWS).min(listed.len().saturating_sub(1));
+                self.scroll_into_view();
+                Outcome::Editing
+            }
+            KeyCode::PageUp => {
+                self.selected = self.selected.saturating_sub(LIST_ROWS);
+                self.scroll_into_view();
+                Outcome::Editing
+            }
+            KeyCode::Home if !listed.is_empty() => {
+                self.selected = 0;
+                self.scroll_into_view();
+                Outcome::Editing
+            }
+            KeyCode::End if !listed.is_empty() => {
+                self.selected = listed.len() - 1;
+                self.scroll_into_view();
                 Outcome::Editing
             }
             KeyCode::Enter => match listed.get(self.selected) {
@@ -155,10 +189,27 @@ impl Prompt {
             _ => {
                 self.field.handle_key(key);
                 // Typing narrows the list under the cursor, so a selection two
-                // rows down would otherwise land on something unrelated.
+                // rows down would otherwise land on something unrelated — or
+                // past the end of what is left.
                 self.selected = 0;
+                self.offset = 0;
                 Outcome::Editing
             }
+        }
+    }
+
+    /// Keep the selected row inside the window that is drawn.
+    ///
+    /// Only moves the window when the selection would otherwise leave it, so
+    /// the list stays put while the cursor travels across it and scrolls by one
+    /// at the edges. Recomputing the window from the selection each time would
+    /// be stateless and simpler, and would also jump the whole list whenever
+    /// you crossed a page boundary going back up.
+    fn scroll_into_view(&mut self) {
+        if self.selected < self.offset {
+            self.offset = self.selected;
+        } else if self.selected >= self.offset + LIST_ROWS {
+            self.offset = self.selected + 1 - LIST_ROWS;
         }
     }
 
@@ -224,7 +275,7 @@ impl Prompt {
     /// the agenda meant a long path scrolled inside about forty columns.
     pub fn render(&self, frame: &mut ratatui::Frame, screen: Rect, theme: &Theme) {
         let listed = self.matches();
-        let rows = u16::try_from(listed.len().min(10)).unwrap_or(0);
+        let rows = u16::try_from(listed.len().min(LIST_ROWS)).unwrap_or(0);
 
         let width = screen.width.clamp(20, 64);
         let height = 3 + rows + crate::frame::FRAME_HEIGHT;
@@ -246,7 +297,16 @@ impl Prompt {
             .max()
             .unwrap_or(0)
             .min(18);
-        for (index, place) in listed.iter().take(usize::from(rows)).enumerate() {
+        // `enumerate` before `skip`, so `index` is the row's place in the whole
+        // list and can be compared against `selected`. Enumerating after
+        // skipping restarts the count at zero and puts the highlight on the top
+        // visible row whatever is actually selected.
+        for (index, place) in listed
+            .iter()
+            .enumerate()
+            .skip(self.offset)
+            .take(usize::from(rows))
+        {
             let here = index == self.selected;
             lines.push(Line::from(vec![
                 Span::styled(
@@ -274,6 +334,13 @@ impl Prompt {
             Some(error) => Line::from(Span::styled(
                 crate::grid::truncate(error, inner),
                 Style::default().fg(theme.error),
+            )),
+            None if listed.len() > LIST_ROWS => Line::from(Span::styled(
+                crate::grid::truncate(
+                    &format!("{} of {} · {}", rows, listed.len(), self.help),
+                    inner,
+                ),
+                Style::default().fg(theme.muted),
             )),
             None => Line::from(Span::styled(
                 crate::grid::truncate(self.help, inner),
@@ -418,6 +485,46 @@ mod tests {
             press(&mut p, KeyCode::Enter),
             Outcome::Submitted("Antarctica/Troll".into())
         );
+    }
+
+    /// The list draws a fixed window of rows. Moving the selection past the
+    /// bottom of it used to keep moving an invisible cursor: the highlight
+    /// vanished and the row that Enter would take was anybody's guess.
+    #[test]
+    fn the_window_follows_the_selection_off_the_bottom_and_back() {
+        // The real table, not the four-entry fixture: with fewer places than
+        // LIST_ROWS nothing ever scrolls and this test cannot fail. It did not,
+        // the first time it was written.
+        let real = crate::zones::PLACES;
+        assert!(real.len() > LIST_ROWS, "there is something to scroll");
+        let mut p = Prompt::new("ZONE", "help", "", Completion::Places(real));
+
+        for _ in 0..real.len() {
+            press(&mut p, KeyCode::Down);
+        }
+        assert!(
+            p.selected >= p.offset && p.selected < p.offset + LIST_ROWS,
+            "selected {} left the window at {}",
+            p.selected,
+            p.offset
+        );
+
+        assert!(p.offset > 0, "the window actually moved");
+
+        for _ in 0..real.len() {
+            press(&mut p, KeyCode::Up);
+        }
+        assert_eq!(p.selected, 0, "back to the first");
+        assert_eq!(p.offset, 0, "and the window came back with it");
+    }
+
+    /// The window only moves when it has to, so the cursor travels across a
+    /// stationary list rather than dragging it along one row at a time.
+    #[test]
+    fn the_window_stays_put_while_the_selection_is_inside_it() {
+        let mut p = prompt("");
+        press(&mut p, KeyCode::Down);
+        assert_eq!(p.offset, 0, "second row is already visible");
     }
 
     #[test]


### PR DESCRIPTION
## The bug

The city list draws ten rows, and the selection could walk straight past the bottom of them — the highlight vanished, the window stayed on the first ten, and the row `Enter` would take was anybody's guess.

The window follows the selection now, moving only when it has to so the cursor travels across a stationary list rather than dragging it along one row at a time. `PageUp`/`PageDown`/`Home`/`End` work, and the help line reads `10 of 143` so a screenful doesn't look like the whole list.

## Two things about how this got through

**The test I wrote for it could not fail.** The fixture had four places and the window is ten rows, so nothing ever scrolled and the assertion passed on a straight line. It uses the real 143-entry table now and fails with `selected 142 left the window at 0` when the fix is removed.

**The render half of the first fix silently didn't apply.** My replacement was matched against a line `cargo fmt` had already reformatted, so the offset was computed and then never read. Every symptom pointed at the scrolling logic, which was fine the whole time.

## Also

- `?` shows the version, right-aligned in its border the way panels show counters — `?` is where you go to find out what the thing does, so it's where you'd look for what version it is.
- `--help` leads with the version, and now lists `w`, `m` and `Ctrl+arrows`, which it had never been told about.
- `--help` and `-h` themselves already worked.

542 tests; clippy, fmt and rustdoc silent. Verified under tmux: 18 rows down shows `▸ Jakarta` with the window scrolled to match.