### PR TITLE
Ship six community themes and a `t` picker to choose them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ themes.rs    `theme = "name"`: bundled themes, inherits, palettes
 config/      mod.rs: paths, loading, validation; widgets.rs: one settings
              struct per panel; layout.rs: the grid
 picker.rs    the `w` dialog — owns its cursor, returns an Action to the shell
+theme_picker.rs the `t` dialog — same shape, but previews as the cursor moves
 arrange.rs   the `m` mode's arithmetic: where a panel goes when you move it
 prompt.rs    the one-line question a panel asks for a path, place or zone,
              with an optional list to choose from
@@ -206,7 +207,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 254 of them, including the ones mirador
+    trip through `toml` discards all 264 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -368,13 +369,64 @@ costs exactly one request. **Requires a browser `User-Agent`** or you get HTTP
 
 ## Named themes — built
 
-`theme = "name"` resolves through `themes.rs`. Four themes are `include_str!`-
-baked (`default`, `default-light`, `high-contrast`, `ansi`) and anything in
-`<config>/mirador/themes/<name>.toml` is found first, so a bundled theme can be
-replaced without renaming it. `inherits` chains with cycle detection; `[palette]`
+`theme = "name"` resolves through `themes.rs`. Ten themes are `include_str!`-
+baked and anything in `<config>/mirador/themes/<name>.toml` is found first, so a
+bundled theme can be replaced without renaming it.
+
+Four are mirador's own (`default`, `default-light`, `high-contrast`, `ansi`).
+Six are **ports** of palettes from elsewhere — `nord`, `gruvbox`, `dracula`,
+`catppuccin-mocha`, `tokyo-night`, `solarized-dark`. Each file cites the
+upstream source its hex values came from, and that is the point: someone who
+picks `nord` wants Nord. Adjust the *mapping* onto mirador's keys if a palette
+reads badly; never adjust the palette. All six keep `text = "reset"`, so body
+text still follows the terminal's own foreground — invariant 8 is not suspended
+because a theme has a name.
+
+Adding one: write `assets/themes/<name>.toml`, add it to `BUNDLED`. Three things
+will bite, and all three are pinned by tests rather than left to memory — the
+filename must match `[A-Za-z0-9_-]+`, colour keys must come **before**
+`[palette]` and the gradient tables, and a standalone theme must set every one of
+`Theme::KEYS`. `inherits` chains with cycle detection; `[palette]`
 names colours once, and a child redefining a palette entry recolours the keys
 its *parent* set with it — which is why palettes are merged separately from the
 colour keys rather than as each document is read.
+
+**The `t` picker previews as the cursor moves**, which is the whole reason it is
+usable: a theme you cannot see is a theme you cannot choose. That makes `Esc`
+load-bearing — it restores the theme the dialog opened on — and it is why the
+dialog holds `(ThemePicker, Theme)` rather than just the picker.
+
+Two things make live preview cheap. Every theme read in the dashboard happens at
+*draw* time from `config.theme`, so a swap is one field assignment; and the one
+exception, `App::gradients`, is a baked 101-entry ramp that `apply_theme`
+re-derives in the same place. Forget the second and the cpu and network graphs
+stay in the old palette while everything around them changes, which reads as a
+rendering bug rather than a missing line. `a_theme_swap_rebakes_the_gradients_the_graphs_draw_from`
+pins it, and `Gradients` derives `PartialEq` purely so it can.
+
+**The choice is remembered in `state.rs`, not written to the config** — and this
+is a real departure from the `[layout]` precedent, so it is worth the paragraph.
+People *do* curate their theme, which by invariant 16's rule would put it in the
+config. What decides it is the shape of the edit: `theme` may be a string *or*
+an inline `[theme]` table, and swapping a whole table for a scalar is a textual
+rewrite far more dangerous than the single-line `[layout]` edits — which are
+safe only because `layout_edit::apply` can re-parse and verify what it wrote.
+There is no equivalent check for "did this still mean the same thing". So the
+config keeps seeding, `t` records where the user moved, and anyone who wants it
+under version control writes `theme = "nord"` themselves.
+
+The consequence to know about: a config `theme` that seems to be ignored means a
+state file outranking it. The README and the shipped config both say so, because
+the alternative is someone editing a config line that does nothing.
+
+Invariant 17 holds for it by construction — the baseline is `config.theme.name`
+taken before `apply_state_theme`, so picking the theme the config already names
+*retracts* the entry. Note that `a_dashboard_nobody_has_touched_writes_nothing`
+cannot see this field: a default config carries an inline table and so names no
+theme, leaving both sides `None` whether or not `theme` is in
+`only_changes_from`'s hand-written list. `a_theme_matching_the_config_is_not_recorded`
+exists because of that, and it was checked by removing the entry and watching it
+go red.
 
 **Two items from the original design were deliberately not built**, and the
 reasons matter more than the decision:
@@ -746,8 +798,9 @@ going to guess that from reading.
 ## Open work
 
 Nothing. All three gaps named in the original product analysis are built — the
-`.ics` agenda, the watch log, and the on-fire signal — along with named themes,
-arrange mode, and in-panel editing for everything the UI can change.
+`.ics` agenda, the watch log, and the on-fire signal — along with named themes
+and the `t` picker over them, arrange mode, and in-panel editing for everything
+the UI can change.
 
 That is a fact about the *list*, not a claim the program is finished. Two things
 shipped recently have never run in the conditions they were built for, and both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,31 @@ While a prompt is open your panel must return `true` from
 `Panel::captures_input`, or the first `q` someone types into it will quit the
 dashboard.
 
+## Adding a theme
+
+Write `assets/themes/<name>.toml` and add it to `BUNDLED` in `src/themes.rs`.
+That is the whole change — the `t` picker lists whatever is in `BUNDLED`.
+
+Four things will catch you out, and each has a test rather than a convention:
+
+1. **Colour keys go *before* `[palette]` and before the gradient tables.** TOML
+   assigns every key after a table header to that table, so a colour written
+   below `[palette]` lands inside it and silently sets nothing.
+2. **Set every key in `Theme::KEYS`** unless the theme `inherits` another.
+3. **The filename must be `[A-Za-z0-9_-]+`.** A theme is looked up by name, not
+   by path, so anything else cannot be loaded.
+4. **`text` stays `reset`.** Body text follows the reader's own terminal
+   foreground; pinning it to your palette breaks on the half of terminals not
+   configured the way yours is.
+
+Keep `border` and `muted` distinct, or secondary text ends up as dim as the
+chrome and reads as broken rather than de-emphasised.
+
+If you are porting a palette from elsewhere, take the hex values from its own
+specification and cite the source in a comment at the top of the file. Adjust
+how the palette maps onto mirador's keys as much as you like; do not adjust the
+palette. Someone choosing `nord` wants Nord.
+
 ## Code standards
 
 - `cargo clippy --all-targets -- -D warnings` must pass. The crate enables

--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ rather than a cap on what a wider panel can draw.
 | `?` | Show all key bindings |
 | `w` | Choose which panels are shown |
 | `m` | Rearrange the panels — see below |
+| `t` | Choose a theme, previewing as you move — see below |
 | `Ctrl+arrow` | Resize the focused panel against its neighbour |
 | `q` / `Ctrl+C` | Quit |
 
@@ -831,7 +832,16 @@ You can also name a theme instead, and drop the table entirely:
 theme = "high-contrast"
 ```
 
-Four ship inside the binary:
+**Press `t` to browse them.** The list previews as you move through it, so you
+see a theme on your own dashboard before you choose it; `Enter` keeps what is on
+screen and `Esc` puts back what you had. Your own themes are listed alongside
+the shipped ones. A theme picked this way is remembered, the same way your
+weather units and task sort order are — so if you set `theme` in the config and
+it appears to be ignored, you picked something else with `t` at some point.
+
+#### What ships
+
+Four are mirador's own:
 
 | Theme | For |
 | --- | --- |
@@ -839,6 +849,24 @@ Four ship inside the binary:
 | `default-light` | Light backgrounds. Not the dark theme inverted: the hues are deepened so they keep their contrast on paper-coloured terminals |
 | `high-contrast` | Bright rooms, projectors, low vision. `muted` is deliberately *not* dim — faint grey is the first thing to vanish on a washed-out screen, so de-emphasis is carried by hue instead |
 | `ansi` | The sixteen ANSI colours and nothing else, so it follows whatever palette your terminal already uses and works with no true-colour support |
+
+Six more are ports of palettes you may already be running in your editor,
+terminal or multiplexer, so mirador can match the rest of your screen. All six
+are dark:
+
+| Theme | Palette |
+| --- | --- |
+| `nord` | [Nord](https://www.nordtheme.com/docs/colors-and-palettes) — arctic, north-bluish; Frost for the instruments, Aurora for the signals |
+| `gruvbox` | [Gruvbox](https://github.com/morhetz/gruvbox) dark — retro groove; the warmest and highest-contrast of the six |
+| `dracula` | [Dracula](https://spec.draculatheme.com/) — the loudest, six saturated accents at the same brightness |
+| `catppuccin-mocha` | [Catppuccin](https://github.com/catppuccin/catppuccin) Mocha — pastel accents on soft charcoal |
+| `tokyo-night` | [Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) Storm — the lifted variant, so mirador's slate chrome stays visible |
+| `solarized-dark` | [Solarized](https://ethanschoonover.com/solarized/) dark — designed against measured contrast rather than by eye, and the calmest of the six |
+
+These are ports, not reinterpretations: the hex values come from each palette's
+own specification, and the theme file cites its source. Body text stays `reset`
+in all of them, so it keeps following your terminal's foreground rather than
+being pinned to the palette's.
 
 The same key does both jobs, and TOML decides which: a quoted string is a theme
 name, a table is colours written out. You cannot do both, because one key cannot
@@ -848,10 +876,12 @@ be both types.
 
 Put `<name>.toml` in `themes/` beside your config — `mirador --config-path` will
 tell you where that is. A file there wins over a bundled theme of the same name,
-so you can replace `default` without renaming it.
+so you can replace `default` without renaming it, and it appears in the `t` list
+marked as yours. The name has to be letters, digits, dashes and underscores;
+anything else is not a name mirador can look up, so it is left out of the list.
 
 ```toml
-# themes/nord.toml
+# themes/frostbite.toml
 inherits = "ansi"
 
 accent         = "frost"

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -99,15 +99,25 @@ rows = [
 #
 # There are two ways to write this, and they use the same key.
 #
+# Press `t` in the dashboard to browse them. The list previews as you move, so
+# you can see a theme before choosing it, and `Esc` puts back what you had. A
+# theme picked that way is remembered in mirador's state file, which outranks
+# whatever this file says — so if you set a theme here and it seems to be
+# ignored, press `t` and pick it again, or delete the state file.
+#
 # Name a theme, and this whole table goes away:
 #
 #     theme = "high-contrast"
 #
-# Four ship inside the binary — `default` (this), `default-light`,
-# `high-contrast` and `ansi` — and anything in themes/<name>.toml beside this
-# file is found first, so a bundled theme can be replaced without renaming it.
-# A theme file may `inherits` another and may define a `[palette]` of named
-# colours; see the README.
+# Ten ship inside the binary. Four are mirador's own — `default` (this),
+# `default-light`, `high-contrast` and `ansi` — and six are ports of palettes
+# you may already be running elsewhere: `nord`, `gruvbox`, `dracula`,
+# `catppuccin-mocha`, `tokyo-night` and `solarized-dark`. All six are dark; on
+# a light terminal, `default-light` is the one to reach for.
+#
+# Anything in themes/<name>.toml beside this file is found first, so a bundled
+# theme can be replaced without renaming it. A theme file may `inherits`
+# another and may define a `[palette]` of named colours; see the README.
 #
 # Or keep the table below and set colours here. Naming a theme and writing the
 # table are mutually exclusive: TOML will not let one key be both a string and

--- a/assets/themes/catppuccin-mocha.toml
+++ b/assets/themes/catppuccin-mocha.toml
@@ -1,0 +1,62 @@
+# Catppuccin Mocha — the darkest of the four Catppuccin flavours.
+#
+# Pastel accents on a soft, slightly warm charcoal. The palette is unusually
+# large, so the mapping below picks from it rather than using all of it: mauve
+# is the documented accent, and the surface/overlay ramp gives three distinct
+# greys for chrome, which most palettes do not.
+#
+# Values from github.com/catppuccin/catppuccin.
+
+border         = "surface1"
+border_focused = "mauve"
+rule           = "surface0"
+title          = "mauve"
+text           = "reset"
+muted          = "overlay0"
+label          = "teal"
+accent         = "mauve"
+key            = "blue"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "surface0"
+
+[palette]
+surface0 = "#313244"
+surface1 = "#45475a"
+overlay0 = "#6c7086"
+subtext0 = "#a6adc8"
+mauve    = "#cba6f7"
+red      = "#f38ba8"
+peach    = "#fab387"
+yellow   = "#f9e2af"
+green    = "#a6e3a1"
+teal     = "#94e2d5"
+sky      = "#89dceb"
+blue     = "#89b4fa"
+lavender = "#b4befe"
+
+[cpu_gradient]
+start = "#313244"
+mid   = "#f9e2af"
+end   = "#f38ba8"
+
+[rx_gradient]
+start = "#45475a"
+mid   = "#89dceb"
+end   = "#a6e3a1"
+
+[tx_gradient]
+start = "#45475a"
+mid   = "#89b4fa"
+end   = "#cba6f7"
+
+[gain_gradient]
+start = "#45475a"
+mid   = "#a6e3a1"
+end   = "#a6e3a1"
+
+[loss_gradient]
+start = "#45475a"
+mid   = "#f38ba8"
+end   = "#f38ba8"

--- a/assets/themes/dracula.toml
+++ b/assets/themes/dracula.toml
@@ -1,0 +1,58 @@
+# Dracula — the dark theme, by Zeno Rocha.
+#
+# The most recognisable of the set: a violet-leaning background with six
+# saturated accents that all sit at roughly the same brightness. That evenness
+# is why the signal colours here are unusually loud — nothing in Dracula
+# recedes, so `error` has to be the one that reads first by hue, not weight.
+#
+# Values from the official specification at spec.draculatheme.com.
+
+border         = "selection"
+border_focused = "purple"
+rule           = "selection"
+title          = "purple"
+text           = "reset"
+muted          = "comment"
+label          = "cyan"
+accent         = "purple"
+key            = "pink"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "selection"
+
+[palette]
+selection = "#44475a"
+comment   = "#6272a4"
+red       = "#ff5555"
+orange    = "#ffb86c"
+yellow    = "#f1fa8c"
+green     = "#50fa7b"
+purple    = "#bd93f9"
+cyan      = "#8be9fd"
+pink      = "#ff79c6"
+
+[cpu_gradient]
+start = "#44475a"
+mid   = "#ffb86c"
+end   = "#ff5555"
+
+[rx_gradient]
+start = "#44475a"
+mid   = "#8be9fd"
+end   = "#50fa7b"
+
+[tx_gradient]
+start = "#44475a"
+mid   = "#bd93f9"
+end   = "#ff79c6"
+
+[gain_gradient]
+start = "#44475a"
+mid   = "#50fa7b"
+end   = "#50fa7b"
+
+[loss_gradient]
+start = "#44475a"
+mid   = "#ff5555"
+end   = "#ff5555"

--- a/assets/themes/gruvbox.toml
+++ b/assets/themes/gruvbox.toml
@@ -1,0 +1,56 @@
+# Gruvbox dark — retro groove, by Pavel Pertsev.
+#
+# The warmest of the popular palettes and the highest contrast, which is why it
+# gets recommended for long sessions. Values from morhetz/gruvbox-contrib's
+# colour table.
+
+border         = "dark2"
+border_focused = "bright-orange"
+rule           = "dark1"
+title          = "bright-orange"
+text           = "reset"
+muted          = "gray"
+label          = "bright-aqua"
+accent         = "bright-orange"
+key            = "bright-yellow"
+success        = "bright-green"
+warning        = "bright-yellow"
+error          = "bright-red"
+track          = "dark1"
+
+[palette]
+dark1         = "#3c3836"
+dark2         = "#504945"
+gray          = "#928374"
+bright-red    = "#fb4934"
+bright-green  = "#b8bb26"
+bright-yellow = "#fabd2f"
+bright-blue   = "#83a598"
+bright-purple = "#d3869b"
+bright-aqua   = "#8ec07c"
+bright-orange = "#fe8019"
+
+[cpu_gradient]
+start = "#3c3836"
+mid   = "#fabd2f"
+end   = "#fb4934"
+
+[rx_gradient]
+start = "#504945"
+mid   = "#689d6a"
+end   = "#b8bb26"
+
+[tx_gradient]
+start = "#504945"
+mid   = "#b16286"
+end   = "#d3869b"
+
+[gain_gradient]
+start = "#504945"
+mid   = "#98971a"
+end   = "#b8bb26"
+
+[loss_gradient]
+start = "#504945"
+mid   = "#cc241d"
+end   = "#fb4934"

--- a/assets/themes/nord.toml
+++ b/assets/themes/nord.toml
@@ -1,0 +1,65 @@
+# Nord — the arctic, north-bluish palette by Arctic Ice Studio.
+#
+# Frost blue for the instruments, Polar Night for chrome, Aurora for signals.
+# Values from the official palette at nordtheme.com; nord8 is the documented
+# primary accent, which is why it carries the focus and the clock here.
+#
+# `border` is nord2 and `muted` is nord3 — Nord's own comment colour — rather
+# than both being nord3. Chrome and secondary text at the same value reads as a
+# panel whose labels have failed rather than as one that is de-emphasised.
+#
+# `text` is `reset` on purpose. A named theme says which *accents* you want; the
+# body text still belongs to whatever foreground your terminal is set to, and
+# hard-coding Snow Storm white would be unreadable on a light background.
+
+border         = "polar2"
+border_focused = "frost-ice"
+rule           = "polar1"
+title          = "frost-ice"
+text           = "reset"
+muted          = "polar3"
+label          = "frost-water"
+accent         = "frost-ice"
+key            = "frost-ice"
+success        = "aurora-green"
+warning        = "aurora-yellow"
+error          = "aurora-red"
+track          = "polar1"
+
+[palette]
+polar1        = "#3b4252"
+polar2        = "#434c5e"
+polar3        = "#4c566a"
+frost-ice     = "#88c0d0"
+frost-water   = "#8fbcbb"
+frost-ocean   = "#5e81ac"
+aurora-red    = "#bf616a"
+aurora-orange = "#d08770"
+aurora-yellow = "#ebcb8b"
+aurora-green  = "#a3be8c"
+aurora-purple = "#b48ead"
+
+[cpu_gradient]
+start = "#3b4252"
+mid   = "#ebcb8b"
+end   = "#bf616a"
+
+[rx_gradient]
+start = "#4c566a"
+mid   = "#8fbcbb"
+end   = "#a3be8c"
+
+[tx_gradient]
+start = "#434c5e"
+mid   = "#5e81ac"
+end   = "#b48ead"
+
+[gain_gradient]
+start = "#4c566a"
+mid   = "#a3be8c"
+end   = "#a3be8c"
+
+[loss_gradient]
+start = "#4c566a"
+mid   = "#bf616a"
+end   = "#bf616a"

--- a/assets/themes/solarized-dark.toml
+++ b/assets/themes/solarized-dark.toml
@@ -1,0 +1,68 @@
+# Solarized dark — by Ethan Schoonover.
+#
+# The oldest palette here and the only one designed against measured contrast
+# rather than by eye, which shows: the accents are deliberately *low* saturation
+# and all sit at similar lightness. That makes it the calmest of the set and the
+# closest in spirit to mirador's own default, and it is why `error` here is a
+# muted brick rather than a shout — Solarized has no shout.
+#
+# `muted` is base0 rather than base01: Solarized's own chrome colour is base02,
+# which is nearly black and would disappear on any terminal not already using a
+# Solarized background. So base01 carries the borders here and secondary text
+# moves up to base0, keeping the two apart on a plain dark terminal too.
+#
+# Values from ethanschoonover.com/solarized.
+
+border         = "base01"
+border_focused = "blue"
+rule           = "base02"
+title          = "blue"
+text           = "reset"
+muted          = "base0"
+label          = "cyan"
+accent         = "blue"
+key            = "violet"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "base02"
+
+[palette]
+base02  = "#073642"
+base01  = "#586e75"
+base00  = "#657b83"
+base0   = "#839496"
+base1   = "#93a1a1"
+yellow  = "#b58900"
+orange  = "#cb4b16"
+red     = "#dc322f"
+magenta = "#d33682"
+violet  = "#6c71c4"
+blue    = "#268bd2"
+cyan    = "#2aa198"
+green   = "#859900"
+
+[cpu_gradient]
+start = "#073642"
+mid   = "#b58900"
+end   = "#dc322f"
+
+[rx_gradient]
+start = "#073642"
+mid   = "#2aa198"
+end   = "#859900"
+
+[tx_gradient]
+start = "#073642"
+mid   = "#268bd2"
+end   = "#6c71c4"
+
+[gain_gradient]
+start = "#073642"
+mid   = "#859900"
+end   = "#859900"
+
+[loss_gradient]
+start = "#073642"
+mid   = "#dc322f"
+end   = "#dc322f"

--- a/assets/themes/tokyo-night.toml
+++ b/assets/themes/tokyo-night.toml
@@ -1,0 +1,58 @@
+# Tokyo Night (Storm) — after the lights of Tokyo at night, by Enkia.
+#
+# The Storm variant rather than the darker default, because mirador draws its
+# chrome *against* the background: on Tokyo Night's near-black the slate borders
+# vanish, and Storm's lifted background keeps them visible without brightening
+# anything else.
+
+border         = "storm-hi"
+border_focused = "blue"
+rule           = "storm"
+title          = "blue"
+text           = "reset"
+muted          = "comment"
+label          = "cyan"
+accent         = "blue"
+key            = "purple"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "storm"
+
+[palette]
+storm    = "#24283b"
+storm-hi = "#414868"
+comment  = "#565f89"
+red      = "#f7768e"
+orange   = "#ff9e64"
+yellow   = "#e0af68"
+green    = "#9ece6a"
+teal     = "#73daca"
+cyan     = "#7dcfff"
+blue     = "#7aa2f7"
+purple   = "#bb9af7"
+
+[cpu_gradient]
+start = "#24283b"
+mid   = "#e0af68"
+end   = "#f7768e"
+
+[rx_gradient]
+start = "#414868"
+mid   = "#7dcfff"
+end   = "#9ece6a"
+
+[tx_gradient]
+start = "#414868"
+mid   = "#7aa2f7"
+end   = "#bb9af7"
+
+[gain_gradient]
+start = "#414868"
+mid   = "#9ece6a"
+end   = "#9ece6a"
+
+[loss_gradient]
+start = "#414868"
+mid   = "#f7768e"
+end   = "#f7768e"

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,6 +37,10 @@ const GLOBAL: &[Binding] = &[
     // narrow for all of them — but a primary, because the alternative is what
     // happened to the resize keys below: shipped, useful, and undiscoverable.
     Binding::primary("m", "arrange"),
+    // Behind `m` for the same reason `m` is behind `w`, and a primary for the
+    // same reason too: six themes ship, and a theme nobody can find is six
+    // files of decoration.
+    Binding::primary("t", "theme"),
     Binding::extra("Shift+Tab", "focus back"),
     Binding::extra("1-9", "jump to panel"),
     Binding::extra("Ctrl+←/→", "resize width"),
@@ -287,6 +291,10 @@ pub struct App {
     today: jiff::civil::Date,
     /// The panel picker, while it is open.
     picker: Option<crate::picker::Picker>,
+    /// The theme picker, while it is open, and the theme to put back if it is
+    /// cancelled. Previewing means the live theme is not the committed one, so
+    /// the dialog cannot be closed without knowing what it replaced.
+    theme_picker: Option<(crate::theme_picker::ThemePicker, crate::theme::Theme)>,
     /// The layout as it stood when arrange mode opened, kept so that `Esc` can
     /// put it back. Moving panels is a bigger, more spatial change than
     /// toggling one on, and being able to try an arrangement and back out of it
@@ -356,6 +364,7 @@ impl App {
             watch: crate::watch::WatchLog::default(),
             today: jiff::Zoned::now().date(),
             picker: None,
+            theme_picker: None,
             arranging: None,
             config_path: None,
             last_resize: None,
@@ -635,6 +644,10 @@ impl App {
         for slot in &self.slots {
             slot.panel.remember(&mut current);
         }
+        // The theme is the shell's, not any panel's, so it is reported here —
+        // but reported the same way, unconditionally, so invariant 17 holds for
+        // it too and picking your config's own theme back retracts the entry.
+        current.theme.clone_from(&self.config.theme.name);
         current.only_changes_from(&self.baseline)
     }
 
@@ -777,6 +790,10 @@ impl App {
 
         // The picker is a real dialog rather than a notice, so it reads keys
         // instead of dismissing on any of them.
+        if self.theme_picker.is_some() {
+            self.handle_theme_picker_key(key);
+            return;
+        }
         if self.picker.is_some() {
             self.handle_picker_key(key);
             return;
@@ -929,6 +946,71 @@ impl App {
         }
     }
 
+    /// Open the theme picker, remembering the theme to put back on `Esc`.
+    ///
+    /// The themes directory sits beside the config, so a `--config` somewhere
+    /// unusual looks for themes beside *it*. With no config path — which is
+    /// only ever the tests — the bundled set is the whole list.
+    fn open_theme_picker(&mut self) {
+        let dir = self
+            .config_path
+            .as_deref()
+            .and_then(crate::themes::user_dir);
+        let picker = crate::theme_picker::ThemePicker::new(
+            self.config.theme.name.as_deref(),
+            dir.as_deref(),
+        );
+        self.theme_picker = Some((picker, self.config.theme.clone()));
+    }
+
+    /// Act on whatever the theme picker made of a keypress.
+    fn handle_theme_picker_key(&mut self, key: KeyEvent) {
+        let Some((picker, original)) = self.theme_picker.as_mut() else {
+            return;
+        };
+        match picker.handle_key(key) {
+            crate::theme_picker::Action::None => {}
+            crate::theme_picker::Action::Preview(name) => {
+                let dir = self
+                    .config_path
+                    .as_deref()
+                    .and_then(crate::themes::user_dir);
+                // A theme that will not load is left as a dead row rather than
+                // reported: the file is the user's own, they have just watched
+                // every other name repaint the screen, and the one that does
+                // nothing is legible enough. Anything louder would put an error
+                // dialog on top of a colour picker.
+                if let Ok(theme) = crate::themes::resolve(&name, dir.as_deref()) {
+                    self.apply_theme(theme);
+                }
+            }
+            crate::theme_picker::Action::Accept => {
+                self.theme_picker = None;
+                // The live theme is already the chosen one, so there is nothing
+                // to apply — only to record. Written here rather than on every
+                // cursor move, so browsing the list costs no writes.
+                self.persist_preferences();
+            }
+            crate::theme_picker::Action::Cancel => {
+                let restore = original.clone();
+                self.theme_picker = None;
+                self.apply_theme(restore);
+            }
+        }
+    }
+
+    /// Swap the live theme, including the colours derived from it.
+    ///
+    /// `gradients` is the one thing that does not read `config.theme` at draw
+    /// time — it is a baked 101-entry ramp, computed once. Forgetting it here
+    /// would leave the cpu and network graphs painted in the previous theme
+    /// while everything around them changed, which looks like a rendering bug
+    /// rather than a missing line.
+    fn apply_theme(&mut self, theme: crate::theme::Theme) {
+        self.config.theme = theme;
+        self.gradients = self.config.theme.gradients();
+    }
+
     /// Turn a widget on or off, rebuilding the dashboard around it.
     fn toggle_widget(&mut self, widget: &str) {
         let before = self.config.layout.clone();
@@ -1031,6 +1113,7 @@ impl App {
                 self.help_scroll = 0;
             }
             KeyCode::Char('w') => self.picker = Some(crate::picker::Picker::new()),
+            KeyCode::Char('t') => self.open_theme_picker(),
             KeyCode::Char('m') => self.enter_arrange(),
             KeyCode::Char(c @ '1'..='9') => {
                 let index = c as usize - '1' as usize;
@@ -1358,6 +1441,9 @@ impl App {
 
         if self.show_help {
             self.render_help(frame, area);
+        }
+        if let Some((picker, _)) = &self.theme_picker {
+            picker.render(frame, area, &self.config.theme);
         }
         if let Some(picker) = &self.picker {
             picker.render(
@@ -2925,6 +3011,107 @@ mod tests {
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// Walk the theme picker down to a named theme and report what it landed on.
+    fn preview_a_theme(app: &mut App) -> String {
+        app.handle_key(key(KeyCode::Char('t')));
+        // Down until the accent actually moves. The list is alphabetical and
+        // starts on `ansi`, whose accent is an ANSI index rather than an RGB
+        // triple, so the first row that differs is a real repaint.
+        let start = app.config.theme.accent;
+        for _ in 0..20 {
+            app.handle_key(key(KeyCode::Down));
+            if app.config.theme.accent != start {
+                break;
+            }
+        }
+        app.config
+            .theme
+            .name
+            .clone()
+            .expect("a previewed theme is a named one")
+    }
+
+    #[test]
+    fn moving_in_the_theme_picker_repaints_before_anything_is_committed() {
+        let mut app = App::new(config_with(&["clocks", "cpu"])).unwrap();
+        let before = app.config.theme.accent;
+        let name = preview_a_theme(&mut app);
+        assert_ne!(
+            app.config.theme.accent, before,
+            "`{name}` was selected but the live theme did not change"
+        );
+        assert!(
+            app.theme_picker.is_some(),
+            "moving must not close the dialog"
+        );
+    }
+
+    /// The graphs read a baked ramp rather than the theme, so a swap that
+    /// forgets it leaves cpu and network painted in the previous palette.
+    #[test]
+    fn a_theme_swap_rebakes_the_gradients_the_graphs_draw_from() {
+        let mut app = App::new(config_with(&["cpu"])).unwrap();
+        let before = app.gradients.clone();
+        preview_a_theme(&mut app);
+        assert_ne!(
+            app.gradients, before,
+            "the graph ramp still holds the previous theme's colours"
+        );
+    }
+
+    #[test]
+    fn esc_puts_back_the_theme_the_picker_opened_on() {
+        let mut app = App::new(config_with(&["clocks", "cpu"])).unwrap();
+        let theme = app.config.theme.clone();
+        let gradients = app.gradients.clone();
+
+        preview_a_theme(&mut app);
+        app.handle_key(key(KeyCode::Esc));
+
+        assert!(app.theme_picker.is_none(), "Esc must close the dialog");
+        assert_eq!(app.config.theme.accent, theme.accent, "theme not restored");
+        assert_eq!(app.gradients, gradients, "gradients not restored");
+    }
+
+    #[test]
+    fn enter_keeps_the_previewed_theme() {
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        let name = preview_a_theme(&mut app);
+        app.handle_key(key(KeyCode::Enter));
+
+        assert!(app.theme_picker.is_none());
+        assert_eq!(
+            app.config.theme.name.as_deref(),
+            Some(name.as_str()),
+            "Enter must keep what was on screen"
+        );
+    }
+
+    /// The dialog owns the keyboard while it is open. Otherwise `q` under the
+    /// cursor quits the dashboard mid-browse, which is invariant 2's rule
+    /// applied to a shell dialog rather than a panel.
+    #[test]
+    fn the_theme_picker_takes_the_keyboard_while_it_is_open() {
+        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
+        app.handle_key(key(KeyCode::Char('t')));
+        let focus = app.focus;
+
+        app.handle_key(key(KeyCode::Tab));
+        assert_eq!(app.focus, focus, "Tab reached the focus ring");
+        app.handle_key(key(KeyCode::Char('w')));
+        assert!(
+            app.picker.is_none(),
+            "`w` opened the panel picker underneath"
+        );
+
+        app.handle_key(key(KeyCode::Char('q')));
+        assert!(
+            !app.should_quit,
+            "`q` quit the dashboard from inside a dialog"
+        );
+        assert!(app.theme_picker.is_none(), "`q` should close the dialog");
     }
 
     #[test]

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -28,7 +28,7 @@ const STEPS: usize = 101;
 ///
 /// Baking the ramp once means drawing a frame is array lookups rather than
 /// per-cell interpolation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Gradient {
     colors: Box<[Color; STEPS]>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -380,6 +380,28 @@ impl Config {
             }
         }
     }
+
+    /// Apply a remembered theme name, if there is one and it still loads.
+    ///
+    /// Separate from [`Config::apply_state`] for the same reason
+    /// [`Config::resolve_theme`] is separate from deserializing: it touches the
+    /// filesystem, and it needs the config's own path to know where to look.
+    ///
+    /// Failure is not an error. A theme file the user has since deleted or
+    /// broken must not stop the dashboard starting — the state file is written
+    /// by mirador and a person who has just made their config unloadable
+    /// deserves a message, but a person whose *remembered* theme has gone
+    /// deserves the config's theme and no drama. The picker will show them the
+    /// list again the next time they press `t`.
+    pub fn apply_state_theme(&mut self, state: &crate::state::UiState, config_path: &Path) {
+        let Some(name) = state.theme.as_deref() else {
+            return;
+        };
+        let dir = crate::themes::user_dir(config_path);
+        if let Ok(theme) = crate::themes::resolve(name, dir.as_deref()) {
+            self.theme = theme;
+        }
+    }
 }
 
 /// Turn a parse failure into an error that says how to fix it.

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -919,7 +919,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 254;
+        const CITED: usize = 264;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod task;
 mod textarea;
 mod textfield;
 mod theme;
+mod theme_picker;
 mod themes;
 mod update;
 mod watch;
@@ -67,6 +68,7 @@ KEYS:
     1 - 9                  Jump straight to a panel
     w                      Choose which panels are shown
     m                      Rearrange the panels
+    t                      Choose a theme
     Ctrl+arrows            Resize the focused panel
     ?                      Show all key bindings, and the version
     q / Ctrl+C             Quit
@@ -190,6 +192,7 @@ fn run() -> Result<()> {
     // difference from this, which is what makes a preference retractable.
     let baseline = crate::state::UiState::from_config(&config);
     config.apply_state(&saved);
+    config.apply_state_theme(&saved, &config_path);
 
     let mouse = config.general.mouse;
     // Started before the terminal is taken over, and off unless the config says

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,21 @@ pub struct UiState {
     pub pomodoro_short_break_minutes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pomodoro_long_break_minutes: Option<u64>,
+    /// `t` in the dashboard.
+    ///
+    /// A theme name and not a set of colours: the picker offers names, and
+    /// storing the resolved palette would freeze a copy of a theme file the
+    /// user can still edit.
+    ///
+    /// This is the one preference with an obvious case for living in the config
+    /// instead — people do curate their theme. It is here anyway, because the
+    /// config's `[theme]` may be an inline table rather than a name, and
+    /// swapping a whole table for a scalar is a textual edit far more likely to
+    /// mangle a config than the single-line `[layout]` rewrites are. The user
+    /// who wants it in the config can still write it there; this only records
+    /// that they pressed `t`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
 }
 
 impl UiState {
@@ -107,6 +122,10 @@ impl UiState {
             pomodoro_focus_minutes: Some(config.pomodoro.focus_minutes),
             pomodoro_short_break_minutes: Some(config.pomodoro.short_break_minutes),
             pomodoro_long_break_minutes: Some(config.pomodoro.long_break_minutes),
+            // `None` when the config carries an inline `[theme]` table, which
+            // is right: such a config names no theme, so *any* name the picker
+            // returns is a change from it.
+            theme: config.theme.name.clone(),
         }
     }
 
@@ -141,6 +160,7 @@ impl UiState {
             pomodoro_focus_minutes,
             pomodoro_short_break_minutes,
             pomodoro_long_break_minutes,
+            theme,
         );
         self
     }
@@ -215,6 +235,7 @@ mod tests {
             pomodoro_focus_minutes: Some(30),
             pomodoro_short_break_minutes: Some(7),
             pomodoro_long_break_minutes: Some(20),
+            theme: Some("nord".into()),
         };
         state.save(&path).unwrap();
         assert_eq!(UiState::load(&path), state);
@@ -328,6 +349,41 @@ mod tests {
             reported.only_changes_from(&baseline),
             UiState::default(),
             "a dashboard nobody has touched wrote something to its state file"
+        );
+    }
+
+    /// `a_dashboard_nobody_has_touched_writes_nothing` cannot see this field.
+    /// A default config carries an inline `[theme]` table and so names no
+    /// theme, which leaves baseline and reported both `None` — equal whether
+    /// or not `theme` is in `only_changes_from`'s list. So the case is made
+    /// here explicitly, with a name on both sides.
+    ///
+    /// Worth the separate test: that list is hand-written, and a field left out
+    /// of it is a preference that can be set once and never retracted.
+    #[test]
+    fn a_theme_matching_the_config_is_not_recorded() {
+        let baseline = UiState {
+            theme: Some("nord".into()),
+            ..UiState::default()
+        };
+        let reported = UiState {
+            theme: Some("nord".into()),
+            ..UiState::default()
+        };
+        assert_eq!(
+            reported.only_changes_from(&baseline).theme,
+            None,
+            "picking the theme the config already names must retract the entry"
+        );
+
+        let moved = UiState {
+            theme: Some("gruvbox".into()),
+            ..UiState::default()
+        };
+        assert_eq!(
+            moved.only_changes_from(&baseline).theme,
+            Some("gruvbox".into()),
+            "a theme that differs from the config must be remembered"
         );
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -245,7 +245,11 @@ pub fn de_theme<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Theme, D::
 }
 
 /// Gradients baked once at startup, so drawing a frame is array lookups.
-#[derive(Debug)]
+///
+/// `PartialEq` is here for the tests that check a theme swap rebaked this —
+/// it is the one thing in the dashboard that does not read `Theme` at draw
+/// time, so it is the one thing a swap can forget.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Gradients {
     pub cpu: Gradient,
     pub rx: Gradient,

--- a/src/theme_picker.rs
+++ b/src/theme_picker.rs
@@ -1,0 +1,380 @@
+//! The `t` dialog: every theme mirador can find, previewed as you move.
+//!
+//! Same shape as [`crate::picker`] — it owns its cursor and its drawing and
+//! nothing else, and reports what it wants via an [`Action`] so the shell keeps
+//! the decisions. What is different is that moving the cursor is itself an
+//! action here. A theme you cannot see is a theme you cannot choose, and the
+//! alternative — pick blind, close, look, reopen — is how you end up cycling
+//! through nine themes to find the one you already had.
+//!
+//! That makes `Esc` load-bearing rather than decorative: it puts back whatever
+//! was in force when the dialog opened, so browsing costs nothing. `Enter`
+//! keeps what is under the cursor.
+//!
+//! The list is read from disk **once, when the dialog opens**. A directory
+//! listing on every frame would be the panels' no-blocking rule broken by the
+//! shell instead of by a widget, and the set of themes does not change while
+//! you are looking at it.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use std::path::Path;
+
+use crate::theme::Theme;
+
+/// What a keypress asked the shell to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    /// Nothing the shell needs to act on.
+    None,
+    /// Show this theme now. Sent on every cursor move, not only on Enter.
+    Preview(String),
+    /// Close, keeping whatever is currently previewed.
+    Accept,
+    /// Close, putting back the theme that was in force when this opened.
+    Cancel,
+}
+
+/// How many rows of the list are on screen at once.
+///
+/// Nine bundled themes plus however many the user wrote is already more than
+/// fits comfortably in a dialog, so this scrolls rather than growing.
+const ROWS: usize = 12;
+
+/// An open theme picker.
+#[derive(Debug)]
+pub struct ThemePicker {
+    names: Vec<String>,
+    /// How many of `names` came from the bundled set, so the rest can be
+    /// labelled as the user's own.
+    bundled: usize,
+    selected: usize,
+    offset: usize,
+}
+
+impl ThemePicker {
+    /// Open on `current`, listing the bundled themes and any in `themes_dir`.
+    ///
+    /// A user theme that shares a bundled name appears once: `themes::resolve`
+    /// searches the directory first, so the file on disk is the one that would
+    /// load, and showing both would offer a choice that does not exist.
+    pub fn new(current: Option<&str>, themes_dir: Option<&Path>) -> Self {
+        let mut names: Vec<String> = crate::themes::bundled_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        names.sort_unstable();
+        let bundled = names.len();
+
+        let mut mine = themes_dir.map(user_themes).unwrap_or_default();
+        mine.retain(|name| !names.contains(name));
+        mine.sort_unstable();
+        names.extend(mine);
+
+        // Landing on the theme in force is the whole reason the dialog knows
+        // what it is. A config with an inline `[theme]` table has no name, so
+        // there is nothing to land on and the top of the list is as good as
+        // anywhere.
+        let selected = current
+            .and_then(|name| names.iter().position(|listed| listed == name))
+            .unwrap_or(0);
+
+        let mut picker = Self {
+            names,
+            bundled,
+            selected,
+            offset: 0,
+        };
+        picker.scroll_into_view();
+        picker
+    }
+
+    /// The themes available, for tests.
+    #[cfg(test)]
+    pub fn names(&self) -> &[String] {
+        &self.names
+    }
+
+    /// The name under the cursor, if the list is not empty.
+    pub fn current(&self) -> Option<&str> {
+        self.names.get(self.selected).map(String::as_str)
+    }
+
+    /// Which row the cursor is on. Exposed for tests.
+    #[cfg(test)]
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    /// Move the cursor, or report what the shell has to do.
+    pub fn handle_key(&mut self, key: KeyEvent) -> Action {
+        let last = self.names.len().saturating_sub(1);
+        let moved = match key.code {
+            KeyCode::Enter | KeyCode::Char(' ') => return Action::Accept,
+            // `t` closes the dialog the same way it opened it, and `q` is the
+            // habit everything else in mirador has taught. Both cancel rather
+            // than accept, because both are reflexes rather than decisions —
+            // the one key that keeps a theme is the one you have to mean.
+            KeyCode::Esc | KeyCode::Char('q' | 't') => return Action::Cancel,
+            KeyCode::Down | KeyCode::Char('j') => self.selected.saturating_add(1).min(last),
+            KeyCode::Up | KeyCode::Char('k') => self.selected.saturating_sub(1),
+            KeyCode::Home => 0,
+            KeyCode::End => last,
+            KeyCode::PageDown => self.selected.saturating_add(ROWS).min(last),
+            KeyCode::PageUp => self.selected.saturating_sub(ROWS),
+            _ => return Action::None,
+        };
+
+        if moved == self.selected {
+            return Action::None;
+        }
+        self.selected = moved;
+        self.scroll_into_view();
+        self.current()
+            .map_or(Action::None, |n| Action::Preview(n.to_string()))
+    }
+
+    /// Keep the cursor inside the visible window.
+    fn scroll_into_view(&mut self) {
+        if self.selected < self.offset {
+            self.offset = self.selected;
+        } else if self.selected >= self.offset + ROWS {
+            self.offset = self.selected + 1 - ROWS;
+        }
+    }
+
+    /// Draw the dialog centred over whatever is behind it.
+    pub fn render(&self, frame: &mut ratatui::Frame, area: Rect, theme: &Theme) {
+        let width = 44u16.min(area.width);
+        let rows = u16::try_from(self.names.len().min(ROWS)).unwrap_or(u16::MAX);
+        // List, the two frame rows, the blank row and the footer. Nothing more:
+        // a spare row inside the border reads as a list that has run out rather
+        // than as breathing space.
+        let height = rows.saturating_add(4).min(area.height);
+        let rect = Rect {
+            x: area.x + (area.width.saturating_sub(width)) / 2,
+            y: area.y + (area.height.saturating_sub(height)) / 2,
+            width,
+            height,
+        };
+
+        let mut lines: Vec<Line<'static>> = Vec::with_capacity(self.names.len() + 2);
+        for (index, name) in self.names.iter().enumerate().skip(self.offset).take(ROWS) {
+            let chosen = index == self.selected;
+            let marker = if chosen { "▸ " } else { "  " };
+            let style = if chosen {
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.text)
+            };
+            let mut spans = vec![
+                Span::styled(marker, Style::default().fg(theme.accent)),
+                Span::styled(name.clone(), style),
+            ];
+            if index >= self.bundled {
+                spans.push(Span::styled("  yours", Style::default().fg(theme.muted)));
+            }
+            lines.push(Line::from(spans));
+        }
+
+        lines.push(Line::default());
+        lines.push(Line::from(vec![
+            Span::styled(
+                crate::glyphs::utility("enter"),
+                Style::default().fg(theme.key).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" keep  ", Style::default().fg(theme.muted)),
+            Span::styled(
+                crate::glyphs::utility("esc"),
+                Style::default().fg(theme.key).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" put back", Style::default().fg(theme.muted)),
+        ]));
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.border_focused))
+            .padding(Padding::horizontal(1))
+            .title(Line::from(vec![
+                Span::styled("┤", Style::default().fg(theme.border_focused)),
+                Span::styled(
+                    crate::glyphs::utility("theme"),
+                    Style::default()
+                        .fg(theme.title)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("├", Style::default().fg(theme.border_focused)),
+            ]));
+
+        frame.render_widget(Clear, rect);
+        frame.render_widget(Paragraph::new(lines).block(block), rect);
+    }
+}
+
+/// Theme names in `dir`, from `*.toml` files.
+///
+/// Anything the resolver would refuse is left out rather than listed and then
+/// rejected on selection: a name with a slash or a space in it cannot be loaded
+/// by name at all, so offering it would be offering a dead end.
+fn user_themes(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension()? != "toml" {
+                return None;
+            }
+            let name = path.file_stem()?.to_str()?.to_string();
+            crate::themes::is_listable(&name).then_some(name)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use std::path::PathBuf;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::from(code)
+    }
+
+    /// A directory of its own per test. Sharing one is how the zone tests came
+    /// to read each other's files on Windows.
+    struct TempDir(PathBuf);
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn themes_dir(name: &str) -> TempDir {
+        let dir =
+            std::env::temp_dir().join(format!("mirador-picker-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("test directory");
+        TempDir(dir)
+    }
+
+    fn write(dir: &Path, name: &str) {
+        std::fs::write(dir.join(format!("{name}.toml")), "accent = \"red\"\n").expect("write");
+    }
+
+    #[test]
+    fn it_opens_on_the_theme_already_in_force() {
+        let picker = ThemePicker::new(Some("nord"), None);
+        assert_eq!(picker.current(), Some("nord"));
+    }
+
+    #[test]
+    fn an_inline_theme_table_has_no_name_to_land_on_and_starts_at_the_top() {
+        let picker = ThemePicker::new(None, None);
+        assert_eq!(picker.selected(), 0);
+    }
+
+    #[test]
+    fn moving_the_cursor_previews_rather_than_waiting_for_enter() {
+        let mut picker = ThemePicker::new(Some("ansi"), None);
+        let first = picker.current().expect("a name").to_string();
+        let action = picker.handle_key(key(KeyCode::Down));
+        let Action::Preview(name) = action else {
+            panic!("a cursor move must preview, got {action:?}");
+        };
+        assert_ne!(name, first, "the preview is the row moved to");
+        assert_eq!(picker.current(), Some(name.as_str()));
+    }
+
+    #[test]
+    fn the_cursor_stops_at_both_ends_without_previewing_again() {
+        let mut picker = ThemePicker::new(None, None);
+        assert_eq!(picker.handle_key(key(KeyCode::Up)), Action::None);
+        picker.handle_key(key(KeyCode::End));
+        assert_eq!(picker.handle_key(key(KeyCode::Down)), Action::None);
+    }
+
+    #[test]
+    fn enter_keeps_and_esc_puts_back() {
+        let mut picker = ThemePicker::new(None, None);
+        assert_eq!(picker.handle_key(key(KeyCode::Enter)), Action::Accept);
+        assert_eq!(picker.handle_key(key(KeyCode::Esc)), Action::Cancel);
+        assert_eq!(picker.handle_key(key(KeyCode::Char('t'))), Action::Cancel);
+        assert_eq!(picker.handle_key(key(KeyCode::Char('q'))), Action::Cancel);
+    }
+
+    /// The bug the clock's zone picker shipped with: the cursor walked past the
+    /// bottom of the window and the list stopped following it.
+    #[test]
+    fn the_window_follows_the_cursor_past_the_bottom_of_the_list() {
+        let dir = themes_dir("scroll");
+        for i in 0..20 {
+            write(&dir.0, &format!("mine-{i:02}"));
+        }
+        let mut picker = ThemePicker::new(None, Some(&dir.0));
+        assert!(picker.names().len() > ROWS, "needs more rows than fit");
+
+        for _ in 0..picker.names().len() {
+            picker.handle_key(key(KeyCode::Down));
+            assert!(
+                picker.selected() >= picker.offset && picker.selected() < picker.offset + ROWS,
+                "cursor {} left the window at offset {}",
+                picker.selected(),
+                picker.offset
+            );
+        }
+    }
+
+    #[test]
+    fn a_user_theme_shadowing_a_bundled_name_is_listed_once() {
+        let dir = themes_dir("shadow");
+        write(&dir.0, "nord");
+        let picker = ThemePicker::new(None, Some(&dir.0));
+        let nords = picker.names().iter().filter(|n| *n == "nord").count();
+        assert_eq!(nords, 1, "the file on disk is the one that would load");
+    }
+
+    /// A name the resolver would refuse must not be offered, or selecting it is
+    /// a dead end the user cannot diagnose.
+    #[test]
+    fn a_file_the_resolver_could_never_load_is_not_offered() {
+        let dir = themes_dir("unlistable");
+        write(&dir.0, "has space");
+        write(&dir.0, "fine-one");
+        let picker = ThemePicker::new(None, Some(&dir.0));
+        assert!(picker.names().iter().any(|n| n == "fine-one"));
+        assert!(
+            !picker.names().iter().any(|n| n.contains(' ')),
+            "got: {:?}",
+            picker.names()
+        );
+    }
+
+    #[test]
+    fn a_missing_themes_directory_is_not_an_error() {
+        let picker = ThemePicker::new(None, Some(Path::new("/nope/not/here")));
+        assert_eq!(picker.names().len(), crate::themes::bundled_names().len());
+    }
+
+    #[test]
+    fn it_draws_without_panicking_in_a_small_terminal() {
+        for (w, h) in [(80, 24), (30, 10), (10, 5)] {
+            let mut terminal = Terminal::new(TestBackend::new(w, h)).expect("terminal");
+            let picker = ThemePicker::new(None, None);
+            terminal
+                .draw(|f| picker.render(f, f.area(), &Theme::default()))
+                .expect("draw");
+        }
+    }
+}

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -2,9 +2,16 @@
 //!
 //! The `[theme]` table has always let you set every colour. What it could not
 //! do is let you *keep* more than one set of them, or hand one to somebody
-//! else. A theme is a file now: four ship inside the binary, and anything in
+//! else. A theme is a file now: ten ship inside the binary, and anything in
 //! `<config>/mirador/themes/<name>.toml` is found first, so a bundled theme can
 //! be replaced without editing it in place.
+//!
+//! Six of the ten are ports of palettes from elsewhere — Nord, Gruvbox,
+//! Dracula, Catppuccin Mocha, Tokyo Night, Solarized Dark. Each file cites the
+//! upstream source its hex values came from, and each is a port rather than an
+//! interpretation: someone who picks `nord` wants Nord, not mirador's opinion
+//! of it. Adjust the *mapping* of a palette onto mirador's keys if it reads
+//! badly; do not adjust the palette.
 //!
 //! Two things make a theme file short. `inherits` names another theme to start
 //! from, so a variant is the handful of lines that differ rather than a copy of
@@ -50,6 +57,24 @@ const BUNDLED: &[(&str, &str)] = &[
         include_str!("../assets/themes/high-contrast.toml"),
     ),
     ("ansi", include_str!("../assets/themes/ansi.toml")),
+    // The community palettes. These are ports, not originals — each file cites
+    // the upstream source it took its hex values from, and none of them should
+    // be "improved" away from it. Someone picking `nord` wants Nord.
+    ("nord", include_str!("../assets/themes/nord.toml")),
+    ("gruvbox", include_str!("../assets/themes/gruvbox.toml")),
+    ("dracula", include_str!("../assets/themes/dracula.toml")),
+    (
+        "catppuccin-mocha",
+        include_str!("../assets/themes/catppuccin-mocha.toml"),
+    ),
+    (
+        "tokyo-night",
+        include_str!("../assets/themes/tokyo-night.toml"),
+    ),
+    (
+        "solarized-dark",
+        include_str!("../assets/themes/solarized-dark.toml"),
+    ),
 ];
 
 /// How deep an `inherits` chain may go before it is treated as a mistake.
@@ -136,6 +161,15 @@ fn is_plain_name(name: &str) -> bool {
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Whether a file in the themes directory can be offered in the picker.
+///
+/// The same rule [`read`] enforces, exposed so the picker can leave a file out
+/// rather than list it and fail on selection. A name mirador cannot look up is
+/// not a theme the user has; it is a file they will have to rename.
+pub fn is_listable(name: &str) -> bool {
+    is_plain_name(name)
 }
 
 /// Read one theme document, preferring the user's copy.
@@ -477,8 +511,16 @@ mod tests {
 
     #[test]
     fn an_unknown_name_lists_what_is_available() {
-        let err = format!("{:#}", resolve("nord", None).expect_err("must fail"));
-        assert!(err.contains("no theme called `nord`"), "got: {err}");
+        // Deliberately not the name of a real palette. This test used to ask
+        // for `nord`, which stopped being unknown the day nord shipped.
+        let err = format!(
+            "{:#}",
+            resolve("no-such-theme", None).expect_err("must fail")
+        );
+        assert!(
+            err.contains("no theme called `no-such-theme`"),
+            "got: {err}"
+        );
         for name in bundled_names() {
             assert!(err.contains(name), "`{name}` missing from: {err}");
         }


### PR DESCRIPTION
Ten themes now ship inside the binary. Four are mirador's own (`default`, `default-light`, `high-contrast`, `ansi`); six are ports of palettes people are likely already running in their editor, terminal or multiplexer:

| Theme | Source |
| --- | --- |
| `nord` | [nordtheme.com](https://www.nordtheme.com/docs/colors-and-palettes) |
| `gruvbox` | [morhetz/gruvbox](https://github.com/morhetz/gruvbox) |
| `dracula` | [spec.draculatheme.com](https://spec.draculatheme.com/) |
| `catppuccin-mocha` | [catppuccin/catppuccin](https://github.com/catppuccin/catppuccin) |
| `tokyo-night` | Tokyo Night Storm |
| `solarized-dark` | [ethanschoonover.com/solarized](https://ethanschoonover.com/solarized/) |

Each file cites its source. These are ports, not reinterpretations — adjust how a palette maps onto mirador's keys if it reads badly, never the palette. All six keep `text = "reset"`, so body text still follows the terminal's own foreground.

## The picker

`t` opens a list of every theme mirador can find, the user's own included and marked. **It previews as the cursor moves** — a theme you cannot see is a theme you cannot choose. `Enter` keeps what is on screen, `Esc` puts back what the dialog opened on.

Live preview is cheap because every theme read happens at draw time from `config.theme`. The one exception is the baked 101-entry gradient ramp the cpu and network graphs use; `apply_theme` re-derives it in the same place, and a test pins that, because forgetting it leaves two graphs in the previous palette while everything around them changes.

## Where the choice is kept

`state.rs`, not the config — a deliberate departure from the `[layout]` precedent. `theme` may be a string *or* an inline table, and swapping a table for a scalar is a textual rewrite with no equivalent of `layout_edit::apply`'s re-parse-and-verify check. The config keeps seeding; `t` records where the user moved. The README and shipped config both say a config `theme` that appears ignored means a state file outranking it.

Invariant 17 holds by construction: the baseline is `config.theme.name` taken before `apply_state_theme`, so picking the theme the config already names retracts the entry.

## Verification

- 587 tests, `clippy -D warnings`, `fmt --check` and `rustdoc -D warnings` all clean.
- Driven under tmux against a real terminal. Each theme's dominant colours match its published palette exactly; `Esc` restores brass/verdigris/slate byte for byte; `Enter` survives a restart.
- Nord and Solarized first shipped with `border` and `muted` on the same value — secondary text as dim as the chrome. Caught in the terminal capture, not by a test, and split.
- `a_theme_matching_the_config_is_not_recorded` was verified by removing the `only_changes_from` entry and watching it go red. The existing coverage test cannot see this field: a default config names no theme, so both sides are `None` regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)