### PR TITLE
Release 0.14.1 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.1] - 2026-07-27
 
 ### Fixed
 
@@ -926,7 +926,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/jchultarsky/mirador/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/jchultarsky/mirador/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/jchultarsky/mirador/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/jchultarsky/mirador/compare/v0.11.0...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Hotfix. **0.13.0 and 0.14.0 can freeze**, and this is the fix for it.

### Fixed

- **A headline containing a wide character could freeze the dashboard.** Text wrapping split an over-long word by taking as many characters as fit — for a CJK glyph or emoji in a one-cell column, none fit, so nothing was consumed and the loop ran for ever. Any news headline with such a character in a narrow panel hung mirador until it was killed.
- **The agenda cloned its whole event list every frame** — 456 clones in 30 idle seconds against a 12-event calendar, scaling with calendar size. Now zero.
- **The news panel cloned every story every frame**, for stories that change hourly.
- **The README said two network panels.** There are three.

Patch release: fixes only, no behaviour or config changes.