### PR TITLE
Point the release note at the release that exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -866,8 +866,10 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`0.7.1` is released**, on crates.io and as a GitHub release with binaries
-  for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. `0.0.0` is still on
+- **`0.15.0` is released**, on crates.io and as a GitHub release with binaries
+  for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
+  stale every release and is worth a glance before you trust anything near it;
+  `git tag --list 'v*' | sort -V | tail -1` is the truth. `0.0.0` is still on
   crates.io below it — the name reservation that went out first, since
   reservation is first-come with no reclamation.
 


### PR DESCRIPTION
`CLAUDE.md` had claimed 0.7.1 was the current release since 0.7.1 — through eight of them. Updated to 0.15.0, and named the command that answers the question so the next reader checks rather than believes a line that goes stale by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)