### PR TITLE
Fix three ways saved data could go wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two mirador windows no longer take each other's saves away.** Every writer
+  of a file used the same `.tmp` name, so whoever renamed second found it gone.
+  Measured with eight concurrent writers: **2,100 of 2,400 saves failed** — and
+  a failed save is reported, so the second window filled with "could not be
+  saved" for no reason. Temporary names are now unique per write.
+
+- **A file you restricted stays restricted.** A save replaces the file, and the
+  replacement was created per the umask — so `chmod 600` on your tasks was
+  silently widened to world-readable the next time you added one.
+
+- **An untouched dashboard no longer writes to its state file.** `[agenda].file`
+  ships commented out, so the baseline was empty while the panel reported a
+  resolved path; one keystroke anywhere pinned that path into `state.toml`,
+  after which setting `[agenda].file` in the config did nothing, because the
+  state file outranks it. That is the failure invariant 17 exists to prevent,
+  reached by a new route.
+
 - **The agenda cloned its whole event list three more times per frame.** Once in
   `render`, once in `counter` — which the frame renderer calls on *every* frame
   with nothing guarding it — and twice more in key handlers that cloned the list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,28 @@ is not, because it is the one people quote back at you.
 
 ### Phase 1 — finish the adversarial review
 
+**`store` and `state`: done.** Three findings, all about data rather than
+speed.
+
+`write_atomic` used one `.tmp` name per *file*, not per *write*. Two mirador
+windows — one per monitor — then raced for it: eight concurrent writers failed
+2,100 of 2,400 saves, and a failed save is reported, so the second window filled
+with complaints. Behind that sat a narrower hazard: `File::create` truncates, so
+a second writer emptied the first's half-written temporary and the first would
+have renamed *that* into place. Never reproduced, and it needs no reproducing to
+be worth removing. Names are unique per write now.
+
+A rename installs a new file, created per the umask, so `chmod 600` on a task
+list was widened to 0644 on the next save. Permissions are carried across.
+
+And invariant 17 was broken again, by a new route. `[agenda].file` ships
+commented out, so `from_config` produced `None` while the panel reported a
+*resolved* path — they differed, so one keystroke anywhere wrote the resolved
+default into the state file, after which editing `[agenda].file` did nothing.
+The rule is not only "compare against the config"; it is **compare against the
+config in the same terms the panel will report**. A test now asserts that an
+untouched default dashboard writes nothing at all.
+
 **Per-frame allocation, swept across all twelve panels: no further offenders.**
 Three fixes of the same shape in one day looked systemic, so it was measured
 rather than argued about. It was not systemic; the agenda was an outlier.

--- a/src/state.rs
+++ b/src/state.rs
@@ -85,10 +85,23 @@ impl UiState {
             todo_sort: Some(sort.label().to_string()),
             todo_show_completed: Some(config.todo.show_completed),
             clocks_show_seconds: Some(config.clocks.show_seconds),
+            // Resolved the same way the panel resolves it, not read raw from
+            // the config. The panel reports the *resolved* path, and a baseline
+            // in different terms is not a baseline: with `[agenda].file`
+            // commented out — which is the shipped default — the raw value is
+            // `None`, the panel reports a real path, they differ, and the
+            // resolved default was written to the state file on the first
+            // keystroke anywhere in the dashboard. After which setting
+            // `[agenda].file` in the config did nothing, because the state file
+            // outranks it.
+            //
+            // That is invariant 17's first wrong version, arrived at again by a
+            // different route: the rule is not only "compare against the
+            // config", it is "compare against the config *as the panel sees
+            // it*".
             agenda_file: config
-                .agenda
-                .file
-                .as_ref()
+                .agenda_path()
+                .ok()
                 .map(|path| path.display().to_string()),
             weather_location: Some(config.weather.location.clone()),
             pomodoro_focus_minutes: Some(config.pomodoro.focus_minutes),
@@ -283,6 +296,39 @@ mod tests {
         config.clocks.show_seconds = true;
         config.pomodoro.focus_minutes = 25;
         config
+    }
+
+    /// The baseline has to be the config *as the panel sees it*, not as it is
+    /// written. `[agenda].file` ships commented out, so the raw value is `None`
+    /// while the panel reports a resolved path — they differ, and the resolved
+    /// default was written to the state file on the first keystroke anywhere.
+    /// After that, setting `[agenda].file` in the config did nothing at all,
+    /// because the state file outranks it.
+    ///
+    /// That is invariant 17's first wrong version reached by a new route, in a
+    /// field added long after the invariant was written. The rule is not only
+    /// "compare against the config" — it is "compare against the config in the
+    /// same terms the panel will report".
+    #[test]
+    fn an_untouched_default_config_records_nothing() {
+        let config = crate::config::Config::default();
+        let baseline = UiState::from_config(&config);
+
+        // Exactly what the panels report when nobody has changed anything: the
+        // config's own values, resolved the way the panels resolve them.
+        let reported = UiState {
+            agenda_file: config
+                .agenda_path()
+                .ok()
+                .map(|path| path.display().to_string()),
+            ..baseline.clone()
+        };
+
+        assert_eq!(
+            reported.only_changes_from(&baseline),
+            UiState::default(),
+            "a dashboard nobody has touched wrote something to its state file"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,10 +47,37 @@ pub fn write_atomic(path: &Path, contents: &str) -> Result<()> {
             .with_context(|| format!("flushing {} to disk", tmp.display()))?;
     }
 
+    carry_permissions_across(path, &tmp);
+
     std::fs::rename(&tmp, path)
         .with_context(|| format!("replacing {} with {}", path.display(), tmp.display()))?;
 
     Ok(())
+}
+
+/// Give the replacement the permissions the original had.
+///
+/// A rename puts a *new* file in place, created with whatever the umask says —
+/// usually 0644. Somebody who ran `chmod 600` on their task list did so on
+/// purpose, and had it silently widened to world-readable the next time they
+/// added a task. Tasks and notes hold whatever the user decided to write down.
+///
+/// Best effort: a failure here is not a reason to abandon a save that is
+/// otherwise fine, and the alternative — refusing to write — loses the data the
+/// permissions were protecting.
+///
+/// Unix only. Windows inherits an ACL from the containing directory rather than
+/// carrying a mode on the file, so there is nothing of the same shape to copy.
+#[allow(unused_variables)]
+fn carry_permissions_across(from: &Path, to: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(existing) = std::fs::metadata(from) {
+            let mode = existing.permissions().mode();
+            let _ = std::fs::set_permissions(to, std::fs::Permissions::from_mode(mode));
+        }
+    }
 }
 
 /// Where the temporary copy goes while it is being written.
@@ -58,9 +85,34 @@ pub fn write_atomic(path: &Path, contents: &str) -> Result<()> {
 /// Appended rather than substituted, because `with_extension` would turn
 /// `mirador.toml` into `mirador.tmp` — and if the rename then failed, the file
 /// left behind would not say what it came from.
+///
+/// **Unique per write, and that is not tidiness.** The name used to be a plain
+/// `.tmp`, shared by every writer of that file. Two mirador windows — one per
+/// monitor, which is an ordinary way to use a dashboard — then raced: both
+/// created the same temporary, and whoever renamed second found it already
+/// gone. Measured with eight concurrent writers over three hundred rounds:
+/// 2,100 of 2,400 writes failed, and a failed save is reported to the user, so
+/// the second window filled with "could not be saved" for no reason.
+///
+/// There was a narrower hazard behind it too. `File::create` truncates, so a
+/// second writer opening the shared temporary emptied the first writer's
+/// half-written file underneath it; the first would then have renamed that into
+/// place. That never reproduced in the probe above, but it needs no reproducing
+/// to be worth removing.
+///
+/// Process id and a counter, rather than randomness: no dependency, unique
+/// across processes and within one, and the leftovers of a crash are
+/// identifiable rather than mysterious.
 fn temp_path(path: &Path) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+
     let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(".tmp");
+    name.push(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
     path.with_file_name(name)
 }
 
@@ -121,6 +173,75 @@ mod tests {
         }
     }
 
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("mirador-store-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("test directory");
+        dir
+    }
+
+    /// Two mirador windows is an ordinary way to use a dashboard — one per
+    /// monitor — and both write the same files. The temporary was a fixed
+    /// `.tmp` shared by every writer, so whoever renamed second found it gone.
+    /// Eight writers over a hundred rounds failed 87% of their saves, and a
+    /// failed save is reported, so the second window filled with "could not be
+    /// saved" for no reason at all.
+    #[test]
+    fn concurrent_writers_do_not_take_each_others_saves_away() {
+        let dir = scratch("concurrent");
+        let path = dir.join("todos.toml");
+        let (a, b) = ("A".repeat(20_000), "B".repeat(20_000));
+
+        let mut failures = 0;
+        for _ in 0..100 {
+            let handles: Vec<_> = (0..8)
+                .map(|i| {
+                    let p = path.clone();
+                    let c = if i % 2 == 0 { a.clone() } else { b.clone() };
+                    std::thread::spawn(move || write_atomic(&p, &c))
+                })
+                .collect();
+            for handle in handles {
+                // A panicked thread counts as a failure too, which the
+                // shorter `is_ok_and(|r| r.is_err())` quietly does not.
+                if !handle.join().is_ok_and(|result| result.is_ok()) {
+                    failures += 1;
+                }
+            }
+
+            // And whatever landed is one writer's work entire, never a blend.
+            let got = std::fs::read_to_string(&path).expect("readable");
+            assert!(
+                got == a || got == b,
+                "a writer's file was left mixed or truncated: {} bytes",
+                got.len()
+            );
+        }
+        assert_eq!(failures, 0, "{failures} of 800 concurrent saves failed");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A rename puts a *new* file in place, created per the umask. Somebody who
+    /// ran `chmod 600` on their tasks did it on purpose and had it widened to
+    /// world-readable the next time they added one.
+    #[cfg(unix)]
+    #[test]
+    fn a_restricted_file_stays_restricted_after_a_save() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch("perms");
+        let path = dir.join("todos.toml");
+
+        std::fs::write(&path, "before").expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+
+        write_atomic(&path, "after").expect("saves");
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "the file was widened to {mode:o}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn a_write_creates_the_file_and_its_parent_directory() {
         let dir = TempDir::new("create");
@@ -157,13 +278,34 @@ mod tests {
     }
 
     #[test]
-    fn the_temp_name_keeps_the_original_extension() {
-        // `with_extension` would turn `mirador.toml` into `mirador.tmp`, which
-        // collides with the temp file for `mirador.md` in the same directory.
+    fn a_temp_name_says_where_it_came_from_and_is_never_reused() {
         let toml = temp_path(Path::new("/data/mirador.toml"));
         let md = temp_path(Path::new("/data/mirador.md"));
-        assert_eq!(toml, Path::new("/data/mirador.toml.tmp"));
+
+        // `with_extension` would turn `mirador.toml` into `mirador.tmp`, which
+        // both collides with `mirador.md`'s temporary and loses the fact that
+        // it came from a `.toml` at all. A leftover from a crash should name
+        // its origin.
+        let shown = toml.to_string_lossy().into_owned();
+        assert!(
+            shown.contains("mirador.toml"),
+            "keeps the full name: {shown}"
+        );
+        // `ends_with` on the string, not on the path's extension: the point is
+        // the literal suffix a person would see in a directory listing.
+        assert!(
+            shown.rsplit('.').next() == Some("tmp"),
+            "and is recognisable: {shown}"
+        );
         assert_ne!(toml, md, "two files must not share one temp path");
+
+        // And the same file twice must not either, which is the whole reason
+        // two mirador windows stopped taking each other's saves away.
+        assert_ne!(
+            temp_path(Path::new("/data/mirador.toml")),
+            temp_path(Path::new("/data/mirador.toml")),
+            "two writes of one file must not share a temp path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 continues with `store` and `state` — what stands between the user and losing something. Three findings, all about data rather than speed.

## Two windows fought over one temp file

`write_atomic` used a single `.tmp` name per *file*, not per *write*. Two mirador windows — one per monitor — both created it, and whoever renamed second found it gone.

| | 8 concurrent writers, 300 rounds |
|---|---|
| before | **2,100 of 2,400 saves failed** |
| after | **0** |

A failed save is reported, so the second window filled with "could not be saved" for nothing.

Behind it sat a narrower hazard worth naming even though it never reproduced: `File::create` truncates, so a second writer emptied the first's half-written temporary and the first would then have renamed *that* into place. 300 rounds never produced it. It needs no reproducing to be worth removing.

## A restricted file was quietly unrestricted

A rename installs a *new* file, created per the umask. `chmod 600` on a task list became `0644` on the next save. Tasks and notes hold whatever someone decided to write down.

## Invariant 17, broken again by a new route

`[agenda].file` ships commented out, so the baseline was `None` while the panel reported a **resolved** path. They differ — so one keystroke anywhere pinned that resolved default into `state.toml`, after which setting `[agenda].file` in the config **did nothing**, because the state file outranks it.

Verified live: a default run plus one `Tab` wrote `agenda_file` before, writes nothing after, and still remembers a path you actually choose.

The invariant needed sharpening, not restating: not only *"compare against the config"* but **compare against the config in the same terms the panel will report**. The new test fails against the old form.

## One note on process

A clippy autofix here (`map(..).unwrap_or(true)` → `is_ok_and`) silently stopped counting *panicked* threads as failures, weakening the concurrency test. Caught and reverted to explicit intent — worth flagging because it looked like a pure lint fix.

568 tests; clippy, fmt and rustdoc silent.