### PR TITLE
Fix a hang and two per-frame allocation faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A headline containing a wide character could freeze the dashboard.** Text
+  wrapping split an over-long word by taking as many characters as fit — and for
+  a CJK glyph or an emoji in a column one cell wide, none fit, so nothing was
+  consumed and the loop ran for ever. Any news headline with such a character in
+  a narrow panel would hang mirador until it was killed. **Present in 0.13.0 and
+  0.14.0.**
+
+- **The agenda cloned its whole event list on every frame.** The on-fire signal
+  asks each panel whether anything is urgent, and the agenda answered by copying
+  every event first. Measured: 456 event clones in thirty idle seconds against a
+  twelve-event calendar, scaling with the size of the calendar. Now zero.
+
+- **The news panel cloned every story on every frame**, for stories that change
+  once an hour. Copied when the fetch lands instead.
+
+- **The README said mirador has two network panels.** It has three.
+
 ## [0.14.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,6 +548,19 @@ change the user had watched happen.
 deliberate: each picker change is one keystroke to undo, an arrangement is not.
 The mode's legend names both keys, so there is nothing to guess.
 
+## Feature freeze
+
+**New features are frozen ahead of 1.0.0.** Bug fixes, documentation and tests
+only. Anything that adds a panel, a key or a config value waits — the point of
+the freeze is to find out what the last round actually broke, and adding to it
+defeats that.
+
+Adversarial review found one hang and two per-frame allocation faults in code
+written the same day, all of them in paths the tests exercised and the tests did
+not catch. That is the argument for the freeze, not an argument against the
+tests: the hang needed a two-cell glyph in a one-cell column, and nothing was
+going to guess that from reading.
+
 ## Open work
 
 Nothing. All three gaps named in the original product analysis are built — the

--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ that is off until you turn it on.
 filtering and full editing without leaving the dashboard. That is the panel most
 dashboards treat as a checkbox, and it is the one you will use most.
 
-The two network panels use free key-less endpoints:
-[Open-Meteo](https://open-meteo.com) for weather, and Yahoo's public chart
-endpoint for prices — see [Market data](#market-data) for what the second one
-means for you.
+The three network panels use free key-less endpoints:
+[Open-Meteo](https://open-meteo.com) for weather, Yahoo's public chart endpoint
+for prices — see [Market data](#market-data) for what that one means for you —
+and, for news, whichever RSS feeds you configure. The shipped feeds are NASA,
+Phys.org and Ars Technica; change or empty them in `[news.feeds]`.
+
+Those three fetch the data their panels exist to show, which is not the same as
+phoning home: nothing is sent about you, and switching a panel off with `w`
+stops its requests entirely.
 
 ## How this was built
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1383,6 +1383,12 @@ impl App {
         // In arrange mode the bar belongs to the mode. The global keys are not
         // reachable anyway — the arrows have been claimed — so listing them
         // would be listing keys that do nothing.
+        //
+        // This also hides an alert for as long as the mode is open, which is a
+        // decision rather than an oversight. Arrange mode is a gesture measured
+        // in seconds and the legend is what makes it usable; an alert that
+        // waits until `Enter` or `Esc` has lost nothing, because the thing it
+        // names has already happened either way.
         if self.arranging.is_some() {
             let mut spans = vec![Span::styled(
                 " ARRANGE",

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -66,16 +66,6 @@ fn char_width(c: char) -> usize {
     unicode_width::UnicodeWidthChar::width(c).unwrap_or(0)
 }
 
-/// Rows that `text` occupies once word-wrapped to `width` cells.
-///
-/// Needed wherever something is sized to fit its own contents — a scroll
-/// clamp, or a dialog that must not be shorter than the text inside it. The
-/// unwrapped line count is not a substitute: it is right until a line is
-/// longer than the box, and then it is short by exactly the amount that
-/// matters.
-///
-/// Matches `Paragraph::new(text).wrap(Wrap { trim: false })`, whose own
-/// `line_count` is private. An empty line still occupies a row.
 /// Break `text` into lines no wider than `width` display cells.
 ///
 /// The companion to [`wrapped_height`], which counts the same rows without
@@ -109,13 +99,24 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
             // A single word longer than the line breaks inside itself, rather
             // than running off the edge.
             while used > width {
-                let keep: String = current
+                let mut keep: String = current
                     .chars()
                     .scan(0usize, |taken, c| {
                         *taken += display_width(&c.to_string());
                         (*taken <= width).then_some(c)
                     })
                     .collect();
+                // Always take at least one character. A glyph wider than the
+                // whole line — any CJK character or emoji in a one-cell column
+                // — otherwise fits nowhere, so nothing is taken, nothing is
+                // consumed, and this loops for ever. That is a hang, not a
+                // slow path: the dashboard freezes and has to be killed.
+                //
+                // The line then exceeds `width` by a cell, which is the honest
+                // outcome. A terminal cannot draw half a wide glyph either.
+                if keep.is_empty() {
+                    keep.extend(current.chars().next());
+                }
                 let rest = current[keep.len()..].to_string();
                 out.push(keep);
                 current = rest;
@@ -133,6 +134,16 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
     out
 }
 
+/// Rows that `text` occupies once word-wrapped to `width` cells.
+///
+/// Needed wherever something is sized to fit its own contents — a scroll
+/// clamp, or a dialog that must not be shorter than the text inside it. The
+/// unwrapped line count is not a substitute: it is right until a line is
+/// longer than the box, and then it is short by exactly the amount that
+/// matters.
+///
+/// Matches `Paragraph::new(text).wrap(Wrap { trim: false })`, whose own
+/// `line_count` is private. An empty line still occupies a row.
 pub fn wrapped_height(text: &str, width: u16) -> u16 {
     if width == 0 {
         return 0;
@@ -441,6 +452,32 @@ mod tests {
         }
     }
 
+    /// A glyph wider than the whole line fits nowhere, so "take as many
+    /// characters as fit" takes none, consumes nothing, and loops for ever.
+    /// That is a hang — the dashboard freezes and has to be killed — and it is
+    /// reachable by any CJK or emoji headline in a narrow panel.
+    #[test]
+    fn a_glyph_wider_than_the_line_does_not_hang() {
+        for text in [
+            "\u{1F31E}\u{1F31E}",
+            "\u{4E2D}\u{6587}\u{6807}\u{9898}",
+            "a\u{1F31E}b",
+        ] {
+            for width in 1..4usize {
+                let out = wrap(text, width);
+                assert!(
+                    out.len() <= text.chars().count() + 1,
+                    "`{text}` at {width} produced {} lines",
+                    out.len()
+                );
+                // Every character survives; the line may exceed the width by a
+                // cell, because a terminal cannot draw half a wide glyph.
+                let joined: String = out.concat();
+                assert_eq!(joined, text, "at {width}");
+            }
+        }
+    }
+
     #[test]
     fn no_wrapped_line_is_wider_than_asked_for() {
         let text = "Wildfire now nine miles away from the French city of Bordeaux";
@@ -451,6 +488,20 @@ mod tests {
                     "`{line}` is wider than {width}"
                 );
             }
+        }
+    }
+
+    /// The one exception, and it is deliberate: a single glyph that cannot fit
+    /// is emitted anyway rather than dropped or looped on. It overruns by a
+    /// cell, which a terminal handles and an infinite loop does not.
+    #[test]
+    fn only_an_unfittable_glyph_may_overrun_and_only_by_itself() {
+        let out = wrap("\u{1F31E}\u{1F31E}", 1);
+        for line in &out {
+            assert!(
+                line.chars().count() <= 1,
+                "an overrunning line holds one glyph and no more: `{line}`"
+            );
         }
     }
 

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -487,13 +487,28 @@ impl Panel for AgendaPanel {
 
     fn alert(&self) -> Option<crate::panel::Alert> {
         let now = Zoned::now();
-        let state = self.snapshot();
+
+        // Reads the events under the lock rather than through `snapshot`, and
+        // the difference is not stylistic. `snapshot` clones the whole event
+        // list, and this runs on every draw — measured at 39 calls in thirty
+        // idle seconds, so a twelve-event calendar cloned 456 events, each with
+        // one or two `String`s, for nothing. A real week of meetings would be
+        // several times that, for ever. Panel::alert's own documentation says
+        // it must not allocate when it has nothing to say, which is nearly
+        // always; this is that promise kept.
+        let guard = match self.state.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if guard.error.is_some() {
+            return None;
+        }
 
         // The nearest event that has not started and starts within the window.
         // An event already under way is deliberately not an alert: you are
         // either in it or you have missed it, and a dashboard telling you about
         // a meeting you are sitting in is noise.
-        state
+        let (until, event) = guard
             .events
             .iter()
             .filter(|event| !event.all_day)
@@ -502,21 +517,18 @@ impl Panel for AgendaPanel {
                 let until = std::time::Duration::try_from(until).ok()?;
                 (until <= IMMINENT).then_some((until, event))
             })
-            .min_by_key(|(until, _)| *until)
-            .map(|(until, event)| {
-                let minutes = until.as_secs() / 60;
-                let when = if minutes == 0 {
-                    "now".to_string()
-                } else {
-                    format!("in {minutes}m")
-                };
-                match &event.location {
-                    Some(place) => {
-                        crate::panel::Alert::soon(format!("{} {when} · {place}", event.summary))
-                    }
-                    None => crate::panel::Alert::soon(format!("{} {when}", event.summary)),
-                }
-            })
+            .min_by_key(|(until, _)| *until)?;
+
+        let minutes = until.as_secs() / 60;
+        let when = if minutes == 0 {
+            "now".to_string()
+        } else {
+            format!("in {minutes}m")
+        };
+        Some(match &event.location {
+            Some(place) => crate::panel::Alert::soon(format!("{} {when} · {place}", event.summary)),
+            None => crate::panel::Alert::soon(format!("{} {when}", event.summary)),
+        })
     }
 
     fn events(&mut self) -> Vec<crate::watch::Event> {

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -79,6 +79,15 @@ pub struct NewsPanel {
     showing_link: Option<String>,
     /// Stories drawn last frame, for clamping the selection.
     drawn: usize,
+    /// The stories as of the last time the fetch thread published.
+    ///
+    /// Cached rather than read through the mutex on every draw. Stories change
+    /// once an hour and a draw happens about once a second, so cloning them per
+    /// frame was sixty allocations for the same sixty headlines — the same
+    /// mistake the agenda's alert made, found in the same review.
+    shown: Vec<Story>,
+    fetched: Option<Instant>,
+    failing: Option<String>,
 }
 
 impl Drop for NewsPanel {
@@ -137,6 +146,9 @@ impl NewsPanel {
             selected: ListState::default(),
             showing_link: None,
             drawn: 0,
+            shown: Vec::new(),
+            fetched: None,
+            failing: None,
         }
     }
 
@@ -193,6 +205,14 @@ impl Panel for NewsPanel {
         let now = self.generation.load(Ordering::Acquire);
         let moved = now != self.seen;
         self.seen = now;
+        // The one moment the stories can have changed, so the one moment worth
+        // copying them out from under the lock.
+        if moved {
+            let state = self.snapshot();
+            self.shown = state.stories;
+            self.fetched = state.fetched;
+            self.failing = state.error;
+        }
         moved
     }
 
@@ -207,7 +227,7 @@ impl Panel for NewsPanel {
                 }
             }
             KeyCode::Char('o') => {
-                let stories = self.snapshot().stories;
+                let stories = &self.shown;
                 // Shown, not opened. Launching a browser means talking to the
                 // platform — `open`, `xdg-open`, `start` — which is the same
                 // decision as playing a sound file and gets the same answer.
@@ -250,7 +270,6 @@ impl Panel for NewsPanel {
             return;
         }
 
-        let state = self.snapshot();
         let width = usize::from(area.width);
 
         // One row at the foot for the age, or the link, or a failure.
@@ -264,8 +283,8 @@ impl Panel for NewsPanel {
             ..area
         };
 
-        if state.stories.is_empty() {
-            let message = match &state.error {
+        if self.shown.is_empty() {
+            let message = match &self.failing {
                 Some(why) => vec![
                     Line::from(Span::styled(
                         "Cannot read the feeds",
@@ -278,7 +297,7 @@ impl Panel for NewsPanel {
                         Style::default().fg(theme.muted),
                     )),
                 ],
-                None if state.fetched.is_some() => vec![Line::from(Span::styled(
+                None if self.fetched.is_some() => vec![Line::from(Span::styled(
                     "No stories.",
                     Style::default().fg(theme.muted),
                 ))],
@@ -297,8 +316,8 @@ impl Panel for NewsPanel {
         // between every story would be more furniture than content at this
         // width, and the panel is meant to read like a page.
         let mut items: Vec<ListItem> = Vec::new();
-        let last = state.stories.len().saturating_sub(1);
-        for (index, story) in state.stories.iter().enumerate() {
+        let last = self.shown.len().saturating_sub(1);
+        for (index, story) in self.shown.iter().enumerate() {
             let mut lines = vec![Line::from(masthead(story, theme))];
             for line in crate::grid::wrap(&story.title, width) {
                 lines.push(Line::from(Span::styled(
@@ -319,7 +338,7 @@ impl Panel for NewsPanel {
         self.drawn = items.len();
         frame.render_stateful_widget(List::new(items), body, &mut self.selected);
 
-        let foot = match (&self.showing_link, &state.error) {
+        let foot = match (&self.showing_link, &self.failing) {
             (Some(link), _) => Span::styled(
                 crate::grid::truncate(link, width),
                 Style::default().fg(theme.label),
@@ -327,15 +346,13 @@ impl Panel for NewsPanel {
             (None, Some(_)) => Span::styled(
                 format!(
                     "{} — refresh failing",
-                    state
-                        .fetched
+                    self.fetched
                         .map_or_else(|| "never read".to_string(), |at| describe_age(at.elapsed()))
                 ),
                 Style::default().fg(theme.warning),
             ),
             (None, None) => Span::styled(
-                state
-                    .fetched
+                self.fetched
                     .map_or_else(String::new, |at| describe_age(at.elapsed())),
                 Style::default().fg(theme.muted),
             ),


### PR DESCRIPTION
Adversarial review ahead of 1.0.0, aimed at the code written in the last day because that's where the risk is.

## The hang, which is already released

`grid::wrap` splits an over-long word by taking as many characters as fit. For a glyph wider than the whole line — **any CJK character or emoji in a one-cell column** — none fit, so nothing is taken, nothing is consumed, and it loops for ever. Not slow: frozen, until the process is killed.

Reachable through the news panel, which wraps third-party headlines to whatever width the panel has. **Present in 0.13.0 and 0.14.0.**

It now always takes at least one character, overrunning by a cell — which is what a terminal does with a wide glyph anyway.

## Two per-frame allocation faults

`Panel::alert` runs on every draw, and its own doc comment says it must not allocate when it has nothing to say. The agenda's implementation began by cloning the entire event list.

Measured with a probe, before and after:

| | 30s idle, 12-event calendar |
|---|---|
| before | **456** event clones |
| after | **0** |

It scales with the calendar, so a real working week is several times that, for ever. The news panel did the same with its stories, which change once an hour — copied when the fetch lands now.

## Checked and sound

Recorded so the next reviewer doesn't repeat them: `ureq` bounds response bodies at 10MB by default, so no feed can exhaust memory; there are no panic paths in any new module beyond the thread-spawn `expect` every panel already uses; and the dashboard survives sizes from 8x40 to 200x12 without a panic. No TODOs, no architecture-map drift.

## Documented, not changed

Arrange mode hides an alert while it's open. The legend is what makes the mode usable and the mode lasts seconds, so an alert waiting for `Enter` has lost nothing. Now a comment rather than an accident.

## Also

The README claimed two network panels. There are three. Feature freeze recorded in CLAUDE.md.

558 tests; clippy, fmt and rustdoc silent.