### PR TITLE
Say in the status bar when something needs you

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **The status bar says when something needs you.** One line, naming the single
+  most pressing thing — an event about to start, a save that is failing, a
+  layout change that did not persist — and nothing at all when nothing is
+  pressing.
+
+  It names one thing and never a count, and it clears itself when the cause
+  does. **There is no all-clear**: an indicator saying everything is fine is a
+  light you have to read to learn nothing.
+
+  Deliberately strict about what qualifies: *will this get worse if nobody acts
+  in the next few minutes*. An overdue task does not — it is notable, already
+  red in its own panel, and a signal lit for it would be lit permanently, which
+  is how a warning becomes furniture.
+
+### Fixed
+
+- **A layout that could not be saved now says so.** It was reported inside the
+  `w` picker and nowhere else, so a rearrangement that failed to persist was
+  silent once the picker closed — and gone at the next launch. It was the one
+  genuine silent failure left in the program.
+
 ## [0.13.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,6 +405,33 @@ exactly the default. Hence two things: `check_palette_ordering` refuses such a
 file by name, and the drift test is paired with one that asserts a standalone
 theme *sets every key*, which is the property that can actually fail.
 
+## The "is anything on fire" signal — built
+
+One line in the status bar naming the single most pressing thing, absent
+otherwise. `Panel::alert` is the present-tense sibling of `Panel::events`: same
+notion of notable, different tense, which is why they are separate hooks.
+
+**The threshold is "will this get worse if nobody acts in the next few
+minutes",** and holding that line is the whole feature. An overdue task does not
+qualify — notable, already red in its own panel, and identically overdue in an
+hour. A signal lit for it is lit permanently, and a permanently lit alarm is
+furniture: the unread-badge failure reached from the other direction. Eight of
+the twelve panels already show what is wrong in their own frames, so the gap
+this fills was aggregation, never detection.
+
+**No all-clear, ever.** An indicator saying everything is fine is a light you
+have to read to learn nothing. Absence is the signal; there is a test.
+
+**It takes the whole bar rather than sharing it.** Squeezing it in beside the
+key hints truncated the *reason*, which is the actionable half —
+`read-only file syste…`. The keys are behind `?`, and an alert is gone the
+moment its cause is.
+
+**`layout_error` was the one genuine silent failure in the program.** It was
+reported inside the `w` picker and nowhere else, so a rearrangement that failed
+to persist said nothing once the picker closed and was gone at the next launch.
+That is now an alert.
+
 ## The news panel — built
 
 The one that came closest to the feature this dashboard turned down. Unread

--- a/README.md
+++ b/README.md
@@ -683,6 +683,31 @@ In the add/edit form, `Tab` and `Shift+Tab` move between fields, `Enter` saves
 and `Esc` cancels. While a form is open, global keys are suppressed, so typing
 a `q` into a task title does not quit the dashboard.
 
+## When something needs you
+
+The status bar carries one line when something will get worse if you ignore it,
+and carries nothing otherwise:
+
+```
+ ⚠ Quarterly planning in 5m · Room 12
+ ⚠ Tasks could not be saved — read-only file system (os error 30)
+```
+
+**There is no all-clear.** An indicator saying everything is fine is a light you
+have to read in order to learn nothing, and reading it is work. Absence is the
+signal.
+
+**It names one thing, never a count**, and it clears itself when the thing
+resolves. Nothing to acknowledge, nothing to dismiss.
+
+The bar is deliberately strict about what qualifies: *will this get worse if
+nobody acts in the next few minutes*. A save that is failing, an event about to
+start, a layout change that did not persist. An overdue task does **not**
+qualify — it is notable, the task panel already shows it in red, and a signal lit
+for it would be lit permanently. A permanently lit warning is furniture you stop
+seeing inside a week, which is the same failure as an unread badge arrived at
+from the other direction.
+
 ## Due dates
 
 The due field accepts more than ISO dates:

--- a/src/app.rs
+++ b/src/app.rs
@@ -1436,6 +1436,34 @@ impl App {
             spans.push(Span::styled(format!(" {}", binding.action), muted));
         }
 
+        // An alert takes the whole bar rather than sharing it. It outranks both
+        // hints — one is about a new version, the other about widgets you are
+        // not using, and neither gets worse while you read the other — and it
+        // outranks the key list too, because the *reason* is the actionable
+        // part and squeezing it in beside `Tab focus` truncated it to
+        // "read-only file syste…". The keys are behind `?`, and an alert is
+        // gone as soon as the thing it names is.
+        if let Some(alert) = self.alert() {
+            let marker = " ⚠ ";
+            let room = usize::from(area.width).saturating_sub(marker.chars().count());
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        marker,
+                        Style::default()
+                            .fg(theme.error)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        crate::grid::truncate(&alert.text, room),
+                        Style::default().fg(theme.error),
+                    ),
+                ])),
+                area,
+            );
+            return;
+        }
+
         // The hint rides on the right of the bar it shares with the global
         // keys, and gives way to them when the terminal is too narrow: knowing
         // how to quit matters more than knowing what you are not using.
@@ -1457,6 +1485,31 @@ impl App {
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    /// The single most pressing thing, if anything is pressing.
+    ///
+    /// Absent almost always, which is the point — see [`crate::panel::Alert`].
+    /// There is no all-clear: an indicator that says everything is fine is a
+    /// light you have to read in order to learn nothing, and reading it is work
+    /// a dashboard should not ask for.
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        // The layout write is the one genuine silent failure in the program.
+        // It is reported inside the `w` picker and nowhere else, so a
+        // rearrangement that fails to persist says nothing at all once the
+        // picker closes — and the change is gone at the next launch.
+        let own = self.layout_error.as_ref().map(|why| {
+            crate::panel::Alert::failing(format!("The layout could not be saved — {why}"))
+        });
+
+        self.slots
+            .iter()
+            .filter_map(|slot| slot.panel.alert())
+            .chain(own)
+            // Most severe wins, and the newest of equals — with two levels and
+            // both near-never, which one shows barely matters; that it is only
+            // ever *one* does.
+            .max_by_key(|alert| alert.severity)
     }
 
     /// The one-line startup notice about widgets this layout does not place.
@@ -1903,6 +1956,52 @@ mod tests {
         // And only once — a second pass on the same day adds nothing.
         assert!(!app.collect_events(), "the same day is not news twice");
         assert_eq!(app.watch.entries().count(), 1);
+    }
+
+    /// The layout write is the one thing in the program that could fail
+    /// silently: it was reported inside the `w` picker and nowhere else, so a
+    /// rearrangement that did not persist said nothing once the picker closed,
+    /// and the change was gone at the next launch.
+    #[test]
+    fn a_layout_that_would_not_save_reaches_the_status_bar() {
+        let mut app = App::new(resizable()).expect("builds");
+        assert!(app.alert().is_none(), "nothing is wrong yet");
+
+        app.layout_error = Some("read-only file system (os error 30)".into());
+        let alert = app.alert().expect("an alert");
+        assert_eq!(alert.severity, crate::panel::Severity::Failing);
+        assert!(alert.text.contains("layout"), "names it: {}", alert.text);
+
+        let bar = status_bar_at(&mut app, 120);
+        assert!(bar.contains('⚠'), "and it is on the bar: {bar}");
+        assert!(bar.contains("os error 30"), "with the reason: {bar}");
+    }
+
+    /// There is no all-clear. An indicator saying everything is fine is a light
+    /// you have to read to learn nothing, and reading it is work.
+    #[test]
+    fn a_quiet_dashboard_says_nothing_at_all() {
+        let mut app = App::new(resizable()).expect("builds");
+        let bar = status_bar_at(&mut app, 120);
+        assert!(!bar.contains('⚠'), "no marker: {bar}");
+        assert!(
+            !bar.to_lowercase().contains("ok") && !bar.to_lowercase().contains("clear"),
+            "and no reassurance: {bar}"
+        );
+    }
+
+    /// An alert outranks both hints. Neither of those is going to get worse
+    /// while you read the other one.
+    #[test]
+    fn an_alert_displaces_the_hints_rather_than_queueing_behind_them() {
+        let mut app = App::new(config_with(&["clocks"])).expect("builds");
+        let before = status_bar_at(&mut app, 200);
+        assert!(before.contains("unused"), "the hint is there to displace");
+
+        app.layout_error = Some("disk full".into());
+        let after = status_bar_at(&mut app, 200);
+        assert!(after.contains("disk full"), "the alert shows: {after}");
+        assert!(!after.contains("unused"), "and the hint gives way: {after}");
     }
 
     #[test]

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -72,6 +72,59 @@ pub struct RenderContext<'a> {
     pub watch: &'a crate::watch::WatchLog,
 }
 
+/// Something that will get worse if it is ignored.
+///
+/// Deliberately not "something is wrong". Panels already show what is wrong in
+/// their own frames — an overdue task is red, a stale reading says its age, a
+/// failing fetch says so — and eight of the twelve do it today. Repeating all
+/// of that in one line would produce a signal that is lit permanently, and a
+/// permanently lit alarm is furniture: you stop seeing it inside a week, which
+/// is the unread-badge failure reached from a different direction.
+///
+/// The bar is therefore **will this deteriorate if nobody acts in the next few
+/// minutes**. A save that is failing loses work. An event about to start is
+/// missed. A layout that did not persist is gone at the next launch. An overdue
+/// task from three days ago is none of those: it is notable, it is already red,
+/// and it will be exactly as overdue in an hour.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Alert {
+    pub severity: Severity,
+    /// One line, naming the thing rather than the panel, in the terms someone
+    /// would use to describe the problem to somebody else.
+    pub text: String,
+}
+
+/// How bad, for picking one alert out of several.
+///
+/// Two levels because two is all the distinction that is needed: something is
+/// about to happen, or something has broken. More would be a taxonomy nobody
+/// consults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    /// A deadline approaching. Missing it is bad and survivable.
+    Soon,
+    /// Something is failing now. Ranked above `Soon` because what it costs —
+    /// usually work you cannot retype — does not come back, where a missed
+    /// meeting at least leaves you the rest of the day.
+    Failing,
+}
+
+impl Alert {
+    pub fn soon(text: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Soon,
+            text: text.into(),
+        }
+    }
+
+    pub fn failing(text: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Failing,
+            text: text.into(),
+        }
+    }
+}
+
 /// A single dashboard widget.
 ///
 /// Implementors are stored as `Box<dyn Panel>`, so the trait is deliberately
@@ -193,6 +246,22 @@ pub trait Panel {
     ///
     /// [`render`]: Panel::render
     fn overlay(&self) -> Option<&crate::prompt::Prompt> {
+        None
+    }
+
+    /// Something about this panel that will get worse if it is ignored.
+    ///
+    /// The present-tense sibling of [`events`]: that one reports a moment that
+    /// has passed, this one a condition that is still true. Both ask what is
+    /// notable; they differ in tense, which is why they are separate hooks
+    /// rather than one.
+    ///
+    /// Called every frame, so it must be cheap and must not allocate when there
+    /// is nothing to say — which is nearly always. Returning `Some` for an
+    /// ordinary state is how this feature stops working: see [`Alert`].
+    ///
+    /// [`events`]: Panel::events
+    fn alert(&self) -> Option<crate::panel::Alert> {
         None
     }
 

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -45,6 +45,13 @@ const BINDINGS: &[Binding] = &[
     Binding::extra("o", "show file path"),
 ];
 
+/// How close an event has to be before it is worth interrupting for.
+///
+/// Ten minutes is about the time it takes to finish a thought, find the link
+/// and get there. Much longer and the signal is lit for a large part of a
+/// working day, which is the failure this whole feature is built to avoid.
+const IMMINENT: std::time::Duration = std::time::Duration::from_mins(10);
+
 /// Width at which the panel stops gaining anything: a time, a generous summary
 /// and a location beside it.
 const USEFUL_WIDTH: u16 = 52;
@@ -476,6 +483,40 @@ impl Panel for AgendaPanel {
             self.note_new_entries();
         }
         moved
+    }
+
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        let now = Zoned::now();
+        let state = self.snapshot();
+
+        // The nearest event that has not started and starts within the window.
+        // An event already under way is deliberately not an alert: you are
+        // either in it or you have missed it, and a dashboard telling you about
+        // a meeting you are sitting in is noise.
+        state
+            .events
+            .iter()
+            .filter(|event| !event.all_day)
+            .filter_map(|event| {
+                let until = event.start.duration_since(&now);
+                let until = std::time::Duration::try_from(until).ok()?;
+                (until <= IMMINENT).then_some((until, event))
+            })
+            .min_by_key(|(until, _)| *until)
+            .map(|(until, event)| {
+                let minutes = until.as_secs() / 60;
+                let when = if minutes == 0 {
+                    "now".to_string()
+                } else {
+                    format!("in {minutes}m")
+                };
+                match &event.location {
+                    Some(place) => {
+                        crate::panel::Alert::soon(format!("{} {when} · {place}", event.summary))
+                    }
+                    None => crate::panel::Alert::soon(format!("{} {when}", event.summary)),
+                }
+            })
     }
 
     fn events(&mut self) -> Vec<crate::watch::Event> {

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -300,6 +300,12 @@ impl Panel for ClocksPanel {
         self.asking.as_ref()
     }
 
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        self.zones.last_error.as_ref().map(|why| {
+            crate::panel::Alert::failing(format!("The world clocks could not be saved — {why}"))
+        })
+    }
+
     fn captures_input(&self) -> bool {
         self.asking.is_some()
     }

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -693,6 +693,15 @@ impl Panel for NotesPanel {
         moved
     }
 
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        // A save that is failing is the clearest case there is: the work is on
+        // screen and not on disk, and every further edit widens the gap.
+        self.store
+            .last_error
+            .as_ref()
+            .map(|why| crate::panel::Alert::failing(format!("Notes could not be saved — {why}")))
+    }
+
     fn captures_input(&self) -> bool {
         !matches!(self.mode, Mode::List)
     }

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -670,6 +670,12 @@ impl Panel for StocksPanel {
         Duration::from_secs(1)
     }
 
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        self.watchlist.last_error.as_ref().map(|why| {
+            crate::panel::Alert::failing(format!("The watchlist could not be saved — {why}"))
+        })
+    }
+
     fn captures_input(&self) -> bool {
         !matches!(self.mode, Mode::List)
     }

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -939,6 +939,15 @@ impl Panel for TodoPanel {
         true
     }
 
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        // A save that is failing is the clearest case there is: the work is on
+        // screen and not on disk, and every further edit widens the gap.
+        self.store
+            .last_error
+            .as_ref()
+            .map(|why| crate::panel::Alert::failing(format!("Tasks could not be saved — {why}")))
+    }
+
     fn events(&mut self) -> Vec<crate::watch::Event> {
         std::mem::take(&mut self.pending)
     }


### PR DESCRIPTION
The last gap from the original analysis, and the one most likely to go wrong: a signal answering "is anything on fire" is an alarm, and an alarm usually right about nothing being wrong is an alarm nobody reads.

```
 ⚠ Quarterly planning in 5m · Room 12
 ⚠ Tasks could not be saved — read-only file system (os error 30)
```

## Two findings shaped this more than the request did

**The gap had partly closed itself.** Eight of twelve panels already show what's wrong in their own frames — overdue tasks in red, a failing fetch with its age, save errors where the save was. What was missing was never *detection*; it's that severity is spread across twelve panels and answering "do I need to act?" means reading all of them. So this **aggregates** rather than detects — a far smaller and safer thing.

**Severity is not urgency.** A task overdue by three days is notable and will be exactly as overdue in an hour; a failing save loses work now. One signal for both is lit permanently, and a permanently lit warning is furniture — the unread-badge failure from the other direction.

So the bar is: **will this get worse if nobody acts in the next few minutes.** Under that rule it's almost never on, which is what makes it worth a glance when it is.

## Decisions

- **No all-clear.** An indicator saying everything is fine is a light you read to learn nothing. Absence is the signal, and a test asserts the bar contains no reassurance when quiet.
- **It takes the whole bar** rather than sharing with the key hints. The first version shared and truncated the *reason* — `read-only file syste…` — which is the actionable half. Keys are behind `?`; an alert is gone the moment its cause is.
- **One thing, never a count.** `Panel::alert()` is the present-tense sibling of `events()`; the shell takes the most severe.

## The silent failure it closes

`layout_error` was reported inside the `w` picker and nowhere else — a rearrangement that wouldn't persist said nothing once the picker closed, and was gone at the next launch. It was the one genuine silent failure left in the program.

## Verified live

An event six minutes out produced `⚠ Quarterly planning in 5m · Room 12`; pushing it three hours out cleared the bar with nothing to acknowledge.

556 tests; clippy, fmt and rustdoc silent. `Duration::from_mins` is the same stabilisation group as the `from_hours` already used here, which the MSRV job proves every run.