### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2026-07-27
 
 ### Added
 
@@ -905,7 +905,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/jchultarsky/mirador/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/jchultarsky/mirador/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/jchultarsky/mirador/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/jchultarsky/mirador/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog date.

### Added

- **The status bar says when something needs you** — one line naming the single most pressing thing, and nothing at all when nothing is pressing. An event about to start, a save that is failing, a layout change that did not persist.

  No count, no all-clear, and it clears itself when the cause does. Strictly limited to *will this get worse if nobody acts in the next few minutes* — an overdue task does not qualify, because a signal lit for it would be lit permanently.

### Fixed

- **A layout that could not be saved now says so.** It was reported inside the `w` picker and nowhere else, so a rearrangement that failed to persist was silent once the picker closed — and gone at the next launch. The last genuine silent failure in the program.

This closes the third and last of the gaps named in the original product analysis: the `.ics` agenda, the watch log, and this.

GIF unchanged and still accurate — the default layout is the same twelve panels, and the status bar only differs when there is an alert.

Not tagged yet; the tag goes on the squashed commit.