### PR TITLE
Record the day turning in the watch log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you. Headlines only — feed summaries are article prose belonging to whoever
   wrote them.
 
+- **The watch log records the day turning.** It is the one source that always
+  fires, so the panel has something to say before you point it at a calendar,
+  and it doubles as the divider marking where one day's entries end. Recorded by
+  the shell rather than a panel: the todo panel notices a rollover too, but a
+  day-divider that vanishes when you switch off the task list would be odd.
+
 - **An empty watch log says what it is watching.** It had no refresh key —
   nothing there is polled, the panels report to it — and "Nothing has happened"
   on its own gave a reader no way to tell working from dead. It now names the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,12 @@ with a hole in it — the hours mirador was not running and observed nothing —
 and it cannot mark that hole. Same discipline as weather showing a reading's
 age rather than implying it is current.
 
+**The day turning is recorded by the shell, not by a panel.** `App` holds the
+date for this and no widget owns it. The todo panel notices a rollover too, but
+a dashboard whose day-divider vanishes when you switch off the task list would
+be strange — and it is the one source that always fires, which is what keeps the
+panel from looking broken on a setup with no calendar and nothing falling due.
+
 **The first read of a calendar is not news.** `AgendaPanel::known` is `None`
 until the first successful read, so a startup does not announce every event in
 your `.ics`. A log that opens with forty entries is a log nobody reads twice.

--- a/README.md
+++ b/README.md
@@ -530,9 +530,13 @@ Almost nothing qualifies, and that is the point. The clock, the readings, the
 prices and the graphs change continuously and none of it is news; your notes and
 tasks change because you changed them. An entry is something that happened *to*
 you rather than because of you, and that you would want to know even if you
-never looked at the panel it came from. Out of the box that means two things: an
-event appearing in your `.ics` that you did not put there, and a task crossing
-into overdue because the day turned.
+never looked at the panel it came from. Out of the box that means three things:
+the day turning, a task crossing into overdue because of it, and an event
+appearing in your `.ics` that you did not put there.
+
+The day turning is the one that always happens, which is more useful than it
+sounds — it is the divider that tells you where one day's entries end, and it
+means the panel has something to say even before you point it at a calendar.
 
 **It has no counter, no unread state, and no effect on any other panel.** Unread
 message counts were considered for this dashboard and rejected — a number that

--- a/src/app.rs
+++ b/src/app.rs
@@ -278,6 +278,13 @@ pub struct App {
     /// changes. Events would be lost every time, and a log that forgets when
     /// you rearrange the dashboard is not a log.
     watch: crate::watch::WatchLog,
+    /// The day the watch log last saw.
+    ///
+    /// Held here rather than in a panel because the day turning is not any
+    /// panel's business — the todo panel happens to notice it too, but a
+    /// dashboard whose day-divider disappears when you switch off the task
+    /// list would be a strange thing.
+    today: jiff::civil::Date,
     /// The panel picker, while it is open.
     picker: Option<crate::picker::Picker>,
     /// The layout as it stood when arrange mode opened, kept so that `Esc` can
@@ -347,6 +354,7 @@ impl App {
             show_update_hint: true,
             unused_widgets,
             watch: crate::watch::WatchLog::default(),
+            today: jiff::Zoned::now().date(),
             picker: None,
             arranging: None,
             config_path: None,
@@ -657,6 +665,22 @@ impl App {
     /// report unconditionally than to ask whether it is placed.
     fn collect_events(&mut self) -> bool {
         let mut recorded = false;
+
+        // The day turning is the one thing in here that always happens, which
+        // matters more than it sounds: with a calendar unconfigured and no task
+        // falling due, every other source can go quiet for days and leave the
+        // panel looking broken. It is also the most useful divider a log of
+        // "what changed while I was away" can have.
+        let today = jiff::Zoned::now().date();
+        if today != self.today {
+            self.today = today;
+            self.watch.push(crate::watch::Event::new(
+                "clock",
+                format!("{} began", today.strftime("%A %-d %B")),
+            ));
+            recorded = true;
+        }
+
         for slot in &mut self.slots {
             for event in slot.panel.events() {
                 self.watch.push(event);
@@ -1853,6 +1877,32 @@ mod tests {
                 assert!(bar.contains("Esc cancel"), "no way out at {width}: {bar}");
             }
         }
+    }
+
+    /// The day turning is the one source that always fires, which is what
+    /// stops the watch log looking broken on a dashboard with no calendar and
+    /// nothing falling due. It lives in the shell rather than a panel so that
+    /// switching off the task list cannot take it away.
+    #[test]
+    fn the_day_turning_is_recorded_whatever_panels_are_placed() {
+        // Only a clock: neither of the panels that report events is here.
+        let mut app = App::new(config_with(&["clocks"])).expect("builds");
+        assert!(app.watch.entries().next().is_none(), "nothing yet");
+
+        // Wind the remembered day back, which is what a night does.
+        app.today = app.today.yesterday().expect("a day before today exists");
+        assert!(app.collect_events(), "the rollover is worth a redraw");
+
+        let entry = app.watch.entries().next().expect("an entry was recorded");
+        assert!(
+            entry.text.ends_with("began"),
+            "reads as a day divider: {}",
+            entry.text
+        );
+
+        // And only once — a second pass on the same day adds nothing.
+        assert!(!app.collect_events(), "the same day is not news twice");
+        assert_eq!(app.watch.entries().count(), 1);
     }
 
     #[test]

--- a/src/widgets/watchlog.rs
+++ b/src/widgets/watchlog.rs
@@ -171,17 +171,20 @@ impl Panel for WatchLogPanel {
             };
             explain(
                 &mut lines,
-                "Watching for things you did not do yourself: a task falling \
-                 overdue, an entry appearing in your calendar.",
+                "Watching for things you did not do yourself: the day turning, \
+                 a task falling overdue, an entry appearing in your calendar.",
                 theme.muted,
             );
             if !self.watching_calendar {
                 lines.push(Line::from(""));
+                // Milder than it was, and correctly so: the day always turns,
+                // so the panel is no longer inert without a calendar — it is
+                // merely watching one thing fewer.
                 explain(
                     &mut lines,
-                    "No calendar set, so only the first can happen. Press f on \
-                     the agenda panel.",
-                    theme.warning,
+                    "No calendar set, so that last one cannot happen. Press f \
+                     on the agenda panel to add one.",
+                    theme.muted,
                 );
             }
             frame.render_widget(Paragraph::new(lines), area);


### PR DESCRIPTION
The one watch-log source that always fires.

Without it, a dashboard with no calendar configured and nothing falling due can go quiet for days — which is what made the panel look broken. The explanation added alongside helps, but a panel with something to say beats a panel explaining why it has nothing.

It also doubles as the divider marking where one day's entries end, which is most of what "what changed while I was away" is for when the away part included a night.

**Recorded by the shell, not a panel.** The todo panel notices a rollover too and could have carried it, but a day-divider that disappears when you switch off the task list would be strange. The date lives on `App`, beside the log.

The empty-state warning about a missing calendar is milder now and correctly so — it costs one of three sources rather than leaving the panel inert.

Verified by test rather than by watching midnight pass: the test winds the remembered day back, which is what a night does, and it fails when the check is removed. `faketime` wasn't available here to drive a real rollover in the terminal.

553 tests; clippy, fmt and rustdoc silent.