### PR TITLE
Keep a config's own line endings when rewriting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Editing a config on Windows no longer rewrites every line in it.** Both
+  places that rewrite a file you wrote by hand — the layout editor and the
+  config migrator — reassembled it from `str::lines()`, which strips the `\r`
+  of a CRLF ending. Joining with `\n` then converted the whole file to LF: you
+  moved one panel and git reported every line as changed. The ending the file
+  already uses is preserved now, in both directions.
+
 ## [0.14.1] - 2026-07-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,18 @@ is not, because it is the one people quote back at you.
 
 ### Phase 1 — finish the adversarial review
 
+**`layout_edit` and `migrate`: done.** Found that both flattened CRLF to LF —
+`str::lines()` strips the `\r`, so a Windows config was rewritten entirely
+because one panel moved. `store::line_ending` now carries the file's own ending
+through both. `migrate` had a third site the first fix missed, in a `writeln!`
+that hard-codes `\n`; the test caught it, which is the argument for writing the
+test before believing the fix.
+
+Also added: eighty-eight structural mutations of the *real shipped config*,
+asserting the only two acceptable outcomes — applied and exactly right, or
+refused and untouched. "Wrote something plausible" is the outcome this module
+exists to make impossible.
+
 One pass covered the code written on 27 July and found a hang and two per-frame
 allocation faults. The rest of the program has not had the same treatment.
 

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -160,9 +160,13 @@ pub fn apply(source: &str, desired: &Layout) -> Result<String> {
         }
     }
 
-    let mut result = out.join("\n");
+    // Rejoined with the ending the file already had. `str::lines()` strips
+    // `\r`, so joining with `\n` would quietly convert a CRLF config to LF and
+    // rewrite every line in it because one panel moved.
+    let newline = crate::store::line_ending(source);
+    let mut result = out.join(newline);
     if source.ends_with('\n') {
-        result.push('\n');
+        result.push_str(newline);
     }
 
     // The whole reason this is safe to do at all. If the text no longer says
@@ -686,6 +690,117 @@ units = "imperial"
             .collect();
         assert_eq!(changed.len(), 1, "exactly one line moved:\n{out}");
         assert!(after[changed[0]].contains("width = 30"));
+    }
+
+    /// A config written on Windows uses CRLF. `str::lines()` strips the `\r`,
+    /// so reassembling with `\n` converted the whole file to LF — moving one
+    /// panel reported every line in the config as changed, which is a
+    /// whole-file diff in git and nothing the user asked for.
+    /// Throws a lot of shapes at the real shipped config and asserts the only
+    /// two acceptable outcomes: the edit applies and the file still describes
+    /// exactly what was asked, or it is refused and the file is untouched.
+    ///
+    /// There is no third outcome. "Wrote something plausible" is the failure
+    /// this module exists to make impossible, and the check at the end of
+    /// `apply` is what makes it so — this exercises that check against shapes
+    /// nobody would think to write by hand.
+    #[test]
+    fn no_mutation_of_the_shipped_config_produces_a_wrong_file() {
+        let shipped = include_str!("../assets/default_config.toml");
+        let base = layout_of(shipped);
+
+        // A deterministic spread of structural mutations. No randomness: a
+        // failure has to be reproducible from the test name alone.
+        let mut shapes: Vec<Layout> = Vec::new();
+        for row in 0..base.rows.len() {
+            for column in 0..base.rows[row].panels.len() {
+                // Move one panel to every other row.
+                for target in 0..base.rows.len() {
+                    let mut want = base.clone();
+                    let panel = want.rows[row].panels.remove(column);
+                    want.rows[target].panels.insert(0, panel);
+                    want.rows.retain(|r| !r.panels.is_empty());
+                    shapes.push(want);
+                }
+                // Give it a row of its own at either end.
+                for at in [0, base.rows.len()] {
+                    let mut want = base.clone();
+                    let panel = want.rows[row].panels.remove(column);
+                    want.rows.insert(
+                        at,
+                        LayoutRow {
+                            height: 10,
+                            panels: vec![panel],
+                        },
+                    );
+                    want.rows.retain(|r| !r.panels.is_empty());
+                    shapes.push(want);
+                }
+                // Drop it entirely.
+                let mut want = base.clone();
+                want.rows[row].panels.remove(column);
+                want.rows.retain(|r| !r.panels.is_empty());
+                shapes.push(want);
+            }
+            // Reverse a row.
+            let mut want = base.clone();
+            want.rows[row].panels.reverse();
+            shapes.push(want);
+        }
+
+        let (mut applied, mut refused) = (0, 0);
+        for (index, want) in shapes.iter().enumerate() {
+            match apply(shipped, want) {
+                Ok(out) => {
+                    applied += 1;
+                    let reparsed = toml::from_str::<Config>(&out)
+                        .unwrap_or_else(|e| panic!("shape {index} produced unparsable TOML: {e}"));
+                    assert_eq!(
+                        shape(&reparsed.layout),
+                        shape(want),
+                        "shape {index} wrote a layout nobody asked for"
+                    );
+                    // The rest of the file is not this module's business.
+                    assert!(
+                        out.contains("[weather]") && out.contains("[news]"),
+                        "shape {index} lost a section outside `[layout]`"
+                    );
+                }
+                Err(_) => refused += 1,
+            }
+        }
+
+        assert_eq!(applied + refused, shapes.len());
+        assert!(
+            applied > shapes.len() / 2,
+            "only {applied} of {} shapes applied; the editor has become too \
+             timid to be useful",
+            shapes.len()
+        );
+    }
+
+    #[test]
+    fn a_crlf_config_stays_crlf() {
+        let crlf = SAMPLE.replace('\n', "\r\n");
+        let mut desired = layout_of(&crlf);
+        desired.rows[1].panels[0].width = 60;
+
+        let out = apply(&crlf, &desired).expect("applies");
+        assert_eq!(
+            out.matches("\r\n").count(),
+            out.matches('\n').count(),
+            "every newline is still a CRLF:\n{out:?}"
+        );
+        assert_eq!(layout_of(&out).rows[1].panels[0].width, 60, "and it took");
+    }
+
+    /// The other direction, so the fix cannot be "always write CRLF".
+    #[test]
+    fn an_lf_config_stays_lf() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows[1].panels[0].width = 60;
+        let out = apply(SAMPLE, &desired).expect("applies");
+        assert_eq!(out.matches('\r').count(), 0, "no carriage returns appeared");
     }
 
     #[test]

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -116,6 +116,9 @@ fn key_of(line: &str) -> Option<&str> {
 
 /// Rewrite `contents`, returning the new text and a description of each change.
 pub fn migrate_text(contents: &str) -> (String, Vec<String>) {
+    // Whatever the file already used. `str::lines()` strips `\r`, so pushing
+    // `\n` would convert a CRLF config to LF and report every line as changed.
+    let newline = crate::store::line_ending(contents);
     let mut out = String::with_capacity(contents.len());
     let mut changes = Vec::new();
     let mut section = String::new();
@@ -124,13 +127,13 @@ pub fn migrate_text(contents: &str) -> (String, Vec<String>) {
         if let Some(name) = section_of(line) {
             section = name.to_string();
             out.push_str(line);
-            out.push('\n');
+            out.push_str(newline);
             continue;
         }
 
         let Some(key) = key_of(line) else {
             out.push_str(line);
-            out.push('\n');
+            out.push_str(newline);
             continue;
         };
 
@@ -152,11 +155,14 @@ pub fn migrate_text(contents: &str) -> (String, Vec<String>) {
                     let eq_col = line.find('=').unwrap_or_default();
                     let pad = eq_col.saturating_sub(indent.len() + to.len()).max(1);
                     // Writing into a String is infallible.
-                    let _ = writeln!(
+                    // `write!` and an explicit ending, not `writeln!`, which
+                    // hard-codes `\n` and would put an LF line into a CRLF file.
+                    let _ = write!(
                         out,
                         "{indent}{to}{:pad$}= {value}  # migrated from {from}",
                         ""
                     );
+                    out.push_str(newline);
                     changes.push(format!("[{want}] {from} -> {to}: {why}"));
                     handled = true;
                 }
@@ -167,7 +173,8 @@ pub fn migrate_text(contents: &str) -> (String, Vec<String>) {
                 } if section == *want && key == *k => {
                     // Commented rather than deleted: the old value stays
                     // visible so the user can see what their colour was.
-                    let _ = writeln!(out, "# {}  # removed: {why}", line.trim());
+                    let _ = write!(out, "# {}  # removed: {why}", line.trim());
+                    out.push_str(newline);
                     changes.push(format!("[{want}] {k} removed: {why}"));
                     handled = true;
                 }
@@ -180,7 +187,7 @@ pub fn migrate_text(contents: &str) -> (String, Vec<String>) {
 
         if !handled {
             out.push_str(line);
-            out.push('\n');
+            out.push_str(newline);
         }
     }
 
@@ -239,6 +246,26 @@ pub fn migrate_file(path: &Path) -> Result<Report> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Same hazard as `layout_edit`: `str::lines()` strips the `\r`, so a
+    /// migration of a Windows config rewrote every line in it.
+    #[test]
+    fn a_crlf_config_stays_crlf() {
+        let lf = "[theme]\nrx = \"green\"\n";
+        let (out, changes) = migrate_text(&lf.replace('\n', "\r\n"));
+        assert!(!changes.is_empty(), "something was migrated");
+        assert_eq!(
+            out.matches("\r\n").count(),
+            out.matches('\n').count(),
+            "every newline is still a CRLF: {out:?}"
+        );
+    }
+
+    #[test]
+    fn an_lf_config_stays_lf() {
+        let (out, _) = migrate_text("[theme]\nrx = \"green\"\n");
+        assert_eq!(out.matches('\r').count(), 0);
+    }
 
     #[test]
     fn a_renamed_key_keeps_the_alignment_of_its_block() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -77,6 +77,25 @@ pub fn report(result: Result<()>, last_error: &mut Option<String>) {
     };
 }
 
+/// The line ending a file already uses.
+///
+/// Two modules rewrite files a person wrote by hand — [`crate::layout_edit`]
+/// and [`crate::migrate`] — and both reassemble them from `str::lines()`, which
+/// strips `\r` and hands back bare lines. Joining those with `\n` silently
+/// converts a CRLF file to LF: on Windows, moving one panel rewrote every line
+/// in the config, which shows up as a whole-file diff in git and is not
+/// remotely what the user asked for.
+///
+/// Judged by the first ending in the file rather than by counting. A file with
+/// mixed endings is already inconsistent and there is no answer that preserves
+/// it; matching the first is at least predictable.
+pub fn line_ending(source: &str) -> &'static str {
+    match source.find('\n') {
+        Some(at) if at > 0 && source.as_bytes()[at - 1] == b'\r' => "\r\n",
+        _ => "\n",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Phase 1 of the road to 1.0, starting with the module that rewrites the user's config — where a mistake costs the most.

## The finding

Two places rewrite a hand-written file, and **both flattened it**. `str::lines()` strips the `\r` of a CRLF ending; reassembling with `\n` converts the whole file to LF.

**On Windows, moving one panel rewrote every line in the config** — a whole-file diff in git from a one-panel edit. Windows is a supported target.

`store::line_ending` reads the ending the file already uses and both callers carry it through. Judged by the *first* ending rather than by counting: a mixed-ending file is already inconsistent and no answer preserves it, so matching the first is at least predictable.

**`migrate` had a third site my first fix missed** — a `writeln!`, which hard-codes `\n`. The test caught it; reading the code had not. That's the argument for writing the test before believing the fix.

## Also

Eighty-eight structural mutations of the **real shipped config** — every panel moved to every row, promoted to its own row at either end, removed, and every row reversed — asserting the only two outcomes this module may have:

- applied, and the file describes exactly what was asked, with every section outside `[layout]` intact; or
- refused, and the file untouched.

"Wrote something plausible" is the third outcome, and making it impossible is what the module is for. The test also fails if too many shapes are *refused*, so the safety net can't be tightened into uselessness without someone noticing.

563 tests; clippy, fmt and rustdoc silent.