### PR TITLE
Fix six defects in the text-input modules, and drop the unused-widget notice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 264 of them, including the ones mirador
+    trip through `toml` discards all 269 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -319,6 +319,23 @@ anything on fire" signal.
 
 **Rejected:** unread email/message counts. Looks like information, is a
 doomscroll hook, turns a calm dashboard into a nagging one.
+
+**Also rejected, after shipping it: the unused-widget notice.** A line in the
+status bar and a section in the help overlay naming the widgets your layout
+does not place. Removed at the owner's request, and the reason generalises:
+*a dashboard cannot tell "has not discovered this yet" from "decided against
+it"*, so a hint aimed at the first group reminds the second group for ever.
+The status bar half retired on the first keypress; the help overlay half did
+not, and that is the one that grated — press `?` and be told about four panels
+you deliberately switched off, every time.
+
+This is the unread-badge rejection reached from the direction of helpfulness
+rather than of notifications, which is exactly why it got built. `w` remains a
+primary binding, so the *capability* is still one keystroke and on the status
+bar; what is gone is being told you should use it.
+`a_layout_missing_widgets_is_not_advertised_anywhere` renders the dashboard and
+the help overlay at 200x40 with eleven widgets unplaced and fails on the word
+"unused".
 
 **Calendar must be independent** — no connecting to the user's mail or calendar
 server. Read a local `.ics` file or a plain events file.

--- a/README.md
+++ b/README.md
@@ -259,18 +259,14 @@ an obvious way back.
 **A new widget will not appear in a config you already have.** A config written
 by an earlier version lays out exactly the panels that existed when it was
 written, and nothing since. Leaving a panel out is a legitimate choice, so this
-cannot be an error and cannot be decided for you.
+cannot be an error and cannot be decided for you — and mirador does not tell
+you about it either. It used to, in the status bar and in the help overlay, and
+that was a mistake in the same family as an unread badge: a dashboard cannot
+tell "hasn't discovered this yet" from "decided against it", and it was
+reminding the second group for ever.
 
-You get a notice on the right of the status bar naming what your layout does
-not place, and telling you which key fixes it:
-
-```
- mirador   Tab focus   ? keys   q quit   w panels        1 unused: pomodoro   press w
-```
-
-It retires on your first keypress, because a dashboard you leave open all day
-must not nag; `?` keeps it in the help overlay. Press `w` and you get the
-picker:
+Press `w` — a key that is on the status bar and in the help — to see every
+widget mirador has and which of them your layout places:
 
 ```
 ╭PANELS────────────────────────────────╮
@@ -304,9 +300,9 @@ and leaves a backup beside the original.
 
 ## The panels
 
-Ten widgets, each answering one question. Put the ones you want in the
-layout and drop the rest — an unused widget costs nothing but is also not
-built.
+Twelve widgets, each answering one question. Put the ones you want in the
+layout and drop the rest — a widget your layout leaves out is never built, and
+nothing will nag you about it.
 
 ### Tasks
 
@@ -418,14 +414,23 @@ is not. Columns drop as the panel narrows, in the order that costs you least.
 A watchlist with the last price, the day's change, and an intraday sparkline.
 
 ```
-╭┤1 Markets├──────────────────────────────────────────────────────────────┤3├╮
+╭┤1 Markets├──────────────────────────────────────────────────────────────┤7├╮
 │   SYMBOL         LAST       CHG        % TODAY                             │
-│ ▸ AAPL         333.02    +11.36   +3.53% ▂▄▅▆▇█▇▇▇▇▇▇                      │
-│   MSFT         381.70     +0.12   +0.03% ▄▃▅▇▆▇▆▆▇▆▆▃                      │
-│   ^GSPC       7411.98     +3.68   +0.05% ▃▃▃▆▇▇▅▆▅▂▁▂                      │
+│ ▸ ^GSPC       7413.18     +1.20   +0.02% ▇▄▃▃▂▃▂▁▂▂▃▃                      │
+│   ^DJI       52210.08   +262.83   +0.51% ▇▅▃▃▂▂▂▂▂▂▃▄                      │
+│   ^IXIC      24932.08    -43.74   -0.18% ▇▄▃▃▂▃▂▂▂▂▄▄                      │
+│   ^RUT        2948.03    +18.04   +0.62% ▇▄▃▃▂▃▂▂▃▃▄▄                      │
+│   ^NDX       28039.21    -89.13   -0.32% ▇▄▃▃▂▃▂▂▃▂▄▄                      │
+│   AAPL         336.91     +3.89   +1.17% ▂▄▅▇▅▅▃▃▂▂▂▄                      │
+│   MSFT         389.10     +7.40   +1.94% ▃▄▂▆▃▃▄▅▇▇▆▂                      │
 │ via yahoo                                                                  │
 ╰─────────────────────── a add · d remove · r refresh ───────────────────────╯
 ```
+
+The default watchlist is the five major US indexes — S&P 500, Dow, Nasdaq
+Composite, Russell 2000 and Nasdaq-100 — plus two ordinary stocks, so the panel
+shows both kinds on a first run. `^VIX` is the volatility index if you want it,
+and `EURUSD=X` and `BTC-USD` work too.
 
 `a` adds a symbol and `d` removes one, and those edits stick — the watchlist
 is a data file rather than config, which is what lets the panel own it. See

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -238,6 +238,11 @@ preview     = "below"        # below | beside
 # Last price, the day's change, and an intraday sparkline. `a` adds a symbol,
 # `d` removes one, `r` refreshes now.
 #
+# The default is the five major US indexes — S&P 500, Dow, Nasdaq Composite,
+# Russell 2000 and Nasdaq-100 — followed by two ordinary stocks, so the panel
+# shows both kinds out of the box. `^VIX` is the volatility index if you want
+# it; `EURUSD=X` and `BTC-USD` also work.
+#
 # `symbols` seeds the watchlist on the FIRST RUN ONLY. After that the watchlist
 # file is the truth, so symbols you add or remove in the UI stick. Only symbols
 # are stored — prices are never written to disk, because a stale price read as
@@ -254,7 +259,7 @@ preview     = "below"        # below | beside
 # unauthenticated; hammering them gets the address blocked for everyone on it.
 # ---------------------------------------------------------------------------
 [stocks]
-symbols        = ["AAPL", "MSFT", "^GSPC"]
+symbols        = ["^GSPC", "^DJI", "^IXIC", "^RUT", "^NDX", "AAPL", "MSFT"]
 # file         = "~/notes/watchlist.toml"
 source         = "yahoo"
 refresh_secs   = 120

--- a/src/app.rs
+++ b/src/app.rs
@@ -262,11 +262,9 @@ pub struct App {
     /// A config written by an earlier version silently lacks every widget added
     /// since — an absent widget is a valid choice, so nothing errors and
     /// `--migrate-config` has nothing to fix. This is the only way to find out.
-    unused_widgets: Vec<&'static str>,
     /// Whether the startup hint is still on screen. Cleared by the first input
     /// of any kind: a dashboard you leave open all day must not nag, and a
     /// notice that will not go away is a nag.
-    show_widget_hint: bool,
     /// A newer version, if the opt-in check found one. Empty otherwise, and
     /// empty always when the check is off — `App` never starts it, so no test
     /// and no `--print-config` run can reach the network.
@@ -345,7 +343,6 @@ impl App {
         let (slots, positions) = Self::build_slots(&config)?;
 
         let gradients = config.theme.gradients();
-        let unused_widgets = crate::widgets::unused_widgets(&config);
         Ok(Self {
             config,
             gradients,
@@ -357,10 +354,8 @@ impl App {
             help_overflow: 0,
             help_viewport: 0,
             should_quit: false,
-            show_widget_hint: !unused_widgets.is_empty(),
             update: crate::update::Found::default(),
             show_update_hint: true,
-            unused_widgets,
             watch: crate::watch::WatchLog::default(),
             today: jiff::Zoned::now().date(),
             picker: None,
@@ -532,7 +527,6 @@ impl App {
             .unwrap_or_else(|| self.focus.min(slots.len().saturating_sub(1)));
         self.slots = slots;
         self.positions = positions;
-        self.unused_widgets = crate::widgets::unused_widgets(&self.config);
         Ok(())
     }
 
@@ -746,7 +740,6 @@ impl App {
     fn handle_key(&mut self, key: KeyEvent) {
         // Any key at all retires the startup hint. It has been read or it has
         // been ignored; either way it has had its turn.
-        self.show_widget_hint = false;
         self.show_update_hint = false;
         // A keypress is weaker evidence than a focus event — the moments this
         // most wants to be right are the glances that touch nothing — but it is
@@ -1234,8 +1227,7 @@ impl App {
         // A deliberate click or scroll retires the startup hint, as a key does.
         // Pointer motion deliberately does not: the mouse crossing the window
         // on its way somewhere else is not the user reading anything.
-        let had_hint =
-            std::mem::take(&mut self.show_widget_hint) | std::mem::take(&mut self.show_update_hint);
+        let had_hint = std::mem::take(&mut self.show_update_hint);
 
         // The help overlay swallows the next input, whatever it is — the same
         // rule keys follow.
@@ -1559,7 +1551,7 @@ impl App {
         // The hint rides on the right of the bar it shares with the global
         // keys, and gives way to them when the terminal is too narrow: knowing
         // how to quit matters more than knowing what you are not using.
-        if let Some(hint) = self.update_hint().or_else(|| self.widget_hint()) {
+        if let Some(hint) = self.update_hint() {
             let used: usize = spans
                 .iter()
                 .map(|s| crate::grid::display_width(&s.content))
@@ -1631,21 +1623,6 @@ impl App {
         Some(format!("mirador {latest} is out   mirador-update "))
     }
 
-    fn widget_hint(&self) -> Option<String> {
-        if !self.show_widget_hint || self.unused_widgets.is_empty() {
-            return None;
-        }
-        // Names the key rather than only the widgets. Saying what is missing
-        // without saying what to do about it is how someone ends up reading the
-        // help, not finding the answer there either, and going to look for a
-        // config file.
-        Some(format!(
-            "{} unused: {}   press w ",
-            self.unused_widgets.len(),
-            self.unused_widgets.join(", ")
-        ))
-    }
-
     fn render_help(&mut self, frame: &mut ratatui::Frame, area: Rect) {
         let theme = self.config.theme.clone();
         let theme = &theme;
@@ -1679,27 +1656,6 @@ impl App {
                 lines.push(section(&slot.panel.title()));
                 lines.extend(panel_keys.iter().map(entry));
             }
-        }
-
-        // The durable half of the unused-widget hint. The status bar notice is
-        // gone after one keypress; this stays, because `?` is where someone
-        // goes when they wonder what else the thing does.
-        if !self.unused_widgets.is_empty() {
-            lines.push(Line::from(""));
-            lines.push(section("widgets not in your layout"));
-            // The actionable line comes before the list because it is the more
-            // useful of the two if only one is on screen. The names go on one
-            // wrapped line because one line per widget cost eight rows on a
-            // stale config.
-            lines.push(Line::from(vec![
-                Span::styled("  press ", muted),
-                Span::styled("w", key_style),
-                Span::styled(" to switch them on", muted),
-            ]));
-            lines.push(Line::from(Span::styled(
-                format!("  {}", self.unused_widgets.join(", ")),
-                Style::default().fg(theme.text),
-            )));
         }
 
         // The footer is rendered separately and pinned to the last row, rather
@@ -2082,18 +2038,24 @@ mod tests {
         );
     }
 
-    /// An alert outranks both hints. Neither of those is going to get worse
-    /// while you read the other one.
+    /// An alert outranks the update notice. That notice is not going to get
+    /// worse while you read the alert; the alert might.
     #[test]
     fn an_alert_displaces_the_hints_rather_than_queueing_behind_them() {
         let mut app = App::new(config_with(&["clocks"])).expect("builds");
+        app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
+            "9.9.9".to_string(),
+        ))));
         let before = status_bar_at(&mut app, 200);
-        assert!(before.contains("unused"), "the hint is there to displace");
+        assert!(before.contains("9.9.9"), "the notice is there to displace");
 
         app.layout_error = Some("disk full".into());
         let after = status_bar_at(&mut app, 200);
         assert!(after.contains("disk full"), "the alert shows: {after}");
-        assert!(!after.contains("unused"), "and the hint gives way: {after}");
+        assert!(
+            !after.contains("9.9.9"),
+            "and the notice gives way: {after}"
+        );
     }
 
     #[test]
@@ -2319,57 +2281,69 @@ mod tests {
     }
 
     #[test]
-    fn an_update_notice_displaces_the_widget_hint_rather_than_sharing_the_row() {
-        // Both want the right-hand end of the status bar. The update notice is
-        // rarer and stops being true once acted on, so it wins; the widget hint
-        // is unchanged every launch until the layout changes.
+    fn the_update_notice_has_the_end_of_the_status_bar_to_itself() {
+        // It used to share the row with a hint listing the widgets your layout
+        // left out. That hint is gone — see
+        // `a_layout_missing_widgets_is_not_advertised_anywhere` — so the update
+        // notice is the only thing that can appear here.
         let mut app = App::new(config_with(&["clocks"])).unwrap();
-        assert!(app.widget_hint().is_some(), "this layout omits widgets");
-
         app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
             "9.9.9".to_string(),
         ))));
-        let shown = app.update_hint().or_else(|| app.widget_hint()).unwrap();
-        assert!(shown.contains("9.9.9"), "the widget hint won: `{shown}`");
+        let shown = app.update_hint().expect("an update is waiting");
+        assert!(shown.contains("9.9.9"), "got `{shown}`");
     }
 
+    /// A layout that leaves widgets out is a decision, not an oversight.
+    ///
+    /// mirador used to say so — once in the status bar at startup, and for ever
+    /// in the help overlay. The status bar line retired on the first keypress;
+    /// the overlay section did not, so someone who had deliberately switched
+    /// four panels off was told about them every time they pressed `?`. That is
+    /// the nagging this dashboard exists not to do, arrived at from the
+    /// direction of helpfulness rather than of notifications.
+    ///
+    /// `w` is still a primary binding, so the way to switch a panel on is on
+    /// the status bar and in the help. What is gone is being told you *should*.
     #[test]
-    fn a_layout_missing_widgets_says_so_once_and_then_stops() {
+    fn a_layout_missing_widgets_is_not_advertised_anywhere() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // One panel out of twelve, so eleven are unused — the loudest possible
+        // case for the hint that used to be here.
         let mut app = App::new(config_with(&["clocks"])).unwrap();
-        assert!(
-            app.unused_widgets.contains(&"stocks"),
-            "a widget the layout never places must be reported: {:?}",
-            app.unused_widgets
-        );
-        let hint = app.widget_hint().expect("the hint shows at startup");
-        assert!(hint.contains("stocks"), "got `{hint}`");
-
-        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
-        assert!(
-            app.widget_hint().is_none(),
-            "a dashboard left open all day must not keep nagging"
-        );
-    }
-
-    #[test]
-    fn a_layout_using_everything_gets_no_hint_at_all() {
-        let config = Config {
-            layout: LayoutConfig {
-                rows: crate::widgets::WIDGET_NAMES
-                    .iter()
-                    .map(|name| LayoutRow {
-                        height: 1,
-                        panels: vec![LayoutPanel {
-                            widget: (*name).to_string(),
-                            width: 1,
-                        }],
-                    })
-                    .collect(),
-            },
-            ..Config::default()
+        let screen = |app: &mut App, help: bool| -> String {
+            if help {
+                app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+            }
+            let mut terminal = Terminal::new(TestBackend::new(200, 40)).unwrap();
+            terminal.draw(|frame| app.render_for_test(frame)).unwrap();
+            let buffer = terminal.backend().buffer().clone();
+            (0..40)
+                .map(|y| {
+                    (0..200)
+                        .map(|x| buffer[(x, y)].symbol())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
         };
-        let unused = crate::widgets::unused_widgets(&config);
-        assert!(unused.is_empty(), "nothing to suggest: {unused:?}");
+
+        let dashboard = screen(&mut app, false);
+        assert!(
+            !dashboard.contains("unused"),
+            "the dashboard advertises what you chose not to run"
+        );
+
+        let help = screen(&mut app, true);
+        assert!(app.show_help, "the overlay is open");
+        for banned in ["unused", "not in your layout", "switch them on"] {
+            assert!(
+                !help.contains(banned),
+                "the help overlay still nags about unused widgets: found `{banned}`"
+            );
+        }
     }
 
     #[test]
@@ -2384,14 +2358,17 @@ mod tests {
         };
 
         let mut app = App::new(config_with(&["clocks"])).unwrap();
+        app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
+            "9.9.9".to_string(),
+        ))));
         app.handle_mouse(mouse(MouseEventKind::Moved));
         assert!(
-            app.widget_hint().is_some(),
+            app.update_hint().is_some(),
             "the mouse crossing the window is not the user reading anything"
         );
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left)));
-        assert!(app.widget_hint().is_none(), "a deliberate click retires it");
+        assert!(app.update_hint().is_none(), "a deliberate click retires it");
     }
 
     #[test]
@@ -2499,23 +2476,14 @@ mod tests {
     }
 
     #[test]
-    fn the_unused_widget_section_stays_a_fixed_size_however_many_are_unused() {
-        // One line per widget put eight rows into an overlay that clips
-        // silently; the names share a single wrapped line instead.
-        let one = App::new(config_with(&["clocks"])).unwrap();
-        let hint = one.widget_hint().expect("something is unused");
-        assert!(
-            hint.lines().count() == 1,
-            "the status hint must stay one line: `{hint}`"
-        );
-    }
-
-    #[test]
     fn the_hint_gives_way_to_the_global_keys_on_a_narrow_terminal() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
         let mut app = App::new(config_with(&["clocks"])).unwrap();
+        app.watch_for_updates(std::sync::Arc::new(std::sync::Mutex::new(Some(
+            "9.9.9".to_string(),
+        ))));
         let row_text = |app: &mut App, width: u16| -> String {
             let mut terminal = Terminal::new(TestBackend::new(width, 6)).unwrap();
             terminal.draw(|frame| app.render_for_test(frame)).unwrap();
@@ -2523,17 +2491,14 @@ mod tests {
             (0..width).map(|x| buf[(x, 5)].symbol()).collect()
         };
 
-        // Wide enough for the global keys *and* a hint naming every widget
-        // this layout leaves out — which grows by a word every time a widget is
-        // added, so this figure is a floor rather than a round number. It was
-        // 160 until the watch log made the list one name longer than that.
+        // Wide enough for the global keys *and* the notice.
         let wide = row_text(&mut app, 200);
-        assert!(wide.contains("unused"), "wide enough for both: `{wide}`");
+        assert!(wide.contains("9.9.9"), "wide enough for both: `{wide}`");
 
         let narrow = row_text(&mut app, 44);
         assert!(
-            !narrow.contains("unused"),
-            "knowing how to quit outranks the hint: `{narrow}`"
+            !narrow.contains("9.9.9"),
+            "knowing how to quit outranks the notice: `{narrow}`"
         );
         assert!(
             narrow.contains("quit"),
@@ -3203,28 +3168,6 @@ mod tests {
         );
         assert_eq!(app.slots.len(), 1);
         assert!(app.layout_error.is_some(), "and it says why");
-    }
-
-    #[test]
-    fn a_toggle_updates_the_unused_list_the_hint_reads_from() {
-        let mut app = App::new(config_with(&["clocks", "todo"])).unwrap();
-        assert!(app.unused_widgets.contains(&"pomodoro"));
-
-        app.handle_key(key(KeyCode::Char('w')));
-        let index = crate::widgets::WIDGET_NAMES
-            .iter()
-            .position(|n| *n == "pomodoro")
-            .unwrap();
-        for _ in 0..index {
-            app.handle_key(key(KeyCode::Down));
-        }
-        assert_eq!(app.picker_row(), Some(index));
-        app.handle_key(key(KeyCode::Char(' ')));
-
-        assert!(
-            !app.unused_widgets.contains(&"pomodoro"),
-            "switching a widget on must stop it being advertised as missing"
-        );
     }
 
     #[test]

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -158,7 +158,13 @@ pub struct StocksConfig {
 impl Default for StocksConfig {
     fn default() -> Self {
         Self {
-            symbols: vec!["AAPL".into(), "MSFT".into(), "^GSPC".into()],
+            // The major US indexes first, then two ordinary stocks so the
+            // panel shows both kinds on a first run. Kept identical to
+            // `[stocks].symbols` in assets/default_config.toml.
+            symbols: ["^GSPC", "^DJI", "^IXIC", "^RUT", "^NDX", "AAPL", "MSFT"]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
             file: None,
             source: "yahoo".to_string(),
             refresh_secs: 120,

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -62,7 +62,7 @@ pub fn truncate(text: &str, width: usize) -> String {
 }
 
 /// Display width of a single character, treating unprintables as zero-width.
-fn char_width(c: char) -> usize {
+pub fn char_width(c: char) -> usize {
     unicode_width::UnicodeWidthChar::width(c).unwrap_or(0)
 }
 

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -919,7 +919,7 @@ units = "imperial"
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 264;
+        const CITED: usize = 269;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -81,6 +81,15 @@ pub struct Prompt {
     /// The first row on screen. Without it the cursor walked off the bottom of
     /// the window and kept going, invisibly.
     offset: usize,
+    /// The rows matching what has been typed, recomputed only when the text
+    /// changes.
+    ///
+    /// This used to be derived on demand — and `render` derived it too, every
+    /// frame, lowercasing all 143 cities and all 143 identifiers each time. The
+    /// absolute cost was small; the shape was the problem. A dialog must
+    /// allocate in proportion to what is on screen, which is ten rows, not in
+    /// proportion to how large the table behind it happens to be.
+    listed: Vec<&'static crate::zones::Place>,
 }
 
 impl Prompt {
@@ -91,7 +100,7 @@ impl Prompt {
         value: &str,
         completion: Completion,
     ) -> Self {
-        Self {
+        let mut prompt = Self {
             label,
             help,
             field: TextField::with_value(value),
@@ -99,7 +108,10 @@ impl Prompt {
             completion,
             selected: 0,
             offset: 0,
-        }
+            listed: Vec::new(),
+        };
+        prompt.refilter();
+        prompt
     }
 
     /// The list rows matching what has been typed so far.
@@ -109,19 +121,28 @@ impl Prompt {
     /// finds every Asian zone, and `kolkata` finds the identifier directly.
     /// Prefix-only matching would answer half these and is the reason a plain
     /// completion was not enough.
-    pub fn matches(&self) -> Vec<&'static crate::zones::Place> {
+    pub fn matches(&self) -> &[&'static crate::zones::Place] {
+        &self.listed
+    }
+
+    /// Recompute [`Prompt::matches`] from the text as it now stands.
+    ///
+    /// Called when the text changes and at no other time — in particular not
+    /// from `render`, which is the whole point.
+    fn refilter(&mut self) {
         let Completion::Places(places) = self.completion else {
-            return Vec::new();
+            self.listed.clear();
+            return;
         };
         let needle = self.field.trimmed().to_lowercase();
-        places
+        self.listed = places
             .iter()
             .filter(|place| {
                 needle.is_empty()
                     || place.city.to_lowercase().contains(&needle)
                     || place.tz.to_lowercase().contains(&needle)
             })
-            .collect()
+            .collect();
     }
 
     /// Refuse the answer and say why, leaving the text in place to be fixed.
@@ -184,10 +205,24 @@ impl Prompt {
             },
             KeyCode::Tab => {
                 self.complete();
+                self.refilter();
+                Outcome::Editing
+            }
+            // Moving within the text is not editing it, so the list is left
+            // alone. Lumped in with typing, these reset the selection: you
+            // scrolled to row thirty, pressed Left to fix a typo, and the
+            // highlight jumped back to the top of the list.
+            //
+            // Home and End are absent because the arms above claim them
+            // whenever there is a list to move through; they reach the field
+            // only when there is not, and then there is no selection to lose.
+            KeyCode::Left | KeyCode::Right => {
+                self.field.handle_key(key);
                 Outcome::Editing
             }
             _ => {
                 self.field.handle_key(key);
+                self.refilter();
                 // Typing narrows the list under the cursor, so a selection two
                 // rows down would otherwise land on something unrelated — or
                 // past the end of what is left.
@@ -367,8 +402,21 @@ impl Prompt {
         );
 
         // A visible cursor, because a text field without one reads as a label.
-        let x = popup.x + 2 + u16::try_from(cursor).unwrap_or(0);
-        frame.set_cursor_position((x.min(popup.x + popup.width - 2), popup.y + 1));
+        //
+        // Every step of this is saturating, and that is not defensive habit.
+        // `centred` clamps the popup to the screen, so on a terminal one column
+        // wide `popup.width` is 1 and the old `popup.x + popup.width - 2`
+        // underflowed — a panic in a debug build and a wrap to 65535 in a
+        // release one. Reachable by resizing the terminal while a prompt is
+        // open, which is exactly when somebody would.
+        let right = popup
+            .x
+            .saturating_add(popup.width.saturating_sub(crate::frame::FRAME_WIDTH));
+        let x = popup
+            .x
+            .saturating_add(2)
+            .saturating_add(u16::try_from(cursor).unwrap_or(u16::MAX));
+        frame.set_cursor_position((x.min(right), popup.y.saturating_add(1)));
     }
 }
 
@@ -562,6 +610,70 @@ mod tests {
         press(&mut p, KeyCode::Backspace);
         assert!(p.error.is_none(), "typing dismisses the complaint");
         assert_eq!(p.value(), "Europe/Lundo", "and the text is still there");
+    }
+
+    /// `centred` clamps the popup to the screen, so a terminal narrower than
+    /// the dialog produced a popup narrower than the arithmetic assumed:
+    /// `popup.x + popup.width - 2` underflowed at width 1. A panic in a debug
+    /// build, a wrap to 65535 in a release one, and reachable by resizing the
+    /// terminal while the prompt is open.
+    #[test]
+    fn a_terminal_too_small_for_the_dialog_does_not_bring_the_dashboard_down() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        for width in 1..8u16 {
+            for height in 1..8u16 {
+                let mut terminal =
+                    Terminal::new(TestBackend::new(width, height)).expect("terminal");
+                let p = Prompt::new("FILE", "help", "some/long/path.ics", Completion::Paths);
+                terminal
+                    .draw(|f| p.render(f, f.area(), &Theme::default()))
+                    .unwrap_or_else(|e| panic!("{width}x{height} failed to draw: {e}"));
+            }
+        }
+    }
+
+    /// And the same for the variant that draws a list under the field.
+    #[test]
+    fn a_list_prompt_survives_a_tiny_terminal_too() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        for width in 1..8u16 {
+            for height in 1..8u16 {
+                let mut terminal =
+                    Terminal::new(TestBackend::new(width, height)).expect("terminal");
+                let p = Prompt::new("ZONE", "help", "", Completion::Places(crate::zones::PLACES));
+                terminal
+                    .draw(|f| p.render(f, f.area(), &Theme::default()))
+                    .unwrap_or_else(|e| panic!("{width}x{height} failed to draw: {e}"));
+            }
+        }
+    }
+
+    /// Moving the text cursor is not editing the text. Left and Right used to
+    /// fall through to the same arm as typing, which reset the list to the top:
+    /// scroll to row thirty, press Left to fix a typo, lose your place.
+    #[test]
+    fn moving_the_text_cursor_does_not_throw_away_the_list_selection() {
+        let mut p = Prompt::new("ZONE", "help", "", Completion::Places(crate::zones::PLACES));
+        for _ in 0..15 {
+            press(&mut p, KeyCode::Down);
+        }
+        let (selected, offset) = (p.selected, p.offset);
+        assert!(selected > 0, "there is a selection to lose");
+
+        press(&mut p, KeyCode::Left);
+        assert_eq!(p.selected, selected, "Left moved the list");
+        assert_eq!(p.offset, offset, "Left scrolled the list");
+
+        press(&mut p, KeyCode::Right);
+        assert_eq!(p.selected, selected, "Right moved the list");
+
+        // Typing still does reset it, which is the behaviour that was correct.
+        p.handle_key(KeyEvent::from(KeyCode::Char('z')));
+        assert_eq!(p.selected, 0, "typing narrows the list and starts again");
     }
 
     #[test]

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -59,6 +59,10 @@ impl TextArea {
     }
 
     /// Cursor as `(row, column)`, both zero-based and in characters.
+    ///
+    /// Rendering goes through [`TextArea::visible`], which places the caret in
+    /// display cells; this raw accessor is for tests.
+    #[cfg(test)]
     pub fn cursor(&self) -> (usize, usize) {
         (self.row, self.col)
     }
@@ -162,8 +166,14 @@ impl TextArea {
     /// the editor, and swallowing them would trap the user inside the body.
     pub fn handle_key(&mut self, key: KeyEvent) -> bool {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
         match key.code {
-            KeyCode::Char(c) if !ctrl => {
+            // Alt is excluded as well as Ctrl, which it was not: `Alt+x` typed
+            // an `x` into the note. `TextField` had always excluded both, and
+            // two editors sitting side by side disagreeing about what a chord
+            // means is the kind of difference nobody reports and everybody
+            // trips over.
+            KeyCode::Char(c) if !ctrl && !alt => {
                 self.insert(c);
                 true
             }
@@ -216,6 +226,75 @@ impl TextArea {
         // Only ever scrolls far enough to bring the cursor back into view, so
         // the text does not jump when the cursor is already visible.
         self.row.saturating_sub(height - 1)
+    }
+
+    /// Display cells to skip at the left of *every* line, so the caret stays on
+    /// screen in a viewport `width` cells wide.
+    ///
+    /// Shared across all rows rather than computed per row, or the lines shear
+    /// against each other and the block stops reading as a block.
+    ///
+    /// The editor deliberately does not wrap — a soft wrap that moves as you
+    /// type makes the cursor impossible to follow — and for a long time that
+    /// meant a long line simply ran off the right-hand edge, taking the caret
+    /// with it. You could keep typing; you could not see any of it. Not
+    /// wrapping is a decision about *layout*; it was never a decision to stop
+    /// showing people what they are writing.
+    fn h_offset(&self, width: usize) -> usize {
+        if width == 0 {
+            return 0;
+        }
+        let line = self.lines.get(self.row).map_or("", String::as_str);
+        let before: usize = line
+            .chars()
+            .take(self.col)
+            .map(crate::grid::char_width)
+            .sum();
+        // One cell held back for the caret, which is drawn between characters
+        // and still has to land somewhere.
+        before.saturating_sub(width - 1)
+    }
+
+    /// The slice of `row` to draw in a viewport `width` cells wide, and the byte
+    /// offset within it where the caret belongs — `None` when the caret is on
+    /// another row.
+    ///
+    /// Measured in cells throughout, per invariant 9: a note written in
+    /// Japanese would otherwise scroll by half a glyph at a time.
+    pub fn visible(&self, row: usize, width: usize) -> (String, Option<usize>) {
+        if width == 0 {
+            return (String::new(), None);
+        }
+        let line = self.lines.get(row).map_or("", String::as_str);
+        let skip = self.h_offset(width);
+        let here = row == self.row;
+        // The caret occupies a cell of its own on the row that carries it.
+        let budget = if here { width - 1 } else { width };
+
+        let mut out = String::new();
+        let mut consumed = 0usize;
+        let mut drawn = 0usize;
+        let mut caret = None;
+        for (index, c) in line.chars().enumerate() {
+            if here && index == self.col && caret.is_none() && consumed >= skip {
+                caret = Some(out.len());
+            }
+            let w = crate::grid::char_width(c);
+            if consumed >= skip {
+                if drawn + w > budget {
+                    break;
+                }
+                out.push(c);
+                drawn += w;
+            }
+            consumed += w;
+        }
+        // A cursor sitting past the last character — the common case, since
+        // that is where typing leaves it.
+        if here && caret.is_none() && self.col >= line.chars().count() {
+            caret = Some(out.len());
+        }
+        (out, caret)
     }
 }
 
@@ -340,6 +419,118 @@ mod tests {
         let mut a = TextArea::new();
         assert!(!a.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)));
         assert_eq!(a.value(), "", "Ctrl+C must not insert a `c`");
+    }
+
+    /// The two editors have to agree about this. `TextField` excluded Alt from
+    /// the start and this did not, so `Alt+x` typed an `x` into a note body and
+    /// did nothing in a task title.
+    #[test]
+    fn alt_chords_are_left_alone_too_just_as_the_single_line_field_does() {
+        let mut a = TextArea::new();
+        assert!(!a.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::ALT)));
+        assert_eq!(a.value(), "", "Alt+x must not insert an `x`");
+
+        let mut f = crate::textfield::TextField::new();
+        assert!(!f.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::ALT)));
+        assert_eq!(f.value(), "", "and the single-line field still agrees");
+    }
+
+    /// The bug: the editor does not wrap, so a long line ran off the right and
+    /// took the caret with it. You could keep typing and see none of it — the
+    /// same complaint as the zone picker's missing scroll, one axis over.
+    #[test]
+    fn a_long_line_scrolls_sideways_so_the_caret_stays_on_screen() {
+        let mut a = TextArea::new();
+        for c in "the quick brown fox jumps over the lazy dog".chars() {
+            a.insert(c);
+        }
+        let (text, caret) = a.visible(0, 20);
+        let caret = caret.expect("the caret is on this row");
+        assert!(
+            crate::grid::display_width(&text) < 20,
+            "drew {} cells into 20 columns",
+            crate::grid::display_width(&text)
+        );
+        assert!(caret <= text.len(), "caret {caret} outside {text:?}");
+        assert!(
+            text.ends_with("dog"),
+            "the window should be pinned to the caret at the end, got {text:?}"
+        );
+
+        // And it comes back as the cursor returns.
+        a.home();
+        let (text, caret) = a.visible(0, 20);
+        assert_eq!(caret, Some(0), "caret back at the left");
+        assert!(
+            text.starts_with("the quick"),
+            "the window followed it back, got {text:?}"
+        );
+    }
+
+    /// Every row shares one offset. Per-row offsets would shear the block.
+    #[test]
+    fn the_whole_block_scrolls_together_rather_than_shearing() {
+        let long = "x".repeat(60);
+        let mut a = TextArea::with_value(format!("{long}\nshort\n{long}"));
+        a.end();
+        let (top, _) = a.visible(0, 20);
+        let (bottom, _) = a.visible(2, 20);
+        assert_eq!(
+            crate::grid::display_width(&top),
+            crate::grid::display_width(&bottom),
+            "two identical lines drew different windows"
+        );
+        // The short line is entirely to the left of the window, so it shows
+        // nothing — which is what a horizontally scrolled editor does.
+        let (short, _) = a.visible(1, 20);
+        assert!(short.is_empty(), "expected an empty window, got {short:?}");
+    }
+
+    /// Measured in cells, or a note in Japanese scrolls by half a glyph.
+    #[test]
+    fn the_sideways_window_is_measured_in_cells_not_characters() {
+        for text in [
+            "日本語のノートです、とても長い行",
+            "aé日b🦀cd",
+            "🦀🦀🦀🦀🦀🦀🦀🦀",
+        ] {
+            let full: Vec<char> = text.chars().collect();
+            for len in 0..=full.len() {
+                let value: String = full[..len].iter().collect();
+                let mut a = TextArea::with_value(value);
+                for back in 0..=len {
+                    for _ in 0..back {
+                        a.left();
+                    }
+                    for width in 1..10usize {
+                        let (window, caret) = a.visible(0, width);
+                        assert!(
+                            crate::grid::display_width(&window) <= width,
+                            "{text:?} len={len} width={width} drew {} cells",
+                            crate::grid::display_width(&window)
+                        );
+                        if let Some(at) = caret {
+                            assert!(
+                                window.is_char_boundary(at),
+                                "caret {at} splits a character in {window:?}"
+                            );
+                        }
+                    }
+                    a.end();
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_zero_width_viewport_cannot_panic() {
+        let a = TextArea::with_value("anything at all");
+        assert_eq!(a.visible(0, 0), (String::new(), None));
+        assert_eq!(
+            a.visible(99, 10).1,
+            None,
+            "no caret on a row that is not there"
+        );
     }
 
     #[test]

--- a/src/textfield.rs
+++ b/src/textfield.rs
@@ -172,19 +172,49 @@ impl TextField {
     /// The window of text to display in a field `width` columns wide, plus the
     /// cursor's column within that window. Scrolls horizontally to keep the
     /// cursor visible in a field narrower than its contents.
+    ///
+    /// **Both figures are display cells, not characters** — invariant 9, and it
+    /// is not pedantry here either. This measured in `chars()` until it was
+    /// reviewed: a field 6 columns wide holding `北京市中心` saw five characters,
+    /// decided they fit, and returned ten cells of text and a cursor column of
+    /// five. The text drew over whatever was beside it and the caret landed in
+    /// the middle of a glyph. Everything a reader types into these prompts is a
+    /// place name or a path, which is exactly where non-Latin text turns up.
     pub fn visible(&self, width: usize) -> (String, usize) {
         if width == 0 {
             return (String::new(), 0);
         }
         let chars: Vec<char> = self.value.chars().collect();
-        if chars.len() < width {
-            return (self.value.clone(), self.cursor);
+        let cells = |c: char| crate::grid::char_width(c);
+
+        // Walk back from the cursor while the text still fits, keeping one cell
+        // free for the caret itself. Where the old code could subtract indices,
+        // this has to accumulate: a step left is worth one cell or two.
+        let budget = width - 1;
+        let mut start = self.cursor;
+        let mut before = 0usize;
+        while start > 0 {
+            let w = cells(chars[start - 1]);
+            if before + w > budget {
+                break;
+            }
+            before += w;
+            start -= 1;
         }
-        // Keep the cursor inside the window, reserving one column for it.
-        let start = (self.cursor + 1).saturating_sub(width);
-        let end = (start + width).min(chars.len());
-        let window: String = chars[start..end].iter().collect();
-        (window, self.cursor - start)
+
+        // Then fill forward, so a window scrolled to the cursor still shows
+        // whatever follows it.
+        let mut window = String::new();
+        let mut drawn = 0usize;
+        for &c in &chars[start..] {
+            let w = cells(c);
+            if drawn + w > width {
+                break;
+            }
+            window.push(c);
+            drawn += w;
+        }
+        (window, before)
     }
 }
 
@@ -339,27 +369,66 @@ mod tests {
         assert!(col < 5);
     }
 
+    /// Measured in **cells**, which is the property that can actually fail —
+    /// the character-counting version of this test passed throughout, because
+    /// counting characters was the bug.
     #[test]
     fn visible_never_exceeds_the_requested_width() {
-        for len in 0..20usize {
-            let value: String = "abcdefghijklmnopqrst".chars().take(len).collect();
-            let mut field = TextField::with_value(value);
-            for cursor_moves in 0..=len {
-                for _ in 0..cursor_moves {
-                    field.left();
+        // Mixed deliberately: one-cell Latin, two-cell CJK, a combining accent
+        // that is zero-cell, and an emoji.
+        for source in [
+            "abcdefghijklmnopqrst",
+            "北京市中心の天気予報です",
+            "aé日b🦀cd",
+            "🦀🦀🦀🦀🦀🦀",
+        ] {
+            let full: Vec<char> = source.chars().collect();
+            for len in 0..=full.len() {
+                let value: String = full[..len].iter().collect();
+                let mut field = TextField::with_value(value);
+                for cursor_moves in 0..=len {
+                    for _ in 0..cursor_moves {
+                        field.left();
+                    }
+                    for width in 1..12usize {
+                        let (text, col) = field.visible(width);
+                        assert!(
+                            crate::grid::display_width(&text) <= width,
+                            "{source:?} len={len} width={width} drew {} cells",
+                            crate::grid::display_width(&text)
+                        );
+                        assert!(col <= width, "cursor column {col} escaped width {width}");
+                    }
+                    field.end();
                 }
-                for width in 1..8usize {
-                    let (text, col) = field.visible(width);
-                    assert!(
-                        text.chars().count() <= width,
-                        "len={len} width={width} produced {} chars",
-                        text.chars().count()
-                    );
-                    assert!(col <= width, "cursor column {col} escaped width {width}");
-                }
-                field.end();
             }
         }
+    }
+
+    /// The case the review found. Five characters "fit" a six-column field only
+    /// if you count characters; they are ten cells wide.
+    #[test]
+    fn a_field_of_wide_characters_is_measured_in_cells_not_characters() {
+        let field = TextField::with_value("北京市中心");
+        let (text, col) = field.visible(6);
+        assert!(
+            crate::grid::display_width(&text) <= 6,
+            "drew {} cells into 6 columns: {text:?}",
+            crate::grid::display_width(&text)
+        );
+        assert!(col <= 6, "caret at column {col} in a 6-column field");
+    }
+
+    /// A caret one cell wide must never land between the halves of a glyph that
+    /// is two — the column it reports has to be the sum of what precedes it.
+    #[test]
+    fn the_reported_column_is_where_the_text_before_the_cursor_actually_ends() {
+        let mut field = TextField::with_value("日本語");
+        field.home();
+        field.right(); // after 日
+        let (text, col) = field.visible(20);
+        assert_eq!(text, "日本語", "it all fits");
+        assert_eq!(col, 2, "one wide glyph precedes the caret, so two cells");
     }
 
     #[test]

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -33,30 +33,6 @@ pub fn is_known_widget(name: &str) -> bool {
     WIDGET_NAMES.contains(&name)
 }
 
-/// Widgets mirador can build that this layout never places, in declaration
-/// order.
-///
-/// A widget missing from a layout is a legitimate choice, not an error, so this
-/// can only ever drive a hint — never a warning and never a default. It exists
-/// because a config written by an earlier version silently lacks every widget
-/// added since, and there is otherwise no way to find out except reading the
-/// release notes.
-pub fn unused_widgets(config: &Config) -> Vec<&'static str> {
-    let placed: Vec<&str> = config
-        .layout
-        .rows
-        .iter()
-        .flat_map(|row| row.panels.iter())
-        .map(|panel| panel.widget.as_str())
-        .collect();
-
-    WIDGET_NAMES
-        .iter()
-        .copied()
-        .filter(|name| !placed.contains(name))
-        .collect()
-}
-
 /// Construct a panel by widget id.
 ///
 /// Returns `Ok(None)` for an unknown name; the config validator rejects those

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -601,38 +601,29 @@ impl NotesPanel {
 
         if rows[3].height > 0 {
             let height = usize::from(rows[3].height);
+            let width = usize::from(rows[3].width);
             let offset = form.body.scroll_offset(height);
-            let (cursor_row, cursor_col) = form.body.cursor();
-            let lines: Vec<Line> = form
-                .body
-                .lines()
-                .iter()
-                .enumerate()
-                .skip(offset)
-                .take(height)
-                .map(|(index, line)| {
-                    if form.field == Field::Body && index == cursor_row {
+            let editing = form.field == Field::Body;
+            let last = form.body.lines().len().min(offset + height);
+            let lines: Vec<Line> = (offset..last)
+                .map(|index| {
+                    // The editor scrolls sideways as well as down, so a long
+                    // line does not carry the caret off the right-hand edge.
+                    // `visible` owns the arithmetic — it is measured in display
+                    // cells, and getting that wrong here is what invariant 9 is
+                    // about.
+                    let (text, caret) = form.body.visible(index, width);
+                    match caret.filter(|_| editing) {
                         // Draw the caret inline rather than moving the terminal
                         // cursor: the panel does not own the screen cursor, and
                         // a caret that only appears in the focused field is
                         // what tells the user where typing will land.
-                        let split = line
-                            .char_indices()
-                            .nth(cursor_col)
-                            .map_or(line.len(), |(byte, _)| byte);
-                        Line::from(vec![
-                            Span::styled(
-                                line[..split].to_string(),
-                                Style::default().fg(theme.text),
-                            ),
+                        Some(at) => Line::from(vec![
+                            Span::styled(text[..at].to_string(), Style::default().fg(theme.text)),
                             Span::styled("▏", Style::default().fg(theme.accent)),
-                            Span::styled(
-                                line[split..].to_string(),
-                                Style::default().fg(theme.text),
-                            ),
-                        ])
-                    } else {
-                        Line::from(Span::styled(line.clone(), Style::default().fg(theme.text)))
+                            Span::styled(text[at..].to_string(), Style::default().fg(theme.text)),
+                        ]),
+                        None => Line::from(Span::styled(text, Style::default().fg(theme.text))),
                     }
                 })
                 .collect();


### PR DESCRIPTION
Phase 1 of the road to 1.0, over `prompt`, `textfield` and `textarea` — plus two changes you asked for.

## Review findings

| | Finding |
| --- | --- |
| **Crash** | A one-column terminal brought the dashboard down. `centred` clamps the popup to the screen, so `popup.x + popup.width - 2` underflowed at width 1 — panic in debug, wrap to 65535 in release. Reachable by resizing while a prompt is open. |
| **Invariant 9** | `TextField::visible` measured characters, not display cells. A 6-column field holding `北京市中心` saw five characters, decided they fit, and returned **ten cells** with the caret at column five. |
| **Usability** | The note editor had no horizontal scroll. It deliberately does not wrap, and that had come to mean a long line ran off the right edge taking the caret with it. |
| **Allocation** | `Prompt::matches` was recomputed in `render` — 286 lowercased strings per frame while the dialog was open. Same shape as the agenda finding: proportional to the table, not to the ten rows on screen. |
| **Behaviour** | Left and Right threw away the list selection, falling through to the same arm as typing. |
| **Consistency** | `TextArea` inserted a letter for `Alt+<letter>`; `TextField` ignored it. |

Each fix was verified by reverting it and watching its test go red — the wide-character one especially, since the old property test *could not fail*: counting characters was the bug it was written in terms of.

### Non-findings worth recording

- `common_prefix` looked like a UTF-8 slicing panic and is not: the byte index always comes from `first`, so every candidate bound is a valid boundary in the string being sliced.
- `TextArea::scroll_offset` counting hard lines is correct — the editor renders unwrapped. Only the *reader* wraps, and that path already clamps against wrapped height.

## Two changes you asked for

**The unused-widget notice is gone**, from the status bar and from the help overlay. A dashboard cannot tell "has not discovered this yet" from "decided against it", so a hint aimed at the first group reminds the second for ever — and the help-overlay half never retired at all. `w` is still a primary binding, so the capability is unchanged; what is gone is being told you should use it. `a_layout_missing_widgets_is_not_advertised_anywhere` renders both surfaces at 200x40 with eleven widgets unplaced and fails on the word "unused".

**The default watchlist leads with the five major US indexes** — `^GSPC`, `^DJI`, `^IXIC`, `^RUT`, `^NDX` — keeping AAPL and MSFT so the panel shows both kinds on a first run. All five verified live through mirador itself; the panel scrolls, so seven rows fit a short panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)