### PR TITLE
Add a news panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A news panel.** Headlines from RSS feeds you choose, refreshed hourly.
+
+  **A window, not a feed:** however many stories fit and no more, with no
+  scrolling, no count, no unread state and nothing to dismiss. News is the
+  doomscroll surface this dashboard has been avoiding, and that commitment is
+  what makes it something you glance at rather than something you work through.
+
+  Stories are interleaved across feeds so the top of the panel holds the newest
+  from *each* — date order alone hands the whole window to whichever outlet
+  publishes most often.
+
+  `o` shows a story's link so you can copy it; no browser is launched. The
+  shipped feeds are science, space and technology only, because choosing
+  outlets for general news is an editorial act this project should not make for
+  you. Headlines only — feed summaries are article prose belonging to whoever
+  wrote them.
+
+- **The default layout is four rows**, with news and the watch log sharing a
+  reading row. Both want width for prose rather than columns of numbers, and
+  squeezing them in beside the lists left neither readable.
+
 ## [0.12.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you. Headlines only — feed summaries are article prose belonging to whoever
   wrote them.
 
+- **An empty watch log says what it is watching.** It had no refresh key —
+  nothing there is polled, the panels report to it — and "Nothing has happened"
+  on its own gave a reader no way to tell working from dead. It now names the
+  two things it watches, and says plainly when no calendar is configured that
+  only one of them can happen.
+
 - **The default layout is four rows**, with news and the watch log sharing a
   reading row. Both want width for prose rather than columns of numbers, and
   squeezing them in beside the lists left neither readable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ store.rs     write_atomic — every file mirador owns goes through it
 state.rs     UI-changed preferences, remembered across restarts
 update.rs    the opt-in update check — off unless the config turns it on
 watch.rs     the watch log's events and the rule that decides what is one
+feed.rs      enough RSS for a headline; quick-xml, unlike ical.rs — see below
 task.rs      task model + TOML store
 note.rs      note model + TOML store
 quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
@@ -136,7 +137,7 @@ textarea.rs  multi-line text editor used by note bodies
 dateinput.rs due-date entry
 ical.rs      enough RFC 5545 to answer "what is next"; no new dependencies
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
-             pomodoro, watchlog, cpu, network
+             pomodoro, watchlog, news, cpu, network
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -205,7 +206,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 232 of them, including the ones mirador
+    trip through `toml` discards all 254 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -403,6 +404,39 @@ fails to parse, and the theme silently comes out as the defaults. The shipped
 exactly the default. Hence two things: `check_palette_ordering` refuses such a
 file by name, and the drift test is paired with one that asserts a standalone
 theme *sets every key*, which is the property that can actually fail.
+
+## The news panel — built
+
+The one that came closest to the feature this dashboard turned down. Unread
+counts were rejected as a doomscroll hook; news *is* the doomscroll surface.
+It survives on the same kind of commitment the watch log made, and the same
+three words apply: **no count, no unread state, nothing to dismiss**, plus a
+fourth — **no scrolling**. It shows what fits. You cannot work through it
+because there is nothing to work through. A `3 new` counter in that frame turns
+it back into the rejected feature; there is a test whose failure message says so.
+
+**Stories are interleaved across feeds, not sorted by date.** Pure date order
+hands the whole visible window to whichever outlet publishes most often — the
+first real run showed three consecutive Phys.org stories. Round-robin puts the
+newest from each feed at the top, which is what "a window on the world" has to
+mean.
+
+**`quick-xml`, where `ical.rs` hand-rolled.** Not an inconsistency: iCalendar is
+line-based and yields to `split`, where XML has entities, CDATA and namespaces.
+Measured before choosing — `quick-xml` adds two crates, `rss` twenty-three,
+`feed-rs` fifty-eight.
+
+**Do not set `trim_text(true)` on the reader.** An entity splits an element's
+text into several events, and trimming each piece separately eats the space
+beside it: a real headline came out as `'Dead stars'may have`. The assembled
+value is trimmed once, at the end. There is a test.
+
+**Headlines only.** Every feed sampled carries 80–384 characters of article
+prose in `<description>`. A headline is a fact; a summary is somebody's work.
+
+**The shipped feeds are science, space and technology.** Choosing outlets for
+general or political news is an editorial act this project should not make on
+a user's behalf, and it is the kind that arrives in the issue tracker.
 
 ## The watch log — built
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "anyhow",
  "dirs",
  "jiff",
+ "quick-xml",
  "ratatui",
  "serde",
  "serde_json",
@@ -1216,6 +1217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["/.github", "/docs", "*.gif", "*.png"]
 anyhow = "1.0.104"
 dirs = "6.0.0"
 jiff = { version = "0.2.34", features = ["serde"] }
+quick-xml = "0.41.0"
 ratatui = "0.30.2"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/README.md
+++ b/README.md
@@ -469,6 +469,50 @@ where one that misses a repeat costs you a glance at the real thing.
 An entry the parser cannot read is counted at the bottom of the panel rather
 than dropped silently, so a half-read calendar does not just look empty.
 
+### News
+
+Headlines from RSS feeds you choose.
+
+```
+╭┤7 News├──────────────────────────────────────────────╮
+│ NASA · 1h old                                        │
+│ Astronaut Chris Williams to discuss station mission  │
+│                                                      │
+│ PHYS.ORG · 22m old                                   │
+│ What Australian lakes showed us about Martian        │
+│ hydrology                                            │
+│                                                      │
+│ ARS TECHNICA · 45m old                               │
+│ 5th Circuit blocks Texas law requiring websites to   │
+│ filter "harmful" speech                              │
+╰───────── r refresh · o show link ────────────────────╯
+```
+
+**A window, not a feed.** It shows however many stories fit and no more. There
+is no scrolling, no count, no unread state, and nothing to dismiss — you glance
+at it the way you glance at the weather. That is deliberate and it is the same
+reasoning that keeps unread-message counts off this dashboard: a number that
+accumulates is a number demanding you zero it.
+
+Stories are interleaved rather than sorted purely by date, so the top of the
+panel holds the newest from *each* feed. Sorting by date alone hands the whole
+window to whichever outlet publishes most often, which is fresh but is not a
+window on the world.
+
+`o` shows the selected story's link so you can copy it. It does not open a
+browser — that means talking to the platform, which is the same decision as
+playing a sound file and gets the same answer.
+
+The shipped feeds are science, space and technology only. Choosing outlets for
+general or political news is an editorial act this project has no business
+making on your behalf; add your own in `[news.feeds]`. A topic *is* a feed —
+RSS has no topic parameter, so subscribing to a science feed is how you ask for
+science.
+
+Only the headline, link and date are read. Feed summaries are article prose
+belonging to whoever wrote them. Refresh is hourly, and an hour is also the
+floor.
+
 ### Watch log
 
 What happened while you were not looking.

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -54,32 +54,36 @@ check_for_updates = false
 # ---------------------------------------------------------------------------
 [layout]
 rows = [
-  { height = 34, panels = [
+  { height = 26, panels = [
     { widget = "clocks",   width = 26 },
     # Wide enough for two months side by side on a normal terminal; it falls
     # back to one when the window is narrow.
     { widget = "calendar", width = 34 },
     { widget = "weather",  width = 40 },
   ] },
-  { height = 42, panels = [
-    { widget = "todo",     width = 30 },
+  { height = 32, panels = [
+    { widget = "todo",     width = 34 },
     # What is next, from [agenda].file. Says how to point it at your .ics
     # until you do.
-    { widget = "agenda",   width = 26 },
-    { widget = "notes",    width = 22 },
+    { widget = "agenda",   width = 30 },
+    { widget = "notes",    width = 36 },
+  ] },
+  # The reading row. Both of these want width for prose rather than columns of
+  # numbers, so they get a row to themselves rather than being squeezed in
+  # beside the lists.
+  { height = 24, panels = [
+    { widget = "news",     width = 55 },
     # What happened while you were not looking. Empty most of the time, which
     # is the point.
-    { widget = "watchlog", width = 22 },
+    { widget = "watchlog", width = 45 },
   ] },
-  { height = 24, panels = [
+  { height = 18, panels = [
     # The timer draws block numerals when it has the width for them and falls
-    # back to plain text when it does not. It leads this row because it is the
-    # one panel here with a width it genuinely needs; the graphs beside it
-    # scale to whatever is left.
-    { widget = "pomodoro", width = 28 },
-    { widget = "stocks",   width = 32 },
-    { widget = "cpu",      width = 18 },
-    { widget = "network",  width = 22 },
+    # back to plain text when it does not.
+    { widget = "pomodoro", width = 24 },
+    { widget = "stocks",   width = 28 },
+    { widget = "cpu",      width = 22 },
+    { widget = "network",  width = 26 },
   ] },
 ]
 
@@ -292,6 +296,43 @@ week_starts = "sunday"   # sunday | monday
 days          = 7        # how far ahead to look
 show_location = true     # show the location when the row has room for both
 refresh_secs  = 60       # how often to re-read the file
+
+# ---------------------------------------------------------------------------
+# News
+#
+# Headlines from RSS feeds you choose. A topic *is* a feed here — RSS has no
+# topic parameter, so subscribing to a science feed is how you ask for science.
+# Add or remove entries freely; `name` is what shows above the headline.
+#
+# The panel is deliberately a window rather than a reader: it shows however
+# many stories fit and no more, there is no scrolling, no count, no unread
+# state and nothing to dismiss. You glance at it. If that sounds thin, it is
+# the same reasoning that keeps unread-message counts off this dashboard.
+#
+# The shipped feeds are science, space and technology only. Choosing outlets
+# for general or political news is an editorial act this project has no
+# business making on your behalf — add your own if you want them.
+#
+# Only the headline, the link and the date are read. Feed summaries are article
+# prose belonging to whoever wrote them.
+# ---------------------------------------------------------------------------
+[news]
+refresh_minutes = 60     # also the floor; news moves slower than a dashboard
+per_feed        = 4      # kept from each feed, so a chatty one cannot crowd
+                         # out a quiet one. Stories are then interleaved, so
+                         # the top of the panel holds one from each.
+
+[[news.feeds]]
+name = "NASA"
+url  = "https://www.nasa.gov/news-release/feed/"
+
+[[news.feeds]]
+name = "PHYS.ORG"
+url  = "https://phys.org/rss-feed/space-news/"
+
+[[news.feeds]]
+name = "ARS TECHNICA"
+url  = "https://feeds.arstechnica.com/arstechnica/index"
 
 # ---------------------------------------------------------------------------
 # Pomodoro

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -37,23 +37,20 @@ impl Default for Layout {
 
         Self {
             rows: vec![
-                row(34, &[("clocks", 26), ("calendar", 34), ("weather", 40)]),
+                row(26, &[("clocks", 26), ("calendar", 34), ("weather", 40)]),
+                row(32, &[("todo", 34), ("agenda", 30), ("notes", 36)]),
+                // The reading row. Both of these want width for prose rather
+                // than columns of numbers, which is why they get a row instead
+                // of being squeezed in beside the lists — and why the default
+                // is four rows now rather than three.
+                row(24, &[("news", 55), ("watchlog", 45)]),
                 row(
-                    42,
+                    18,
                     &[
-                        ("todo", 30),
-                        ("agenda", 26),
-                        ("notes", 22),
-                        ("watchlog", 22),
-                    ],
-                ),
-                row(
-                    24,
-                    &[
-                        ("pomodoro", 28),
-                        ("stocks", 32),
-                        ("cpu", 18),
-                        ("network", 22),
+                        ("pomodoro", 24),
+                        ("stocks", 28),
+                        ("cpu", 22),
+                        ("network", 26),
                     ],
                 ),
             ],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,8 +45,8 @@ mod widgets;
 pub use layout::{Layout, LayoutPanel, LayoutRow};
 #[allow(unused_imports)]
 pub use widgets::{
-    AgendaConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig, NetworkConfig, NotesConfig,
-    PomodoroConfig, StocksConfig, TodoConfig, WeatherConfig,
+    AgendaConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig, NetworkConfig, NewsConfig,
+    NewsFeed, NotesConfig, PomodoroConfig, StocksConfig, TodoConfig, WeatherConfig,
 };
 
 /// Top-level configuration.
@@ -70,6 +70,7 @@ pub struct Config {
     pub stocks: StocksConfig,
     pub agenda: AgendaConfig,
     pub calendar: CalendarConfig,
+    pub news: NewsConfig,
     pub pomodoro: PomodoroConfig,
     pub cpu: CpuConfig,
     pub network: NetworkConfig,
@@ -493,7 +494,10 @@ mod tests {
     #[test]
     fn empty_config_falls_back_to_defaults() {
         let config: Config = toml::from_str("").expect("an empty config is valid");
-        assert_eq!(config.layout.rows.len(), 3);
+        // Four since the news and watch log panels took a row of their own;
+        // the figure is here to catch a default that silently loses rows, not
+        // because three was ever special.
+        assert_eq!(config.layout.rows.len(), 4);
         assert!(config.validate().is_ok());
     }
 

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -373,3 +373,53 @@ impl Default for NetworkConfig {
         }
     }
 }
+
+/// A news feed the user subscribes to.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct NewsFeed {
+    /// Shown above the headline, so `BBC WORLD` rather than the URL.
+    pub name: String,
+    pub url: String,
+}
+
+/// The news panel.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NewsConfig {
+    /// Feeds to read, in order. A topic *is* a feed here: RSS has no topic
+    /// parameter, so subscribing to a science feed is how you ask for science.
+    pub feeds: Vec<NewsFeed>,
+    /// How often to re-read them. An hour is the floor as well as the default —
+    /// news does not move faster than a dashboard should, and hammering
+    /// somebody's feed from every mirador on earth would be rude.
+    pub refresh_minutes: u64,
+    /// Most stories to keep from any one feed, so a chatty outlet cannot crowd
+    /// out a quiet one.
+    pub per_feed: usize,
+}
+
+impl Default for NewsConfig {
+    fn default() -> Self {
+        let feed = |name: &str, url: &str| NewsFeed {
+            name: name.into(),
+            url: url.into(),
+        };
+        Self {
+            // Science, space and technology only. Choosing outlets for general
+            // or political news would be an editorial act this project has no
+            // business making on somebody else's behalf — and the config is
+            // commented so what you are subscribed to is never a mystery.
+            feeds: vec![
+                feed("NASA", "https://www.nasa.gov/news-release/feed/"),
+                feed("PHYS.ORG", "https://phys.org/rss-feed/space-news/"),
+                feed(
+                    "ARS TECHNICA",
+                    "https://feeds.arstechnica.com/arstechnica/index",
+                ),
+            ],
+            refresh_minutes: 60,
+            per_feed: 4,
+        }
+    }
+}

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,0 +1,357 @@
+//! Just enough RSS to answer "what happened in the world".
+//!
+//! Three fields out of each `<item>`: the title, the link and the date. Not the
+//! description — every feed measured carries between eighty and four hundred
+//! characters of real article prose there, and that is somebody's writing
+//! rather than a fact about the world. A headline is a fact; a summary is a
+//! work. Titles only also happens to solve the space problem, which is a nice
+//! coincidence and not the reason.
+//!
+//! **RSS 2.0 only.** Every feed sampled while designing this was RSS 2.0 —
+//! BBC, Ars Technica, NASA, Phys.org and Hacker News. Atom exists and is not
+//! read; a feed that produces no items says so in the panel rather than looking
+//! empty, which is the honest failure for something this narrow.
+//!
+//! Parsing goes through `quick-xml` rather than being hand-rolled, which is the
+//! opposite of the call [`crate::ical`] made and worth explaining. iCalendar is
+//! line-based and can be read with `split` and a state machine. XML has
+//! entities, CDATA and namespaces, and hand-decoding those is exactly how
+//! `Don&#8217;t` reaches the screen. Measured before choosing: `quick-xml` adds
+//! two crates where `rss` adds twenty-three and `feed-rs` fifty-eight, against
+//! the hundred and twenty-three already here.
+
+use anyhow::{Context, Result};
+use jiff::Zoned;
+use quick_xml::events::Event as XmlEvent;
+
+/// One headline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Story {
+    /// The feed's display name, filled in by the panel — a feed does not know
+    /// what you call it, and `BBC WORLD` reads better than the channel title.
+    pub source: String,
+    pub title: String,
+    pub link: String,
+    /// When it was published, if the feed said so in a form that parsed.
+    ///
+    /// The three feeds sampled emitted `GMT`, `+0000` and `EDT`, and jiff reads
+    /// all three — including the obsolete zone abbreviations, which RFC 2822
+    /// permits an implementation to treat as unknown and which it instead maps
+    /// correctly (`EDT` to -04:00). That was checked rather than assumed; the
+    /// assumption had been the other way.
+    ///
+    /// `None` therefore means a missing or genuinely malformed date. The story
+    /// still shows, without an age — the same choice the watchlist makes for a
+    /// missing price. Dropping it would hide news over a formatting slip.
+    pub published: Option<Zoned>,
+}
+
+/// Pull the stories out of an RSS document.
+///
+/// Tolerant by design: an item with no title is skipped, an unparseable date
+/// becomes `None`, and unknown elements are ignored. A feed is somebody else's
+/// output and will contain things this does not expect.
+pub fn parse(xml: &str) -> Result<Vec<Story>> {
+    let mut reader = quick_xml::Reader::from_str(xml);
+    // Deliberately *not* `trim_text(true)`. An entity splits an element's text
+    // into several events, so a headline like `‘Dead stars’ may have appetites`
+    // arrives as text, entity, text, entity, text — and trimming each piece
+    // eats the space that followed the closing quote, producing
+    // `'Dead stars'may have`. Seen on a real feed within a minute of the panel
+    // first running. The assembled value is trimmed once, at the end.
+    reader.config_mut().trim_text(false);
+
+    let mut stories = Vec::new();
+    let mut in_item = false;
+    // Which element's text is currently being collected. `None` between them.
+    let mut field: Option<Field> = None;
+    let mut current = Partial::default();
+
+    loop {
+        match reader.read_event().context("reading the feed as XML")? {
+            XmlEvent::Start(tag) => {
+                match local_name(tag.name().as_ref()) {
+                    b"item" => {
+                        in_item = true;
+                        current = Partial::default();
+                    }
+                    // Only inside an item: a feed's channel has a `<title>` and
+                    // a `<link>` of its own, and reading those as a story is how
+                    // the outlet's own name ends up as the first headline.
+                    b"title" if in_item => field = Some(Field::Title),
+                    b"link" if in_item => field = Some(Field::Link),
+                    b"pubDate" if in_item => field = Some(Field::Date),
+                    _ => {}
+                }
+            }
+            XmlEvent::End(tag) => match local_name(tag.name().as_ref()) {
+                b"item" => {
+                    in_item = false;
+                    if let Some(story) = current.take() {
+                        stories.push(story);
+                    }
+                }
+                _ => field = None,
+            },
+            // CDATA and plain text both reach here; `quick-xml` unescapes
+            // entities for us, which is most of why it is here at all.
+            XmlEvent::Text(text) => {
+                if let Some(which) = field {
+                    let value = text.decode().unwrap_or_default().into_owned();
+                    current.set(which, &value);
+                }
+            }
+            XmlEvent::CData(data) => {
+                if let Some(which) = field {
+                    let value = String::from_utf8_lossy(&data).into_owned();
+                    current.set(which, &value);
+                }
+            }
+            // `&amp;` and `&#8217;` arrive as their own events rather than as
+            // part of the text around them, so ignoring these silently deletes
+            // every ampersand and every typographic quote — which is how a link
+            // came out as `?at_medium=RSSat_campaign=x` the first time.
+            //
+            // Worth noting against the choice to use a library at all: it does
+            // not do this for you. What it does do is get the *splitting* right,
+            // which is the part a hand-rolled scanner gets wrong.
+            XmlEvent::GeneralRef(reference) => {
+                if let Some(which) = field
+                    && let Some(text) = resolve_entity(&reference)
+                {
+                    current.set(which, &text);
+                }
+            }
+            XmlEvent::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(stories)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    Title,
+    Link,
+    Date,
+}
+
+#[derive(Debug, Default)]
+struct Partial {
+    title: String,
+    link: String,
+    date: String,
+}
+
+impl Partial {
+    fn set(&mut self, which: Field, value: &str) {
+        // Appended rather than assigned: an entity splits an element's text
+        // into several events, so `AT&T` arrives as `AT`, `&`, `T`.
+        let slot = match which {
+            Field::Title => &mut self.title,
+            Field::Link => &mut self.link,
+            Field::Date => &mut self.date,
+        };
+        slot.push_str(value);
+    }
+
+    /// A story, if there is enough of one. A headline with no text is not news.
+    fn take(&mut self) -> Option<Story> {
+        let title = self.title.trim();
+        if title.is_empty() {
+            return None;
+        }
+        Some(Story {
+            source: String::new(),
+            title: title.to_string(),
+            link: self.link.trim().to_string(),
+            published: parse_date(self.date.trim()),
+        })
+    }
+}
+
+/// The text an entity reference stands for.
+///
+/// Numeric references are resolved by `quick-xml`. Named ones are not, because
+/// XML only predefines five and anything else has to come from a DTD nobody is
+/// going to fetch — so the five are spelled out here, plus `nbsp`, which feeds
+/// emit constantly despite it being an HTML entity rather than an XML one.
+/// Anything else is dropped rather than shown raw: `&hellip;` in a headline is
+/// noise, and there is no honest way to guess.
+fn resolve_entity(reference: &quick_xml::events::BytesRef<'_>) -> Option<String> {
+    if let Ok(Some(character)) = reference.resolve_char_ref() {
+        return Some(character.to_string());
+    }
+    let name = reference.decode().ok()?;
+    Some(
+        match name.as_ref() {
+            "amp" => "&",
+            "lt" => "<",
+            "gt" => ">",
+            "quot" => "\"",
+            "apos" => "'",
+            "nbsp" => " ",
+            _ => return None,
+        }
+        .to_string(),
+    )
+}
+
+/// An RFC 2822 date, or `None` if the feed wrote one this cannot read.
+fn parse_date(raw: &str) -> Option<Zoned> {
+    if raw.is_empty() {
+        return None;
+    }
+    jiff::fmt::rfc2822::parse(raw).ok()
+}
+
+/// The element name with any namespace prefix removed.
+///
+/// Feeds use `dc:date` and `media:content` freely, and matching on the whole
+/// qualified name would miss anything a feed chose to namespace.
+fn local_name(name: &[u8]) -> &[u8] {
+    match name.iter().rposition(|byte| *byte == b':') {
+        Some(colon) => &name[colon + 1..],
+        None => name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from real feeds, and deliberately awkward: CDATA titles, an
+    /// entity inside a link, an entity that splits a title into three text
+    /// events, the three date spellings seen in the wild, an item with no date
+    /// and an item with no title at all.
+    const SAMPLE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>The Feed Itself</title>
+    <link>https://example.org</link>
+    <item>
+      <title><![CDATA[Wildfire now nine miles from Bordeaux, mayor warns]]></title>
+      <description><![CDATA[Some prose that must not be read.]]></description>
+      <link>https://example.org/a?at_medium=RSS&amp;at_campaign=x</link>
+      <pubDate>Mon, 27 Jul 2026 17:50:42 GMT</pubDate>
+    </item>
+    <item>
+      <title>&#8216;Dead stars&#8217; may have surprisingly healthy appetites</title>
+      <link>https://example.org/f</link>
+      <pubDate>Mon, 27 Jul 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>AT&amp;T reverses course on the physical button</title>
+      <link>https://example.org/b</link>
+      <pubDate>Mon, 27 Jul 2026 15:58:34 +0000</pubDate>
+    </item>
+    <item>
+      <title>Europa Clipper returns its first images</title>
+      <link>https://example.org/c</link>
+      <pubDate>Mon, 27 Jul 2026 15:40:06 EDT</pubDate>
+    </item>
+    <item>
+      <title>A story its feed forgot to date</title>
+      <link>https://example.org/d</link>
+    </item>
+    <item>
+      <link>https://example.org/e</link>
+      <pubDate>Mon, 27 Jul 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+"#;
+
+    #[test]
+    fn the_feeds_own_title_is_not_a_story() {
+        let stories = parse(SAMPLE).expect("parses");
+        assert!(
+            !stories.iter().any(|s| s.title == "The Feed Itself"),
+            "the channel's own title became a headline: {:?}",
+            stories.iter().map(|s| &s.title).collect::<Vec<_>>()
+        );
+        assert_eq!(stories.len(), 5, "five items have titles, one does not");
+    }
+
+    /// `quick-xml` is here rather than a hand-rolled scanner precisely for
+    /// this: CDATA and entities, decoded rather than shown.
+    #[test]
+    fn cdata_and_entities_come_out_as_text() {
+        let stories = parse(SAMPLE).expect("parses");
+        assert_eq!(
+            stories[0].title,
+            "Wildfire now nine miles from Bordeaux, mayor warns"
+        );
+        assert_eq!(
+            stories[0].link, "https://example.org/a?at_medium=RSS&at_campaign=x",
+            "&amp; in a URL is decoded, not left as written"
+        );
+        assert_eq!(
+            stories[2].title, "AT&T reverses course on the physical button",
+            "an entity splits the text into several events and must be rejoined"
+        );
+    }
+
+    /// The bug that reached the screen within a minute of the panel first
+    /// running: an entity splits the text around it, and trimming each piece
+    /// separately eats the space that followed. `'Dead stars'may have`.
+    #[test]
+    fn a_space_next_to_an_entity_survives() {
+        let stories = parse(SAMPLE).expect("parses");
+        let quoted = stories
+            .iter()
+            .find(|s| s.title.contains("Dead stars"))
+            .expect("present");
+        assert_eq!(
+            quoted.title,
+            "\u{2018}Dead stars\u{2019} may have surprisingly healthy appetites"
+        );
+    }
+
+    /// Every date form seen in the wild reads, including the obsolete zone
+    /// abbreviations — `EDT` becomes -04:00 rather than being discarded or,
+    /// worse, silently read as UTC and shown four hours out. A story whose date
+    /// is missing or malformed still appears, without an age.
+    #[test]
+    fn the_date_forms_feeds_actually_emit_all_read() {
+        let stories = parse(SAMPLE).expect("parses");
+        let by_title = |want: &str| {
+            stories
+                .iter()
+                .find(|s| s.title.starts_with(want))
+                .unwrap_or_else(|| panic!("`{want}` is missing"))
+        };
+
+        assert!(by_title("Wildfire").published.is_some(), "GMT reads");
+        assert!(by_title("AT&T").published.is_some(), "+0000 reads");
+
+        // The one worth pinning: an obsolete abbreviation must reach the right
+        // offset, not be quietly taken as UTC and shown four hours out.
+        let europa = by_title("Europa").published.as_ref().expect("EDT reads");
+        assert_eq!(
+            europa.offset().seconds(),
+            -4 * 3600,
+            "EDT is -04:00, not UTC"
+        );
+
+        assert!(
+            by_title("A story its feed forgot").published.is_none(),
+            "a missing date costs the age, not the story"
+        );
+    }
+
+    #[test]
+    fn something_that_is_not_a_feed_is_an_error_or_an_empty_list() {
+        // Not XML at all.
+        assert!(parse("<<<not xml").is_err() || parse("<<<not xml").unwrap().is_empty());
+        // Valid XML, no items.
+        assert!(parse("<html><body>hello</body></html>").unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_namespaced_element_is_matched_by_its_local_name() {
+        assert_eq!(local_name(b"dc:creator"), b"creator");
+        assert_eq!(local_name(b"title"), b"title");
+    }
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -76,6 +76,63 @@ fn char_width(c: char) -> usize {
 ///
 /// Matches `Paragraph::new(text).wrap(Wrap { trim: false })`, whose own
 /// `line_count` is private. An empty line still occupies a row.
+/// Break `text` into lines no wider than `width` display cells.
+///
+/// The companion to [`wrapped_height`], which counts the same rows without
+/// producing them. `wrap(t, w).len()` and `wrapped_height(t, w)` are held equal
+/// by a test — they were written from the same rules and would otherwise drift,
+/// which for a panel that sizes itself from one and draws with the other means
+/// content sitting outside the box it was measured for.
+///
+/// Measured in cells rather than characters, per the rule the whole module
+/// exists for: a headline with an em dash or an accent breaks in the wrong
+/// place otherwise.
+pub fn wrap(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let mut current = String::new();
+        let mut used = 0usize;
+
+        for word in line.split_inclusive(' ') {
+            let w = display_width(word);
+            if used > 0 && used + w > width {
+                out.push(std::mem::take(&mut current));
+                used = 0;
+            }
+            current.push_str(word);
+            used += w;
+
+            // A single word longer than the line breaks inside itself, rather
+            // than running off the edge.
+            while used > width {
+                let keep: String = current
+                    .chars()
+                    .scan(0usize, |taken, c| {
+                        *taken += display_width(&c.to_string());
+                        (*taken <= width).then_some(c)
+                    })
+                    .collect();
+                let rest = current[keep.len()..].to_string();
+                out.push(keep);
+                current = rest;
+                used = display_width(&current);
+            }
+        }
+        out.push(current);
+    }
+    // `wrapped_height` floors at one row, on the grounds that an empty line
+    // still occupies one. These two are held equal by a test, so this has to
+    // agree — and `"".lines()` yields nothing at all.
+    if out.is_empty() {
+        out.push(String::new());
+    }
+    out
+}
+
 pub fn wrapped_height(text: &str, width: u16) -> u16 {
     if width == 0 {
         return 0;
@@ -360,6 +417,42 @@ fn fit(text: &str, width: u16, align: Align) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two must agree: a panel sizes itself with one and draws with the
+    /// other, so a disagreement puts content outside the box measured for it.
+    #[test]
+    fn wrapping_produces_exactly_as_many_rows_as_it_measures() {
+        let samples = [
+            "Wildfire now nine miles away from the French city of Bordeaux, mayor warns",
+            "short",
+            "",
+            "a supercalifragilisticexpialidociousandthensomeword in a line",
+            "Europa Clipper returns its first images — and they are extraordinary",
+            "line one\nline two is a good deal longer than the first one is",
+        ];
+        for text in samples {
+            for width in 8..40u16 {
+                assert_eq!(
+                    u16::try_from(wrap(text, usize::from(width)).len()).unwrap(),
+                    wrapped_height(text, width),
+                    "`{text}` at {width}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_wrapped_line_is_wider_than_asked_for() {
+        let text = "Wildfire now nine miles away from the French city of Bordeaux";
+        for width in 8..40usize {
+            for line in wrap(text, width) {
+                assert!(
+                    display_width(&line) <= width,
+                    "`{line}` is wider than {width}"
+                );
+            }
+        }
+    }
 
     fn columns() -> Vec<Column> {
         vec![

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -804,7 +804,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 232;
+        const CITED: usize = 254;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod arrange;
 mod chart;
 mod config;
 mod dateinput;
+mod feed;
 mod frame;
 mod glyphs;
 mod grid;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -81,7 +81,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
             config.stocks_path()?,
         )?),
         "calendar" => Box::new(calendar::CalendarPanel::new(config.calendar.clone())),
-        "watchlog" => Box::new(watchlog::WatchLogPanel::new()),
+        "watchlog" => Box::new(watchlog::WatchLogPanel::new(config)),
         "news" => Box::new(news::NewsPanel::new(&config.news)),
         "agenda" => Box::new(agenda::AgendaPanel::new(
             &config.agenda,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -9,6 +9,7 @@ pub mod calendar;
 pub mod clocks;
 pub mod cpu;
 pub mod network;
+pub mod news;
 pub mod notes;
 pub mod pomodoro;
 pub mod stocks;
@@ -24,7 +25,7 @@ use crate::panel::Panel;
 /// Every widget id accepted in the `[layout]` table.
 pub const WIDGET_NAMES: &[&str] = &[
     "clocks", "weather", "todo", "notes", "stocks", "calendar", "agenda", "pomodoro", "watchlog",
-    "cpu", "network",
+    "news", "cpu", "network",
 ];
 
 /// Whether `name` refers to a widget mirador knows how to build.
@@ -81,6 +82,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
         )?),
         "calendar" => Box::new(calendar::CalendarPanel::new(config.calendar.clone())),
         "watchlog" => Box::new(watchlog::WatchLogPanel::new()),
+        "news" => Box::new(news::NewsPanel::new(&config.news)),
         "agenda" => Box::new(agenda::AgendaPanel::new(
             &config.agenda,
             config.agenda_path()?,

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -1,0 +1,548 @@
+//! Headlines: a window on the world, not a feed.
+//!
+//! This is the panel that came closest to the one this dashboard turned down.
+//! Unread counts were rejected for being "a doomscroll hook" that "turns a calm
+//! dashboard into a nagging one", and news is *the* doomscroll surface —
+//! unbounded, constantly moving, and written by professionals to be clicked.
+//!
+//! So the commitment is the same shape as the watch log's, and it is
+//! presentational:
+//!
+//! - **However many stories fit, and no more.** There is no scrolling and no
+//!   "more below". You cannot work through it, because there is nothing to work
+//!   through.
+//! - **No count anywhere.** Not in the frame, not in the body.
+//! - **Nothing is new.** No unread state, no marker, no reordering to put fresh
+//!   items on top beyond the newest-first order they already have.
+//! - **Refreshed hourly**, which is slower than news moves and about as often
+//!   as a person should want to know.
+//!
+//! You glance at it the way you glance at the weather glass. Break any of those
+//! and this becomes the feature that was turned down.
+//!
+//! Headlines only, never the summary — see [`crate::feed`] for why. And no
+//! browser is launched: `o` shows the link and you copy it yourself, the same
+//! answer this project gave to playing a sound file.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use jiff::Zoned;
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+
+use crate::config::NewsConfig;
+use crate::feed::Story;
+use crate::frame::{Binding, FRAME_WIDTH};
+use crate::panel::{KeyOutcome, Panel, RenderContext, describe_age};
+
+const BINDINGS: &[Binding] = &[
+    Binding::primary("r", "refresh"),
+    Binding::primary("o", "show link"),
+    Binding::extra("↑ / ↓", "select"),
+    Binding::extra("j / k", "select"),
+];
+
+/// Interior width past which the panel gains nothing.
+///
+/// A headline runs about seventy cells at the median, measured across five real
+/// feeds, so this is two comfortable lines plus room for the longest to breathe.
+/// Past it the text just gets further from the eye.
+const USEFUL_WIDTH: u16 = 62;
+
+/// How long a request may take before it is given up on.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// What the fetch thread has produced.
+#[derive(Debug, Default)]
+struct State {
+    stories: Vec<Story>,
+    fetched: Option<Instant>,
+    /// Why the last attempt failed. The stories are kept either way — an hour
+    /// old headline is still news, where an empty panel is nothing.
+    error: Option<String>,
+}
+
+pub struct NewsPanel {
+    state: Arc<Mutex<State>>,
+    refresh: Arc<Mutex<bool>>,
+    stop: Arc<AtomicBool>,
+    generation: Arc<AtomicU64>,
+    seen: u64,
+    selected: ListState,
+    /// Set by `o`; the link of whatever is selected.
+    showing_link: Option<String>,
+    /// Stories drawn last frame, for clamping the selection.
+    drawn: usize,
+}
+
+impl Drop for NewsPanel {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+impl NewsPanel {
+    pub fn new(config: &NewsConfig) -> Self {
+        let state = Arc::new(Mutex::new(State::default()));
+        let refresh = Arc::new(Mutex::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        let generation = Arc::new(AtomicU64::new(0));
+
+        // An hour is the floor as well as the default. A dashboard left open
+        // for a week should not be re-reading somebody's feed every minute
+        // because a config said so.
+        let interval = Duration::from_secs(config.refresh_minutes.max(60) * 60);
+        let feeds: Vec<(String, String)> = config
+            .feeds
+            .iter()
+            .filter(|feed| !feed.url.trim().is_empty())
+            .map(|feed| (feed.name.clone(), feed.url.clone()))
+            .collect();
+        let per_feed = config.per_feed.clamp(1, 20);
+
+        let shared = (
+            Arc::clone(&state),
+            Arc::clone(&refresh),
+            Arc::clone(&stop),
+            Arc::clone(&generation),
+        );
+        std::thread::Builder::new()
+            .name("mirador-news".into())
+            .spawn(move || {
+                let (state, refresh, stop, generation) = shared;
+                fetch_loop(
+                    &feeds,
+                    per_feed,
+                    interval,
+                    &state,
+                    &refresh,
+                    &stop,
+                    &generation,
+                );
+            })
+            .expect("spawning the news thread");
+
+        Self {
+            state,
+            refresh,
+            stop,
+            generation,
+            seen: 0,
+            selected: ListState::default(),
+            showing_link: None,
+            drawn: 0,
+        }
+    }
+
+    fn snapshot(&self) -> State {
+        match self.state.lock() {
+            Ok(guard) => State {
+                stories: guard.stories.clone(),
+                fetched: guard.fetched,
+                error: guard.error.clone(),
+            },
+            Err(poisoned) => {
+                let guard = poisoned.into_inner();
+                State {
+                    stories: guard.stories.clone(),
+                    fetched: guard.fetched,
+                    error: guard.error.clone(),
+                }
+            }
+        }
+    }
+}
+
+impl Panel for NewsPanel {
+    fn title(&self) -> String {
+        "News".into()
+    }
+
+    /// Deliberately `None`.
+    ///
+    /// Every other list panel here carries a count. This one must not: a number
+    /// in the border is a badge, a badge accumulates, and an accumulating badge
+    /// is the unread-message count this dashboard turned down. The age of the
+    /// reading is not a count and would be defensible, but it belongs to the
+    /// fetch rather than to the news, and the panel already says it below.
+    fn counter(&self) -> Option<String> {
+        None
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn max_width(&self) -> Option<u16> {
+        Some(USEFUL_WIDTH + FRAME_WIDTH)
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        // How often a completed fetch reaches the screen, not how often one is
+        // made — the thread owns that, and it is an hour.
+        Duration::from_secs(20)
+    }
+
+    fn tick(&mut self) -> bool {
+        let now = self.generation.load(Ordering::Acquire);
+        let moved = now != self.seen;
+        self.seen = now;
+        moved
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        // Nothing here dismisses, hides or marks a story. There is no state to
+        // keep up with, which is the point.
+        self.showing_link = None;
+        match key.code {
+            KeyCode::Char('r') => {
+                if let Ok(mut flag) = self.refresh.lock() {
+                    *flag = true;
+                }
+            }
+            KeyCode::Char('o') => {
+                let stories = self.snapshot().stories;
+                // Shown, not opened. Launching a browser means talking to the
+                // platform — `open`, `xdg-open`, `start` — which is the same
+                // decision as playing a sound file and gets the same answer.
+                self.showing_link = self
+                    .selected
+                    .selected()
+                    .and_then(|index| stories.get(index))
+                    .map(|story| story.link.clone())
+                    .filter(|link| !link.is_empty());
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                crate::selection::down(&mut self.selected, 1, self.drawn);
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                crate::selection::up(&mut self.selected, 1, self.drawn);
+            }
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> KeyOutcome {
+        match event.kind {
+            MouseEventKind::ScrollDown => {
+                crate::selection::down(&mut self.selected, 1, self.drawn);
+            }
+            MouseEventKind::ScrollUp => crate::selection::up(&mut self.selected, 1, self.drawn),
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        let theme = ctx.theme;
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let state = self.snapshot();
+        let width = usize::from(area.width);
+
+        // One row at the foot for the age, or the link, or a failure.
+        let footer = Rect {
+            y: area.y + area.height.saturating_sub(1),
+            height: 1.min(area.height),
+            ..area
+        };
+        let body = Rect {
+            height: area.height.saturating_sub(1),
+            ..area
+        };
+
+        if state.stories.is_empty() {
+            let message = match &state.error {
+                Some(why) => vec![
+                    Line::from(Span::styled(
+                        "Cannot read the feeds",
+                        Style::default()
+                            .fg(theme.error)
+                            .add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(Span::styled(
+                        crate::grid::truncate(why, width),
+                        Style::default().fg(theme.muted),
+                    )),
+                ],
+                None if state.fetched.is_some() => vec![Line::from(Span::styled(
+                    "No stories.",
+                    Style::default().fg(theme.muted),
+                ))],
+                None => vec![Line::from(Span::styled(
+                    "Reading…",
+                    Style::default().fg(theme.muted),
+                ))],
+            };
+            frame.render_widget(Paragraph::new(message), body);
+            self.drawn = 0;
+            return;
+        }
+
+        // Each story is its source and age on one line, the headline wrapped
+        // under it, and a blank line after. Air rather than rules: a separator
+        // between every story would be more furniture than content at this
+        // width, and the panel is meant to read like a page.
+        let mut items: Vec<ListItem> = Vec::new();
+        let last = state.stories.len().saturating_sub(1);
+        for (index, story) in state.stories.iter().enumerate() {
+            let mut lines = vec![Line::from(masthead(story, theme))];
+            for line in crate::grid::wrap(&story.title, width) {
+                lines.push(Line::from(Span::styled(
+                    line,
+                    Style::default().fg(theme.text),
+                )));
+            }
+            // The gap goes *between* stories, not after every one. A trailing
+            // blank on the last item costs a whole row, and `List` draws only
+            // items that fit entirely — so that row was routinely the
+            // difference between two stories and three.
+            if index != last {
+                lines.push(Line::from(""));
+            }
+            items.push(ListItem::new(lines));
+        }
+
+        self.drawn = items.len();
+        frame.render_stateful_widget(List::new(items), body, &mut self.selected);
+
+        let foot = match (&self.showing_link, &state.error) {
+            (Some(link), _) => Span::styled(
+                crate::grid::truncate(link, width),
+                Style::default().fg(theme.label),
+            ),
+            (None, Some(_)) => Span::styled(
+                format!(
+                    "{} — refresh failing",
+                    state
+                        .fetched
+                        .map_or_else(|| "never read".to_string(), |at| describe_age(at.elapsed()))
+                ),
+                Style::default().fg(theme.warning),
+            ),
+            (None, None) => Span::styled(
+                state
+                    .fetched
+                    .map_or_else(String::new, |at| describe_age(at.elapsed())),
+                Style::default().fg(theme.muted),
+            ),
+        };
+        if footer.height > 0 {
+            frame.render_widget(Paragraph::new(Line::from(foot)), footer);
+        }
+    }
+}
+
+/// `NASA · 2h`, in the engraved-label face.
+fn masthead(story: &Story, theme: &crate::theme::Theme) -> Vec<Span<'static>> {
+    let mut spans = vec![Span::styled(
+        crate::glyphs::utility(&story.source),
+        Style::default()
+            .fg(theme.label)
+            .add_modifier(Modifier::BOLD),
+    )];
+    if let Some(at) = &story.published {
+        let age = Zoned::now().duration_since(at);
+        if let Ok(age) = std::time::Duration::try_from(age) {
+            spans.push(Span::styled(
+                format!(" · {}", describe_age(age)),
+                Style::default().fg(theme.muted),
+            ));
+        }
+    }
+    spans
+}
+
+/// Read every feed, newest first, then wait.
+#[allow(clippy::too_many_arguments)]
+fn fetch_loop(
+    feeds: &[(String, String)],
+    per_feed: usize,
+    interval: Duration,
+    state: &Arc<Mutex<State>>,
+    refresh: &Arc<Mutex<bool>>,
+    stop: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
+) {
+    while !stop.load(Ordering::Relaxed) {
+        let mut stories = Vec::new();
+        let mut failures = Vec::new();
+
+        for (name, url) in feeds {
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
+            match read_feed(url) {
+                Ok(mut found) => {
+                    found.truncate(per_feed);
+                    for mut story in found {
+                        story.source.clone_from(name);
+                        stories.push(story);
+                    }
+                }
+                Err(e) => failures.push(format!("{name}: {e:#}")),
+            }
+        }
+
+        let stories = interleave(stories);
+
+        let failed = (!failures.is_empty()).then(|| failures.join("; "));
+        match state.lock() {
+            Ok(mut guard) => {
+                // A total failure keeps what is on screen; a partial one takes
+                // what arrived. Either way the age below says how fresh it is.
+                if !stories.is_empty() {
+                    guard.stories = stories;
+                    guard.fetched = Some(Instant::now());
+                }
+                guard.error = failed;
+            }
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                if !stories.is_empty() {
+                    guard.stories = stories;
+                    guard.fetched = Some(Instant::now());
+                }
+                guard.error = failed;
+            }
+        }
+        generation.fetch_add(1, Ordering::Release);
+
+        let woke = crate::poll::wait(interval, stop, || match refresh.lock() {
+            Ok(mut flag) => std::mem::replace(&mut *flag, false),
+            Err(poisoned) => std::mem::replace(&mut *poisoned.into_inner(), false),
+        });
+        if woke == crate::poll::Wake::Stop {
+            return;
+        }
+    }
+}
+
+/// One story from each feed, then the next from each, and so on.
+///
+/// Not simply newest-first, which is what this did at first and which is wrong
+/// for what the panel is. The feeds publish at wildly different rates, so date
+/// order hands the whole visible window to whichever one happens to be chatty
+/// — the first run showed three consecutive Phys.org space stories, which is
+/// not a window on the world however fresh it is.
+///
+/// Round-robin guarantees that the first thing you see is the newest from each
+/// feed, which is the shape "a handful of stories, however many fit" was meant
+/// to have. Within a feed the order is still newest first.
+fn interleave(stories: Vec<Story>) -> Vec<Story> {
+    let mut by_source: Vec<Vec<Story>> = Vec::new();
+    for story in stories {
+        match by_source
+            .iter_mut()
+            .find(|group| group.first().is_some_and(|s| s.source == story.source))
+        {
+            Some(group) => group.push(story),
+            None => by_source.push(vec![story]),
+        }
+    }
+
+    // Newest first inside each feed. An undated story goes last rather than
+    // first — an absent date is not "just now".
+    for group in &mut by_source {
+        group.sort_by(|a, b| match (&b.published, &a.published) {
+            (Some(later), Some(earlier)) => later.cmp(earlier),
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+    }
+
+    let deepest = by_source.iter().map(Vec::len).max().unwrap_or(0);
+    let mut out = Vec::new();
+    for rank in 0..deepest {
+        for group in &by_source {
+            if let Some(story) = group.get(rank) {
+                out.push(story.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Fetch and parse one feed.
+fn read_feed(url: &str) -> anyhow::Result<Vec<Story>> {
+    let body = ureq::get(url)
+        .config()
+        .timeout_global(Some(HTTP_TIMEOUT))
+        .build()
+        .call()?
+        .body_mut()
+        .read_to_string()?;
+    crate::feed::parse(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn story(source: &str, title: &str, minutes_ago: i64) -> Story {
+        Story {
+            source: source.into(),
+            title: title.into(),
+            link: String::new(),
+            published: Zoned::now()
+                .checked_sub(jiff::Span::new().minutes(minutes_ago))
+                .ok(),
+        }
+    }
+
+    /// The first version sorted purely by date and handed the whole visible
+    /// window to whichever feed published most often — three consecutive
+    /// Phys.org stories on the first real run. However fresh that is, it is not
+    /// a window on the world.
+    #[test]
+    fn the_top_of_the_panel_holds_one_story_from_each_feed() {
+        let mixed = interleave(vec![
+            story("PHYS", "phys newest", 5),
+            story("PHYS", "phys second", 10),
+            story("PHYS", "phys third", 15),
+            story("NASA", "nasa newest", 60),
+            story("ARS", "ars newest", 90),
+        ]);
+
+        let first_three: Vec<&str> = mixed.iter().take(3).map(|s| s.source.as_str()).collect();
+        assert_eq!(first_three, ["PHYS", "NASA", "ARS"], "one from each first");
+        assert_eq!(
+            mixed[0].title, "phys newest",
+            "and the newest within a feed"
+        );
+        assert_eq!(mixed[3].title, "phys second", "then the second round");
+    }
+
+    /// Within a feed the order is still newest first, and a story with no date
+    /// sorts last rather than being taken for the freshest thing there is.
+    #[test]
+    fn an_undated_story_goes_last_within_its_feed() {
+        let undated = Story {
+            source: "PHYS".into(),
+            title: "undated".into(),
+            link: String::new(),
+            published: None,
+        };
+        let ordered = interleave(vec![
+            undated,
+            story("PHYS", "older", 90),
+            story("PHYS", "newer", 5),
+        ]);
+        let titles: Vec<&str> = ordered.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(titles, ["newer", "older", "undated"]);
+    }
+}

--- a/src/widgets/watchlog.rs
+++ b/src/widgets/watchlog.rs
@@ -40,13 +40,17 @@ pub struct WatchLogPanel {
     scroll: ListState,
     /// Entries drawn last frame, so `tick` can answer honestly.
     drawn: usize,
+    /// Whether a calendar is configured, so the empty panel can say that one
+    /// of the two things it watches is not switched on.
+    watching_calendar: bool,
 }
 
 impl WatchLogPanel {
-    pub fn new() -> Self {
+    pub fn new(config: &crate::config::Config) -> Self {
         Self {
             scroll: ListState::default(),
             drawn: 0,
+            watching_calendar: config.agenda.file.is_some(),
         }
     }
 }
@@ -138,19 +142,49 @@ impl Panel for WatchLogPanel {
         }
 
         if items.is_empty() {
-            frame.render_widget(
-                Paragraph::new(vec![
-                    Line::from(Span::styled(
-                        "Nothing has happened",
-                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
-                    )),
-                    Line::from(Span::styled(
-                        format!("since {}.", started(log.since())),
-                        Style::default().fg(theme.muted),
-                    )),
-                ]),
-                area,
+            // An empty log has to say what it is watching, or it reads as
+            // broken. It has no refresh key because nothing here is polled —
+            // the panels report to it — and "Nothing has happened" alone gives
+            // a reader no way to tell the difference between working and dead.
+            // Somebody switched this on, waited, and reasonably concluded it
+            // was the latter.
+            let width = usize::from(area.width);
+            let mut lines = vec![
+                Line::from(Span::styled(
+                    "Nothing has happened",
+                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(Span::styled(
+                    format!("since {}.", started(log.since())),
+                    Style::default().fg(theme.muted),
+                )),
+                Line::from(""),
+            ];
+
+            // Wrapped rather than hand-broken. The first version assumed a
+            // width the panel does not have and lost its last line off the
+            // bottom, which is a poor way to explain something.
+            let explain = |lines: &mut Vec<Line<'static>>, text: &str, colour| {
+                for line in crate::grid::wrap(text, width) {
+                    lines.push(Line::from(Span::styled(line, Style::default().fg(colour))));
+                }
+            };
+            explain(
+                &mut lines,
+                "Watching for things you did not do yourself: a task falling \
+                 overdue, an entry appearing in your calendar.",
+                theme.muted,
             );
+            if !self.watching_calendar {
+                lines.push(Line::from(""));
+                explain(
+                    &mut lines,
+                    "No calendar set, so only the first can happen. Press f on \
+                     the agenda panel.",
+                    theme.warning,
+                );
+            }
+            frame.render_widget(Paragraph::new(lines), area);
             self.drawn = 0;
             return;
         }
@@ -217,7 +251,10 @@ mod tests {
     /// fails, the question to ask is not how to fix the test.
     #[test]
     fn the_panel_never_offers_a_counter() {
-        assert_eq!(WatchLogPanel::new().counter(), None);
+        assert_eq!(
+            WatchLogPanel::new(&crate::config::Config::default()).counter(),
+            None
+        );
     }
 
     /// The log is read, never edited. A key that dismissed an entry would make
@@ -225,7 +262,7 @@ mod tests {
     /// obligation this panel is designed to avoid.
     #[test]
     fn nothing_dismisses_acknowledges_or_clears_an_entry() {
-        let mut panel = WatchLogPanel::new();
+        let mut panel = WatchLogPanel::new(&crate::config::Config::default());
         panel.drawn = 5;
         for code in [
             KeyCode::Char('d'),


### PR DESCRIPTION
Headlines from RSS feeds you choose, hourly.

## The commitment

This is the panel closest to the one already turned down — unread counts were rejected as a doomscroll hook, and news *is* the doomscroll surface. It survives on the watch log's kind of commitment, plus one more clause:

**No count. No unread state. Nothing to dismiss. No scrolling.** It shows however many stories fit and that's all there is. You can't work through it because there's nothing to work through. A `3 new` counter in that frame makes it the refused feature again; a test says so in its failure message.

## Three things building it found that the design didn't predict

**Date order handed the window to the chattiest feed.** The first real run showed three consecutive Phys.org space stories — fresh, and not a window on the world. Stories are interleaved by feed now, so the top holds the newest from each.

**`trim_text(true)` ate spaces beside entities.** An entity splits an element's text into separate events, so a real headline reached the screen as `'Dead stars'may have surprisingly healthy appetites`. Trimmed once at the end instead; there's a test that reproduces it exactly.

**A trailing blank after the last story cost a whole row** — `List` needs an item to fit entirely before drawing it, so that row was routinely the difference between two stories and three.

## Decisions worth reviewing

- **quick-xml, where `ical.rs` hand-rolled.** Not inconsistent: iCal is line-based, XML has entities/CDATA/namespaces. Measured first — quick-xml **2** crates, `rss` 23, `feed-rs` 58.
- **Headlines only.** Feeds carry 80–384 chars of article prose in `<description>`. A headline is a fact; a summary is someone's work.
- **`o` shows a link, doesn't open one.** Same answer this project gave to playing a sound file.
- **Science, space and technology feeds only.** Choosing outlets for general news is an editorial act this project shouldn't make for people.
- **The default layout is four rows.** Three was measured and recorded as sufficient at eleven panels; a twelfth wanting sixty columns for prose changes that.

552 tests; clippy, fmt and rustdoc silent. No test touches the network — the parser is tested against a captured fixture built from real feeds.