### PR TITLE
Record the per-frame allocation sweep, which found nothing further

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,43 @@ is not, because it is the one people quote back at you.
 
 ### Phase 1 — finish the adversarial review
 
+**Per-frame allocation, swept across all twelve panels: no further offenders.**
+Three fixes of the same shape in one day looked systemic, so it was measured
+rather than argued about. It was not systemic; the agenda was an outlier.
+
+The property that matters is not the size of the number, it is what the number
+scales with. **A panel may allocate in proportion to what is on screen. It must
+not allocate in proportion to how much data you have.** The agenda broke that —
+a recurring calendar expands, and it cloned the expansion four times a frame —
+and nothing else does. Verified by loading 5 items and then 500: `todo` stayed
+at 667 allocations a frame both times, `notes` at 783 and 768.
+
+For reference, allocations per frame with each panel alone, on an idle
+dashboard. Roughly 150 of each figure is the shell — frames, layout, status bar
+— so `cpu`, `network` and the fixed `agenda` are at the floor:
+
+```
+notes 1118   calendar 892   todo 885   weather 755   clocks 438
+pomodoro 404  stocks 348    watchlog 271  news 252
+agenda 175    cpu 174       network 159      (whole dashboard: 1345)
+```
+
+Nothing here is worth optimising. A thousand small allocations a frame at about
+one frame a second is ordinary work for building styled spans, and the
+measurement exists to catch *growth*, not to be minimised.
+
+**To repeat the measurement:** put a counting `GlobalAlloc` in `main.rs`, wrap
+the `terminal.draw` call in `App::run` to record the delta, and write it to a
+file each frame. `unsafe_code = "forbid"` in Cargo.toml has to be relaxed for
+that build, so do it on a scratch branch and check `git status` is clean
+afterwards — shipping that lint relaxed would be a worse bug than any it found.
+Then generate one config per widget with a single-panel `[layout]` and run each
+for a few seconds.
+
+**The fix to copy, if a panel ever does break the rule:** cache the shared state
+in the panel when `tick` sees the generation move, and have `render`, `counter`
+and `alert` read the cache. `agenda` and `news` both do this.
+
 **`ical` and the agenda panel: done.** The parser itself held up — two
 thousand recurring events in 32ms, `COUNT=999999999` clipped by the window,
 fifty thousand folded lines and twenty thousand nested components all bounded.


### PR DESCRIPTION
Three fixes of the same shape in one day looked systemic, so I measured it across all twelve panels rather than argue about it. **It wasn't systemic** — the agenda was an outlier, already fixed.

## The property, which matters more than the numbers

A panel may allocate in proportion to **what is on screen**. It must not allocate in proportion to **how much data you have**.

That's exactly what the agenda broke — a recurring calendar expands, and it cloned the expansion four times a frame. Nothing else breaks it. Checked directly:

| | 5 items | 500 items |
|---|---|---|
| todo | 667/frame | **667/frame** |
| notes | 783/frame | **768/frame** |

Flat. That's the correct shape.

## Reference figures

Allocations per frame with each panel alone, idle. About 150 of each is the shell, so `cpu`, `network` and the fixed `agenda` sit at the floor:

```
notes 1118   calendar 892   todo 885   weather 755   clocks 438
pomodoro 404  stocks 348    watchlog 271  news 252
agenda 175    cpu 174       network 159     (whole dashboard: 1345)
```

**None of this is worth optimising.** A thousand small allocations a frame at roughly one frame a second is what building styled spans costs. The measurement exists to catch *growth*, and recording the ordinary cost is the only way a future reader can tell a regression from normal.

## Method, written down

Including the part that matters: it needs `unsafe_code = "forbid"` relaxed in Cargo.toml for a counting `GlobalAlloc`, so it belongs on a scratch branch with a `git status` check afterwards. Shipping that lint relaxed would be a worse bug than anything the measurement could find. This branch's tree is clean and the lint is back to `forbid`.

Docs only — no code changed.