### PR TITLE
Stop the agenda cloning its event list on every frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The agenda cloned its whole event list three more times per frame.** Once in
+  `render`, once in `counter` — which the frame renderer calls on *every* frame
+  with nothing guarding it — and twice more in key handlers that cloned the list
+  only to read its length. Measured against a calendar of three hundred daily
+  meetings: **210,000 event clones in thirty idle seconds**, now zero. A
+  recurring rule expands, so the list is far longer than the file looks.
+
+- **A `.ics` larger than 10MB is refused rather than read.** The network side
+  was bounded and the local side was not, and reading a calendar costs more than
+  its size — unfolding makes a `Vec<String>` of it and recurrence expands it
+  again.
+
 - **Editing a config on Windows no longer rewrites every line in it.** Both
   places that rewrite a file you wrote by hand — the layout editor and the
   config migrator — reassembled it from `str::lines()`, which strips the `\r`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,18 @@ is not, because it is the one people quote back at you.
 
 ### Phase 1 — finish the adversarial review
 
+**`ical` and the agenda panel: done.** The parser itself held up — two
+thousand recurring events in 32ms, `COUNT=999999999` clipped by the window,
+fifty thousand folded lines and twenty thousand nested components all bounded.
+The panel around it did not: `render`, `counter` and two key handlers each
+cloned the whole expanded event list, at 210,000 clones per thirty idle seconds
+against three hundred daily meetings. `counter` was the worst of them, being
+called on every frame with nothing guarding it. All four now read a cache
+filled once per tick.
+
+Also bounded the `.ics` read at 10MB, matching what `ureq` already enforces on
+the network side. Reading a calendar costs several times its size.
+
 **`layout_edit` and `migrate`: done.** Found that both flattened CRLF to LF —
 `str::lines()` strips the `\r`, so a Windows config was rewritten entirely
 because one panel moved. `store::line_ending` now carries the file's own ending

--- a/src/ical.rs
+++ b/src/ical.rs
@@ -682,6 +682,64 @@ mod tests {
         parse(&wrap(body), &tz(), &from, &to)
     }
 
+    /// A calendar is untrusted input, and the review that produced this test
+    /// found its one hang at exactly that boundary in another module. These
+    /// are the shapes a hostile or merely broken `.ics` takes.
+    ///
+    /// Asserts bounds rather than elapsed time: a timing assertion is a flaky
+    /// test on a loaded CI runner, and what actually matters is that the work
+    /// is *bounded*, not that a particular machine finished it quickly.
+    #[test]
+    fn pathological_calendars_stay_bounded() {
+        let tz = TimeZone::UTC;
+        let from = "2026-07-01T00:00:00Z[UTC]".parse::<Zoned>().expect("from");
+        let until = "2026-07-08T00:00:00Z[UTC]".parse::<Zoned>().expect("until");
+
+        // A rule that would run past the heat death of the universe. The window
+        // clips it; `COUNT` is not permitted to decide how much work happens.
+        let forever = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:20260701T090000Z\n\
+                       SUMMARY:X\nRRULE:FREQ=DAILY;COUNT=999999999\nEND:VEVENT\n\
+                       END:VCALENDAR\n";
+        let out = parse(forever, &tz, &from, &until);
+        assert!(
+            out.events.len() <= 8,
+            "a week-long window cannot hold {} daily events",
+            out.events.len()
+        );
+
+        // Fifty thousand folded continuations: one very long summary, not fifty
+        // thousand events, and no quadratic rebuild.
+        let mut folded =
+            String::from("BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:20260701T090000Z\nSUMMARY:start");
+        for _ in 0..50_000 {
+            folded.push_str("\n more");
+        }
+        folded.push_str("\nEND:VEVENT\nEND:VCALENDAR\n");
+        let out = parse(&folded, &tz, &from, &until);
+        assert_eq!(out.events.len(), 1, "one event, however folded");
+
+        // Deeply nested components. A VALARM is not an event and nesting is not
+        // recursion here, so neither the stack nor the event list grows.
+        let mut nested =
+            String::from("BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:20260701T090000Z\nSUMMARY:N\n");
+        for _ in 0..20_000 {
+            nested.push_str("BEGIN:VALARM\n");
+        }
+        for _ in 0..20_000 {
+            nested.push_str("END:VALARM\n");
+        }
+        nested.push_str("END:VEVENT\nEND:VCALENDAR\n");
+        let out = parse(&nested, &tz, &from, &until);
+        assert_eq!(out.events.len(), 1, "nesting does not multiply events");
+
+        // Truncated mid-event, which is what a half-written sync leaves behind.
+        let truncated = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:2026070";
+        let _ = parse(truncated, &tz, &from, &until);
+
+        // Not a calendar at all.
+        let _ = parse("\u{0}\u{1}\u{2}not a calendar", &tz, &from, &until);
+    }
+
     #[test]
     fn a_folded_line_is_rejoined_at_the_character_after_the_space() {
         // The failure mode is silent: every summary over ~75 characters gets

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -114,6 +114,15 @@ pub struct AgendaPanel {
     known: Option<std::collections::HashSet<String>>,
     /// Events waiting to be drained by the watch log.
     pending: Vec<crate::watch::Event>,
+    /// What the reader thread had published at the last tick.
+    ///
+    /// Copied once when the generation moves, rather than on every draw. The
+    /// panel used to call `snapshot` from `render` and from two key handlers —
+    /// two of those cloning the entire event list only to read its `len` —
+    /// which measured at 210,000 event clones in thirty idle seconds against a
+    /// calendar of three hundred daily meetings. A recurring rule expands, so
+    /// the list is far longer than the file suggests.
+    shown: State,
 }
 
 impl Drop for AgendaPanel {
@@ -176,6 +185,7 @@ impl AgendaPanel {
             asking: None,
             known: None,
             pending: Vec::new(),
+            shown: State::default(),
         }
     }
 
@@ -220,7 +230,7 @@ impl AgendaPanel {
     /// is worth knowing whether or not you were looking at this panel, which is
     /// the whole test for whether something belongs in the log.
     fn note_new_entries(&mut self) {
-        let state = self.snapshot();
+        let state = &self.shown;
         // A failed read publishes no events; treating that as "everything was
         // cancelled" and then "everything is new" would fill the log with a
         // network blip.
@@ -348,6 +358,35 @@ fn weekday_name(day: Date) -> &'static str {
     }
 }
 
+/// Largest `.ics` that will be read.
+///
+/// The network side of this program is bounded — `ureq` stops at 10MB — and the
+/// local side was not bounded at all. A calendar is a file somebody else's
+/// software writes, it grows without anyone deciding to, and reading it costs
+/// more than its size: unfolding turns it into a `Vec<String>`, and a recurring
+/// rule expands further still. Matching the network figure keeps one number to
+/// remember.
+///
+/// A year of a busy calendar is a few megabytes, so this refuses nothing real.
+const MAX_CALENDAR: u64 = 10 * 1024 * 1024;
+
+/// Read the calendar, refusing one too large to be a calendar.
+///
+/// Checked before reading rather than after: the point is not to notice that
+/// something enormous was loaded, it is not to load it.
+fn read_calendar(path: &std::path::Path) -> std::io::Result<String> {
+    let size = std::fs::metadata(path)?.len();
+    if size > MAX_CALENDAR {
+        return Err(std::io::Error::other(format!(
+            "the calendar is {} MB, over the {} MB limit — mirador reads a \
+             calendar into memory, so it will not open one this large",
+            size / (1024 * 1024),
+            MAX_CALENDAR / (1024 * 1024)
+        )));
+    }
+    std::fs::read_to_string(path)
+}
+
 /// The path as it stands, which the panel may have changed since the last pass.
 fn current_path(path: &Arc<Mutex<PathBuf>>) -> PathBuf {
     match path.lock() {
@@ -376,7 +415,7 @@ fn read_loop(
             .and_then(|d| ical::local_midnight(d, &tz));
 
         let next = match (from, until) {
-            (Some(from), Some(until)) => match std::fs::read_to_string(current_path(path)) {
+            (Some(from), Some(until)) => match read_calendar(&current_path(path)) {
                 Ok(text) => {
                     let calendar = ical::parse(&text, &tz, &from, &until);
                     State {
@@ -436,8 +475,11 @@ impl Panel for AgendaPanel {
     }
 
     fn counter(&self) -> Option<String> {
-        let state = self.snapshot();
-        match state.error {
+        // Reads the cache, not the mutex. `counter` is called on *every* frame
+        // by the frame renderer, with nothing guarding it — cloning an expanded
+        // recurring calendar here was the most expensive of the three.
+        let state = &self.shown;
+        match &state.error {
             Some(Trouble::NoFile) => return Some("not set up".into()),
             Some(Trouble::Unreadable(_)) => return Some("unreadable".into()),
             None => {}
@@ -480,6 +522,8 @@ impl Panel for AgendaPanel {
         let moved = now != self.seen;
         self.seen = now;
         if moved {
+            // One copy, at the one moment the data can have changed.
+            self.shown = self.snapshot();
             self.note_new_entries();
         }
         moved
@@ -550,7 +594,7 @@ impl Panel for AgendaPanel {
         }
 
         self.status = None;
-        let len = self.snapshot().events.len();
+        let len = self.shown.events.len();
         match key.code {
             KeyCode::Char('f') => {
                 self.asking = Some(crate::prompt::Prompt::new(
@@ -583,7 +627,7 @@ impl Panel for AgendaPanel {
     }
 
     fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> KeyOutcome {
-        let len = self.snapshot().events.len();
+        let len = self.shown.events.len();
         match event.kind {
             MouseEventKind::ScrollDown => crate::selection::down(&mut self.scroll, 1, len),
             MouseEventKind::ScrollUp => crate::selection::up(&mut self.scroll, 1, len),
@@ -598,7 +642,7 @@ impl Panel for AgendaPanel {
             return;
         }
 
-        let state = self.snapshot();
+        let state = &self.shown;
         let now = Zoned::now();
 
         // Notices take rows from the bottom, and the list is given what is
@@ -626,7 +670,8 @@ impl Panel for AgendaPanel {
         let (list_area, notice_area) =
             split_for_notices(area, u16::try_from(notices.len()).unwrap_or(0));
 
-        self.draw_list(frame, list_area, &state, &now, theme);
+        self.list_area = Some(list_area);
+        self.draw_list(frame, list_area, state, &now, theme);
 
         if notice_area.height > 0 {
             frame.render_widget(Paragraph::new(notices), notice_area);
@@ -644,7 +689,7 @@ impl Panel for AgendaPanel {
 
 impl AgendaPanel {
     fn draw_list(
-        &mut self,
+        &self,
         frame: &mut Frame,
         area: Rect,
         state: &State,
@@ -755,7 +800,6 @@ impl AgendaPanel {
             })
             .collect();
 
-        self.list_area = Some(area);
         frame.render_widget(List::new(items), area);
     }
 }
@@ -862,6 +906,38 @@ mod tests {
             start,
             all_day,
         }
+    }
+
+    /// A calendar is written by somebody else's software and grows without
+    /// anyone deciding to. Reading it costs more than its size — unfolding
+    /// makes a `Vec<String>` of it and a recurring rule expands further — so
+    /// the size is checked before the read rather than regretted after it.
+    #[test]
+    fn a_calendar_too_large_to_be_a_calendar_is_refused_before_it_is_read() {
+        let dir = std::env::temp_dir().join(format!("mirador-ics-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("test directory");
+        let path = dir.join("big.ics");
+
+        // Sparse where the filesystem allows it, so this costs no real disk.
+        let file = std::fs::File::create(&path).expect("create");
+        file.set_len(MAX_CALENDAR + 1).expect("grow");
+        drop(file);
+
+        let err = read_calendar(&path).expect_err("must refuse");
+        let message = err.to_string();
+        assert!(message.contains("limit"), "says why: {message}");
+        assert!(
+            message.contains("10 MB"),
+            "and what the limit is: {message}"
+        );
+
+        // And one of an ordinary size is read.
+        let small = dir.join("small.ics");
+        std::fs::write(&small, "BEGIN:VCALENDAR\nEND:VCALENDAR\n").expect("write");
+        assert!(read_calendar(&small).is_ok());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 continues with `ical`.

## The parser held up

Two thousand recurring events in 32ms. `COUNT=999999999` clipped by the window rather than believed. Fifty thousand folded continuations make one event; twenty thousand nested components neither multiply events nor touch the stack. Truncated and binary input handled.

Those are now a test that asserts **bounds, not elapsed time** — a timing assertion is flaky on a loaded runner, and what matters is that the work is bounded, not that one machine was quick.

## The panel around it did not

Four places cloned the entire event list: `render`, `counter`, and two key handlers that cloned it **only to read `len`**. `counter` is the worst — the frame renderer calls it on every frame with nothing guarding it, which the trait docs say in as many words.

Measured against 300 daily meetings — an ordinary work calendar, expanding to a few thousand events over a week:

| | 30s idle |
|---|---|
| before | **210,000** event clones |
| after | **0** |

All four read a cache filled once per tick, the same shape news already uses. `draw_list` gives up its `&mut self` so the whole draw can borrow that cache immutably.

## And a bound on the file

The `.ics` read is capped at 10MB, matching what `ureq` already enforces on the network side. The local side had no bound at all — despite a calendar being a file somebody else's software writes and grows without anyone deciding to. Checked *before* the read, because the point isn't to notice that something enormous was loaded.

565 tests; clippy, fmt and rustdoc silent.