### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] - 2026-07-27
+
+### Added
+
+- **The version is shown in the `?` overlay**, right-aligned in its border the
+  way every panel shows a counter. `?` is where you go to find out what the
+  thing does, so it is where you look for what version it is.
+
+- The command-line `--help` now leads with the version, and lists `w`, `m` and
+  `Ctrl+arrows`, which it had never been told about.
 
 ### Changed
 
@@ -27,19 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scrolled fragment through about forty columns. Prompts are drawn by the shell
   over the whole terminal now, after every panel — which is also what stopped
   the new city list coming out interleaved with the task list.
-
-## [Unreleased]
-
-### Added
-
-- **The version is shown in the `?` overlay**, right-aligned in its border the
-  way every panel shows a counter. `?` is where you go to find out what the
-  thing does, so it is where you look for what version it is.
-
-- The command-line `--help` now leads with the version, and lists `w`, `m` and
-  `Ctrl+arrows`, which it had never been told about.
-
-### Fixed
 
 - **The city list scrolls.** It draws ten rows, and moving the selection past
   the bottom kept moving a cursor nobody could see — the highlight vanished and
@@ -847,7 +843,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/jchultarsky/mirador/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/jchultarsky/mirador/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/jchultarsky/mirador/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/jchultarsky/mirador/compare/v0.9.0...v0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog date. Two `[Unreleased]` sections merged into one — the first release PR was closed rather than merged when the picker's scroll bug turned up, so the picker's entry was still waiting.

### Added
- The version in the `?` overlay and leading `--help`; the CLI key list now mentions `w`, `m` and `Ctrl+arrows`.

### Changed
- Adding a clock offers a list of cities rather than asking for an identifier — `seattle` finds `America/Los_Angeles`.

### Fixed
- A panel's prompt is drawn over the terminal rather than inside the panel that owns it.
- The city list scrolls; the selection can no longer leave the window.

Not tagged yet; the tag goes on the squashed commit.