### PR TITLE
Fix two defects in arrange and selection, both beside a test that could not fail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,45 @@ filled once per tick.
 Also bounded the `.ics` read at 10MB, matching what `ureq` already enforces on
 the network side. Reading a calendar costs several times its size.
 
+**`arrange` and `selection`: done.** Two findings, both in code that had a test
+sitting next to it which could not fail.
+
+`promote` broke the one rule its own module header states. Splitting a row's
+height in two read `source.height.max(2)`, so a row of height **1** produced two
+rows of 1 and grew the total by one — and heights are relative weights, so
+`[1, 1]` becoming `[1, 1, 1]` takes an untouched row from half the screen to a
+third of it. Reachable without doing anything odd: `LayoutRow::default()` is
+height 1, nothing in `validate` bounds heights, and a `[[layout.rows]]` entry
+written without a `height` gets the default. It now doubles every row before
+splitting, which preserves every proportion exactly, and a height of 0 stays 0
+rather than being forced up to 2.
+
+`a_move_never_changes_what_the_weights_add_up_to` could never have caught it —
+every height in its fixture is comfortably above two. The replacement asserts
+the property the rule is actually about: an untouched row keeps its *share*.
+
+`selection::up` did not clamp its starting index against `len` where `down`
+always had. A list that gets shorter can leave the selection past its end —
+`news` and `watchlog` both bound movement by what they last managed to *draw*,
+so making the panel shorter does exactly that — and the two directions then
+disagreed: `down` pulled a stale index back into range, `up` walked it down one
+row at a time with nothing highlighted the whole way. This is the same complaint
+as the zone picker's missing scroll, one module over.
+
+Non-findings worth recording. `row_at` maps one screen row to one list index,
+which would be wrong for a multi-line `ListItem` — `news` builds one — but news
+does not use `row_at`; only `todo`, `notes` and `stocks` do, and all three draw
+one line per row. And `insertion_point` cannot divide by zero or see a NaN,
+because `weight` floors each panel at 1.
+
+Found while driving arrange mode in a real terminal, and left as a known
+limitation rather than fixed: **`layout_edit` can only rewrite the
+`rows = [ … ]` form**, not a layout spelled with `[[layout.rows]]` sections.
+Both load; only one can be edited. That is not silent — it is an alert — but the
+message said "no `[layout]` rows found" about a file that visibly has rows,
+which reads as a bug. It now names the form it wants, front-loaded so the useful
+clause survives the status bar's truncation on a narrow terminal.
+
 **`layout_edit` and `migrate`: done.** Found that both flattened CRLF to LF —
 `str::lines()` strips the `\r`, so a Windows config was rewritten entirely
 because one panel moved. `store::line_ending` now carries the file's own ending
@@ -749,9 +788,7 @@ exists to make impossible.
 One pass covered the code written on 27 July and found a hang and two per-frame
 allocation faults. The rest of the program has not had the same treatment.
 
-Not yet reviewed: `layout_edit` (the structural path especially), `themes`,
-`prompt`/`textfield`/`textarea`, `arrange`, `ical`, `quote`, `migrate`, `state`,
-`store`, `chart`, `samples`, `selection`, `glyphs`.
+Not yet reviewed: `chart`, `samples`, `glyphs`, `theme_picker`.
 
 *Exit:* every module reviewed, findings fixed or recorded with a reason.
 

--- a/README.md
+++ b/README.md
@@ -761,6 +761,13 @@ rows = [
 ]
 ```
 
+**Keep that shape if you want `w` and `m` to work.** TOML lets you spell the
+same layout as a series of `[[layout.rows]]` sections, and mirador reads it
+perfectly well — but it *writes* your config by editing the text, so your
+comments survive, and the text it knows how to edit is the form above.
+Rearranging a layout written the other way tells you so in the status bar
+rather than failing quietly.
+
 ### Widgets
 
 | Widget | What it shows |

--- a/src/arrange.rs
+++ b/src/arrange.rs
@@ -87,12 +87,34 @@ fn vertical(layout: &mut Layout, row: usize, column: usize, down: bool) -> Optio
 
 /// Give the panel a row of its own at the outer edge.
 fn promote(layout: &mut Layout, row: usize, column: usize, below: bool) -> Option<(usize, usize)> {
+    // Splitting a weight of one in two needs finer granularity than the layout
+    // currently has. Scale every row rather than inventing weight for this one:
+    // doubling preserves every proportion exactly, which is what the rule at the
+    // top of this module is actually about.
+    //
+    // It used to read `source.height.max(2)`, which for a row of height 1 handed
+    // out two rows of 1 and grew the total by one. A `[[layout.rows]]` written
+    // without a `height` gets `LayoutRow::default()`, which is height 1, and
+    // nothing validates heights — so with rows of `[1, 1]` a promotion turned a
+    // 50/50 dashboard into 33/33/33 and rescaled a row the user had not touched.
+    // `a_move_never_changes_what_the_weights_add_up_to` could not see it: every
+    // height in that fixture is comfortably above two.
+    if layout.rows.get(row).is_some_and(|entry| entry.height == 1) {
+        for entry in &mut layout.rows {
+            entry.height = entry.height.saturating_mul(2);
+        }
+    }
+
     let source = layout.rows.get_mut(row)?;
     let panel = source.panels.remove(column);
 
     // The new row's height comes out of the row the panel left, so the total is
     // unchanged and every other row keeps the share the user gave it.
-    let height = source.height.max(2);
+    //
+    // A source of height 0 gives 0, which is right rather than a special case: a
+    // row with no weight draws nothing, and a panel promoted out of one has not
+    // asked to start being visible.
+    let height = source.height;
     let taken = height / 2;
     source.height = height - taken;
 
@@ -100,7 +122,7 @@ fn promote(layout: &mut Layout, row: usize, column: usize, below: bool) -> Optio
     layout.rows.insert(
         at,
         LayoutRow {
-            height: taken.max(1),
+            height: taken,
             panels: vec![panel],
         },
     );
@@ -272,6 +294,102 @@ mod tests {
         assert_eq!(move_panel(&mut l, 0, 0, Direction::Up), None);
         assert_eq!(l.rows.len(), 2, "no row was opened");
         assert_eq!(heights(&l), [50, 50], "and no weight was moved");
+    }
+
+    /// The rule at the top of this module, stated as the property it is really
+    /// about: an untouched row keeps its *share* of the dashboard.
+    ///
+    /// The sum-based test below cannot see the case this exists for. Every
+    /// height in its fixture is comfortably above two, and the bug only showed
+    /// up at one: `source.height.max(2)` turned a row of height 1 into two rows
+    /// of 1, so `[1, 1]` became `[1, 1, 1]` and a row nobody had moved went from
+    /// half the screen to a third of it.
+    #[test]
+    fn promoting_out_of_a_thin_row_does_not_rescale_the_rows_around_it() {
+        for height in [0u16, 1, 2, 3, 7, 100] {
+            let mut l = layout(&[
+                (height, &[("clocks", 50), ("weather", 50)]),
+                (50, &[("todo", 100)]),
+            ]);
+            let before: u16 = heights(&l).iter().sum();
+            let untouched_share = f64::from(50) / f64::from(before.max(1));
+
+            assert_eq!(
+                move_panel(&mut l, 0, 0, Direction::Up),
+                Some((0, 0)),
+                "height {height}: the move itself must still work"
+            );
+
+            let after: u16 = heights(&l).iter().sum();
+            let todo = *heights(&l).last().expect("the untouched row");
+            let share = f64::from(todo) / f64::from(after.max(1));
+            assert!(
+                (share - untouched_share).abs() < 1e-9,
+                "height {height}: the untouched row went from {:.4} of the screen \
+                 to {:.4} — heights {:?}",
+                untouched_share,
+                share,
+                heights(&l)
+            );
+        }
+    }
+
+    /// `validate` refuses a layout with no rows, and a row with no panels. A
+    /// gesture the user can hold down must not be able to produce either.
+    #[test]
+    fn no_sequence_of_moves_can_produce_a_layout_the_config_would_reject() {
+        let start = layout(&[
+            (1, &[("clocks", 26), ("calendar", 74)]),
+            (1, &[("todo", 100)]),
+            (2, &[("cpu", 50), ("network", 50)]),
+        ]);
+
+        // Every direction, from every position, repeatedly — which is what
+        // holding the key down amounts to.
+        let mut l = start;
+        for step in 0..200usize {
+            let direction = match step % 4 {
+                0 => Direction::Down,
+                1 => Direction::Right,
+                2 => Direction::Up,
+                _ => Direction::Left,
+            };
+            let row = step % l.rows.len().max(1);
+            let column = step % l.rows[row].panels.len().max(1);
+            move_panel(&mut l, row, column, direction);
+
+            assert!(!l.rows.is_empty(), "step {step}: the layout emptied");
+            for entry in &l.rows {
+                assert!(
+                    !entry.panels.is_empty(),
+                    "step {step}: an empty row survived: {:?}",
+                    shape(&l)
+                );
+            }
+            let mut placed: Vec<&str> = l.widgets();
+            placed.sort_unstable();
+            assert_eq!(
+                placed,
+                ["calendar", "clocks", "cpu", "network", "todo"],
+                "step {step}: a panel was lost or duplicated"
+            );
+        }
+    }
+
+    /// The one panel on the dashboard has nowhere to go in any direction, and
+    /// must not be able to leave the layout empty by trying.
+    #[test]
+    fn the_only_panel_on_the_dashboard_refuses_every_direction() {
+        for direction in [
+            Direction::Left,
+            Direction::Right,
+            Direction::Up,
+            Direction::Down,
+        ] {
+            let mut l = layout(&[(100, &[("clocks", 100)])]);
+            assert_eq!(move_panel(&mut l, 0, 0, direction), None, "{direction:?}");
+            assert_eq!(shape(&l), [["clocks"]], "{direction:?} moved something");
+        }
     }
 
     #[test]

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -421,7 +421,21 @@ fn map_layout(lines: &[&str]) -> Result<LayoutMap> {
     }
 
     if rows.is_empty() {
-        bail!("no `[layout]` rows found in the config text");
+        // Naming the shape it wants, because the reader is looking at a config
+        // that loaded perfectly well and is being told it cannot be written to.
+        // `[[layout.rows]]` is valid TOML and mirador parses it happily; this
+        // module only knows how to edit the `rows = [ { … } ]` form the shipped
+        // config uses, and "no rows found" on a file that visibly has rows reads
+        // as a bug rather than as a limitation.
+        // The actionable half comes first, because the status bar truncates and
+        // the whole of this will not fit on a narrow terminal. The first clause
+        // has to be the one worth reading.
+        bail!(
+            "only the `rows = [ … ]` layout form can be rewritten, not \
+             `[[layout.rows]]` sections. Both load; mirador edits the config as \
+             text so your comments survive, and it recognises the form that \
+             `mirador --print-config` writes"
+        );
     }
     Ok(LayoutMap { rows })
 }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -29,11 +29,20 @@ pub fn down(state: &mut ListState, n: usize, len: usize) {
 }
 
 /// Move the cursor `n` rows up, stopping at the first row.
+///
+/// Clamps the *starting* position against `len` as well, which [`down`] has
+/// always done and this had not. A selection can be left past the end of a list
+/// that has since got shorter — `news` and `watchlog` both count what they last
+/// managed to draw, so making the panel shorter does exactly that — and the two
+/// directions then disagreed about it. `down` pulled a stale index back into
+/// range; `up` walked it one row at a time from wherever it was, so the
+/// highlight stayed invisible and the key looked broken until you had pressed
+/// it as many times as the list had shrunk.
 pub fn up(state: &mut ListState, n: usize, len: usize) {
-    if len == 0 {
+    let Some(last) = len.checked_sub(1) else {
         return;
-    }
-    let current = state.selected().unwrap_or(0);
+    };
+    let current = state.selected().unwrap_or(0).min(last);
     state.select(Some(current.saturating_sub(n)));
 }
 
@@ -103,6 +112,34 @@ mod tests {
             state.selected(),
             None,
             "a highlight over an empty list has nothing under it"
+        );
+    }
+
+    /// A list that gets shorter can leave the selection past its end — `news`
+    /// and `watchlog` both bound movement by what they last drew, so shrinking
+    /// the panel does it. Both directions have to pull it back, and `up` did
+    /// not: it stepped down from the stale index one row at a time, with
+    /// nothing highlighted the whole way.
+    #[test]
+    fn both_directions_pull_a_selection_left_past_the_end_back_into_range() {
+        let mut state = at(30);
+        down(&mut state, 1, 5);
+        assert_eq!(state.selected(), Some(4), "down clamps into the new list");
+
+        let mut state = at(30);
+        up(&mut state, 1, 5);
+        assert_eq!(
+            state.selected(),
+            Some(3),
+            "up must land one above the last row, not one below a row that is gone"
+        );
+
+        let mut state = at(30);
+        up(&mut state, usize::MAX, 5);
+        assert_eq!(
+            state.selected(),
+            Some(0),
+            "and `first` still goes to the top"
         );
     }
 


### PR DESCRIPTION
Phase 1 of the road to 1.0, over `arrange` and `selection`.

## `promote` broke the one rule its own module header states

Splitting a row's height in two read `source.height.max(2)`, so a row of height **one** produced two rows of 1 and grew the total by one. Heights are relative weights, so `[1, 1]` becoming `[1, 1, 1]` takes a row nobody touched from half the screen to a third of it — precisely the quiet rescale the header promises never happens.

Reachable without doing anything unusual: `LayoutRow::default()` is height 1, nothing in `validate` bounds heights, and a `[[layout.rows]]` entry written without a `height` gets the default.

It now doubles every row before splitting — which preserves every proportion exactly — and a height of 0 stays 0 rather than being forced up to 2.

`a_move_never_changes_what_the_weights_add_up_to` could never have caught this: every height in its fixture is comfortably above two. The replacement asserts the property the rule is actually about — **an untouched row keeps its share** — and fails at heights 0 and 1 without the fix.

## `selection::up` did not clamp against `len`

`down` always had. A list that gets shorter can leave the selection past its end — `news` and `watchlog` both bound movement by what they last managed to *draw*, so making the panel shorter does exactly that. The two directions then disagreed: `down` pulled a stale index back into range, `up` stepped down from wherever it was one row at a time, with nothing highlighted the whole way.

Same complaint as the zone picker's missing scroll, one module over.

## Also added

Two tests for properties nothing pinned: no sequence of two hundred moves can empty the layout, leave an empty row, or lose a panel — all three of which `validate` would reject at the next launch — and the only panel on the dashboard refuses every direction rather than trying to leave.

## Non-findings

- `row_at` maps one screen row to one list index, which would be wrong for a multi-line `ListItem` — `news` builds one — but news does not use `row_at`, and the three panels that do all draw one line per row.
- `insertion_point` cannot divide by zero or produce a NaN, because `weight` floors each panel at 1.

## One known limitation, documented rather than fixed

Driving arrange mode in a real terminal turned up that `layout_edit` can only rewrite the `rows = [ … ]` form, not a layout spelled with `[[layout.rows]]` sections. Both load; only one can be edited. It was already an alert rather than a silent failure, but it said *"no `[layout]` rows found"* about a file that visibly has rows — which reads as a bug. It now names the form it wants, front-loaded so the useful clause survives truncation at 80 columns, and the README says which shape to keep.

Both fixes verified by reverting them and watching their tests go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)