### PR TITLE
Pin what keeps hostile numbers out of the market panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,24 @@ is not, because it is the one people quote back at you.
 
 ### Phase 1 — finish the adversarial review
 
+**`quote`: done, and clean.** No defects. Worth recording *why*, because the
+reasons are load-bearing and easy to remove by accident:
+
+- Numbers too large for an `f64` are refused by the JSON parser before any
+  guard sees them. That is stronger than a downstream check and it is why no
+  downstream check exists — so a future move away from `serde_json`'s strictness
+  would need one.
+- `change_pct` returns zero rather than infinity for a previous close of zero,
+  and the sparkline returns its middle glyph for a series with no span. Both
+  divisors are guarded at the point of division.
+- Symbols reach the URL through a strict RFC 3986 unreserved allowlist, so
+  nothing in a symbol can alter the request — while `.` passes through, which is
+  what keeps `BRK.B` working.
+
+All four market-data promises are enforced rather than merely written down, and
+were re-checked: no key anywhere, `WatchlistFile` carries symbols and no prices,
+`refresh_secs.max(60)`, and `stagger_ms.clamp(100, 10_000)`.
+
 **`store` and `state`: done.** Three findings, all about data rather than
 speed.
 

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -469,6 +469,73 @@ mod tests {
       }
     }"#;
 
+    /// A quote response is untrusted network input carrying numbers straight
+    /// into arithmetic and onto a screen. These are the shapes that break float
+    /// code: a value too large for an `f64`, a divisor of zero, a series with
+    /// no span, nothing at all.
+    ///
+    /// The outcome to insist on is that a row never reads `inf%` or `NaN`. A
+    /// wrong-looking number in a money column is worse than a missing one,
+    /// which is the same reasoning that keeps stale prices off this panel.
+    #[test]
+    fn hostile_numbers_never_reach_the_screen_as_inf_or_nan() {
+        let swap = |price: &str, prev: &str, series: &str| {
+            SAMPLE
+                .replace("213.5,", &format!("{price},"))
+                .replace(
+                    "\"chartPreviousClose\": 211.0",
+                    &format!("\"chartPreviousClose\": {prev}"),
+                )
+                .replace("[211.0, null, 212.5, 213.5]", series)
+        };
+
+        for (name, price, prev, series) in [
+            (
+                "a price too large for an f64",
+                "1e400",
+                "211.0",
+                "[211.0, 212.5]",
+            ),
+            (
+                "a previous close too large",
+                "213.5",
+                "1e400",
+                "[211.0, 212.5]",
+            ),
+            (
+                "a value in the series too large",
+                "1.0",
+                "1.0",
+                "[1e400, 1.0]",
+            ),
+            ("a previous close of zero", "213.5", "0.0", "[211.0, 212.5]"),
+            ("negative prices", "-5.0", "-10.0", "[-1.0, -2.0, -3.0]"),
+            ("an empty series", "1.0", "1.0", "[]"),
+            ("a flat series", "1.0", "1.0", "[7.0, 7.0, 7.0]"),
+        ] {
+            // Out-of-range literals are refused outright by the JSON parser,
+            // which is a stronger defence than any guard downstream — and one
+            // worth pinning, since it is the reason no guard is needed for them.
+            let Ok(quote) = parse_chart(&swap(price, prev, series)) else {
+                continue;
+            };
+
+            assert!(quote.price.is_finite(), "{name}: price is {}", quote.price);
+            assert!(
+                quote.change_pct().is_finite(),
+                "{name}: `{}%` would read as a broken panel",
+                quote.change_pct()
+            );
+            // And the sparkline neither panics nor overruns its width.
+            for width in [0, 1, 8, 40] {
+                assert!(
+                    sparkline(&quote.series, width).chars().count() <= width,
+                    "{name}: sparkline overran {width} cells"
+                );
+            }
+        }
+    }
+
     #[test]
     fn a_chart_response_becomes_a_quote() {
         let q = parse_chart(SAMPLE).unwrap();


### PR DESCRIPTION
Phase 1 continues with `quote` — the last parser eating untrusted network input, and the only module touching money.

**No defects.** A clean result is only useful if the reasons are recorded, so this pins them.

## Why it's clean

- **Numbers too large for an `f64` are refused by the JSON parser** before any guard sees them. That's stronger than a downstream check and it's *why no downstream check exists* — so moving away from `serde_json`'s strictness would need one. I assumed the opposite going in, that `1e400` would arrive as infinity and need catching. It doesn't.
- **Both divisors are guarded where they're divided.** A previous close of zero yields `0.00%`, not `inf%`. A series with no span yields the middle glyph. A money column reading `inf%` is worse than one reading nothing — the same reasoning that keeps stale prices off this panel.
- **Symbols reach the URL through a strict RFC 3986 unreserved allowlist**, so nothing in a symbol can alter the request. `.` is unreserved, which is what keeps `BRK.B` working rather than being encoded into something Yahoo won't recognise.

## The four promises, re-checked rather than assumed

| Promise | Enforcement |
|---|---|
| No bundled API key | zero key references in the module |
| Quotes never persisted | `WatchlistFile` carries symbols only |
| Poll ≥ 60s | `refresh_secs.max(MIN_SECONDS_BETWEEN_POLLS)`, and that constant is 60 |
| Staggered, not concurrent | `stagger_ms.clamp(100, 10_000)` |

## The test

Covers a price too large to represent, a previous close of zero, negative prices, an empty series and a flat one — asserting what matters: nothing reaches the screen as `inf` or `NaN`, and a sparkline never overruns the width it was given.

569 tests; clippy, fmt and rustdoc silent.