### PR TITLE
Treat a theme name as a name rather than a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A theme name is a name, not a path.** `theme = "../../elsewhere"` resolved,
+  reading and parsing a file outside your themes directory. Nothing escalated —
+  the config and anything it could reach are yours — but a name whose meaning
+  depends on where your config sits is not a name.
+
 - **Two mirador windows no longer take each other's saves away.** Every writer
   of a file used the same `.tmp` name, so whoever renamed second found it gone.
   Measured with eight concurrent writers: **2,100 of 2,400 saves failed** — and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,22 @@ is not, because it is the one people quote back at you.
 
 ### Phase 1 — finish the adversarial review
 
+**`themes`: done.** One finding and one non-finding.
+
+A theme name was used as a path component without checking, so
+`theme = "../../elsewhere"` read and parsed a file outside the themes
+directory. Nothing escalates — the config and anything it reaches belong to the
+user — but a name whose meaning depends on where the config happens to live is
+not a name, and the failure messages quote whatever it reached. Letters, digits,
+dash and underscore now, which admits every bundled name and excludes
+separators, `..` and the empty string. `inherits` goes through the same door.
+
+The non-finding is worth as much: `substitute` recurses through nested tables,
+and the bound on that recursion is the TOML parser's, not this module's. Fifty
+thousand nested inline tables are refused before they ever become a `Table`.
+Pinned by a test, because the bound lives in a dependency and would leave with
+it.
+
 **`quote`: done, and clean.** No defects. Worth recording *why*, because the
 reasons are load-bearing and easy to remove by accident:
 

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -120,8 +120,34 @@ pub fn resolve(name: &str, themes_dir: Option<&Path>) -> Result<Theme> {
         .map(|theme| theme.named(name))
 }
 
+/// Whether a theme name is a name rather than a path.
+///
+/// `theme = "../../elsewhere"` used to resolve, reading and parsing a file
+/// outside the themes directory. Nothing is escalated by it — the config is the
+/// user's own, and so is anything it could reach — but a theme name is not a
+/// path and letting it act like one means error messages quoting arbitrary
+/// files, and a name whose meaning depends on where the config happens to live.
+///
+/// Letters, digits, dash and underscore. That admits every bundled name and
+/// every convention a theme is likely to use; it excludes separators, `..`, and
+/// the empty string.
+fn is_plain_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 /// Read one theme document, preferring the user's copy.
 fn read(name: &str, themes_dir: Option<&Path>) -> Result<toml::Table> {
+    if !is_plain_name(name) {
+        bail!(
+            "`{name}` is not a theme name. Use letters, digits, dashes and \
+             underscores — a theme is looked up by name in your themes \
+             directory, not by path."
+        );
+    }
+
     if let Some(path) = themes_dir.map(|dir| dir.join(format!("{name}.toml")))
         && path.exists()
     {
@@ -198,6 +224,11 @@ fn check_palette_ordering(name: &str, table: &toml::Table) -> Result<()> {
 /// Only strings that are palette *keys* change; everything else is left for the
 /// colour parser to accept or reject, so a typo still produces "`brss` is not a
 /// colour" rather than being silently dropped.
+/// Recursion here is bounded by the TOML parser rather than by anything below:
+/// a document nested deeply enough to matter is refused before it becomes a
+/// `Table`. Checked with fifty thousand nested inline tables, which `toml`
+/// rejects outright. Worth knowing, because the bound lives in a dependency and
+/// would leave with it.
 fn substitute(table: &mut toml::Table, palette: &BTreeMap<String, toml::Value>) {
     for (_, value) in table.iter_mut() {
         // Taken by value and put back, because a palette hit replaces the whole
@@ -240,6 +271,55 @@ mod tests {
 
     fn write(dir: &Path, name: &str, body: &str) {
         std::fs::write(dir.join(format!("{name}.toml")), body).expect("writing a theme");
+    }
+
+    /// A theme name is a name, not a path. `theme = "../../elsewhere"` used to
+    /// resolve — reading and parsing a file outside the themes directory.
+    /// Nothing escalates, since the config and anything it reaches are the
+    /// user's own, but a name whose meaning depends on where the config sits is
+    /// not a name, and the error messages quote whatever it reached.
+    #[test]
+    fn a_theme_name_cannot_reach_outside_the_themes_directory() {
+        let (dir, _g) = themes_dir("traversal");
+        let outside = dir.parent().expect("has a parent").join("outside.toml");
+        std::fs::write(&outside, "accent = \"#010203\"\n").expect("write");
+
+        for name in ["../outside", "/etc/passwd", "sub/theme", "..", ""] {
+            let err = resolve(name, Some(&dir))
+                .err()
+                .unwrap_or_else(|| panic!("`{name}` was accepted as a theme name"));
+            let message = format!("{err:#}");
+            assert!(
+                message.contains("not a theme name") || message.contains("no theme called"),
+                "`{name}` refused for the wrong reason: {message}"
+            );
+        }
+
+        // And an ordinary name still works.
+        write(&dir, "nord", "accent = \"#88c0d0\"\n");
+        assert!(resolve("nord", Some(&dir)).is_ok());
+        let _ = std::fs::remove_file(&outside);
+    }
+
+    /// The palette substitution recurses through nested tables, and the bound
+    /// on that recursion lives in the TOML parser rather than here — a document
+    /// nested deeply enough to overflow a stack never becomes a `Table` at all.
+    /// Pinned because the bound would leave with the dependency.
+    #[test]
+    fn a_deeply_nested_theme_is_refused_before_it_can_be_walked() {
+        let (dir, _g) = themes_dir("deep");
+        let depth = 50_000;
+        let mut deep = String::from("accent = \"#010203\"\n\nnest = ");
+        deep.push_str(&"{ a = ".repeat(depth));
+        deep.push('1');
+        deep.push_str(&" }".repeat(depth));
+        deep.push('\n');
+        write(&dir, "deep", &deep);
+
+        assert!(
+            resolve("deep", Some(&dir)).is_err(),
+            "{depth} levels of nesting were walked rather than refused"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 continues with `themes` — the last module reading something a person edits by hand.

## The finding

The name went into a path component unchecked, so `theme = "../../elsewhere"` **resolved**: read the file, parsed it as TOML, used whatever colours it found.

Nothing escalates — the config and anything it reaches belong to the user already. But a theme name whose meaning depends on where the config happens to sit is not a name, and every failure message quotes whatever it reached.

Letters, digits, dash and underscore now. That admits every bundled name and every convention a theme is likely to use, and excludes separators, `..` and the empty string. `inherits` resolves through the same door and gets the same check.

## The non-finding, which is worth as much

Palette substitution recurses through nested tables and could in principle be walked off a stack — except the bound is **the TOML parser's, not this module's**. Fifty thousand nested inline tables are refused before they ever become a `Table` for `substitute` to see.

That's now a test, because a bound living in a dependency leaves when the dependency does, and nothing else here would notice.

571 tests; clippy, fmt and rustdoc silent.