### PR TITLE
Close five holes in chart, samples and glyphs — one of them live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,48 @@ filled once per tick.
 Also bounded the `.ics` read at 10MB, matching what `ureq` already enforces on
 the network side. Reading a calendar costs several times its size.
 
+**`chart`, `samples` and `glyphs`: done.** Five findings, and the interesting
+thing about them is the split: four were *latent* — a hole in a public function
+that no current caller can reach — and one was live, in a module these three
+led to rather than in any of them.
+
+Latent, all now closed because the guards cost a line each:
+
+- `samples::push_bounded` spun for ever on a capacity of 0. `buffer.len() >= 0`
+  is always true for a `usize`, and `pop_front` on an empty deque returns `None`
+  without breaking anything. Unreachable through `capacity`, which floors at 1,
+  and both callers go through it.
+- `chart::BrailleGraph::render` panicked when handed an area larger than the
+  buffer, because indexing a `Buffer` out of bounds does. Every ratatui widget
+  clamps; this one did not. Panels take their rects from the layout, so nothing
+  passes one today.
+- `glyphs::width_of` overflows `u16` at about ten thousand characters and panics
+  in a debug build. Its two callers pass `"00:00:00"` and a formatted clock.
+- `glyphs::utility` can make text *wider*: uppercasing is not one-to-one, so `ß`
+  becomes `SS` and `ﬄ` becomes `FFL` — ten characters in, thirty cells out.
+  Measuring the argument instead of the result is therefore wrong. Documented on
+  the function rather than "fixed", because the behaviour is correct.
+
+Live, and the one that mattered: **`feed` bounded nothing it parsed.** Following
+`utility` back to its one caller that takes text mirador did not write —
+`news::masthead` — led to the parser, where a story's title, link and source had
+no length limit at all. Everything downstream runs per *frame*: the title is
+wrapped on every draw and the source uppercased on every draw. Measured before
+fixing, a 2 MB headline wrapped to 40,000 lines and cost **72 ms a frame**, and
+`ureq`'s body cap allows five times that. A feed is the one input to this program
+somebody else writes, and it could decide how much work the dashboard did.
+Titles are clipped to 400 characters at parse, links to 1,000, source names to
+80 — all far above anything real, and a test pins that an ordinary headline is
+untouched.
+
+That is Phase 2's exit criterion for `feed`, reached from Phase 1.
+
+Non-findings, recorded because they were checked rather than assumed: the graph
+survives `u64::MAX` data against a `u64::MAX` scale, data far above its scale,
+and a scale of zero; `level()` is safe against NaN and infinity because
+`f64::max` returns the non-NaN operand and an infinite cast saturates; and
+`lerp` cannot leave `0..=255`, because `step` is clamped to `span` first.
+
 **`arrange` and `selection`: done.** Two findings, both in code that had a test
 sitting next to it which could not fail.
 
@@ -788,7 +830,7 @@ exists to make impossible.
 One pass covered the code written on 27 July and found a hang and two per-frame
 allocation faults. The rest of the program has not had the same treatment.
 
-Not yet reviewed: `chart`, `samples`, `glyphs`, `theme_picker`.
+Not yet reviewed: `theme_picker`, which is newer than this list.
 
 *Exit:* every module reviewed, findings fixed or recorded with a reason.
 

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -191,6 +191,13 @@ impl<'a> BrailleGraph<'a> {
     /// The most recent samples are kept: a graph narrower than the history
     /// shows the right-hand end of it, which is the part anyone cares about.
     pub fn render(&self, area: Rect, buf: &mut Buffer) {
+        // Clip to the buffer before touching it. Indexing a `Buffer` out of
+        // bounds panics, and every ratatui widget clamps for exactly this
+        // reason — a graph handed an area larger than the screen should draw
+        // what fits, not bring the dashboard down. No caller does that today;
+        // the panels take their rects from the layout, which is derived from
+        // the frame. This is here so that a future one cannot.
+        let area = area.intersection(buf.area);
         if area.width == 0 || area.height == 0 {
             return;
         }
@@ -310,6 +317,41 @@ mod tests {
 
     fn c(r: u8, g: u8, b: u8) -> Color {
         Color::Rgb(r, g, b)
+    }
+
+    /// Indexing a `Buffer` out of bounds panics. Nothing passes an oversized
+    /// area today — the panels take their rects from the layout — but a graph
+    /// asked to draw outside the screen should draw what fits.
+    #[test]
+    fn an_area_larger_than_the_buffer_is_clipped_rather_than_panicking() {
+        let gradient = Gradient::new(c(0, 0, 0), None, Some(c(255, 0, 0)));
+        let data: Vec<u64> = (0..200).collect();
+
+        for (bw, bh) in [(1u16, 1u16), (10, 4), (40, 12)] {
+            for (aw, ah) in [(1u16, 1u16), (40, 12), (500, 200)] {
+                let mut buf = Buffer::empty(Rect::new(0, 0, bw, bh));
+                BrailleGraph::new(&data, 199, &gradient).render(Rect::new(0, 0, aw, ah), &mut buf);
+            }
+        }
+
+        // And an area that starts outside the buffer entirely.
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 4));
+        BrailleGraph::new(&data, 199, &gradient).render(Rect::new(50, 50, 10, 4), &mut buf);
+    }
+
+    /// Values and a scale at the top of `u64` must not wrap or divide badly.
+    #[test]
+    fn saturated_values_still_draw() {
+        let gradient = Gradient::new(c(0, 0, 0), None, Some(c(255, 0, 0)));
+        for (data, max) in [
+            (vec![u64::MAX; 60], u64::MAX),
+            (vec![u64::MAX; 60], 1),
+            (vec![0u64; 60], u64::MAX),
+            (vec![0u64; 60], 0),
+        ] {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 20, 4));
+            BrailleGraph::new(&data, max, &gradient).render(Rect::new(0, 0, 20, 4), &mut buf);
+        }
     }
 
     #[test]

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -164,11 +164,41 @@ impl Partial {
         }
         Some(Story {
             source: String::new(),
-            title: title.to_string(),
-            link: self.link.trim().to_string(),
+            title: clip(title, MAX_TITLE),
+            link: clip(self.link.trim(), MAX_LINK),
             published: parse_date(self.date.trim()),
         })
     }
+}
+
+/// The longest headline kept. Real ones run to about 150 characters; this is
+/// generous enough that nothing genuine is ever clipped.
+const MAX_TITLE: usize = 400;
+
+/// The longest link kept. Real ones are well under 200.
+const MAX_LINK: usize = 1_000;
+
+/// The longest feed name kept, applied where the panel names the feed.
+pub const MAX_SOURCE: usize = 80;
+
+/// Keep the first `limit` characters of `text`.
+///
+/// This is the bound that was missing, and the reason it matters is not tidiness
+/// — it is that everything downstream is per *frame*. A story's title is wrapped
+/// on every draw and its source is uppercased on every draw, so an unbounded
+/// string here becomes unbounded work sixty times a minute. Measured before
+/// fixing: a 2 MB headline wrapped to 40,000 lines and cost **72 ms a frame**,
+/// and `ureq`'s body cap allows five times that. A feed you do not control
+/// should not be able to decide how much work the dashboard does.
+///
+/// Cutting on a character boundary rather than a byte one, so a clipped headline
+/// is still a string. The panel truncates again for display, in *cells*; this
+/// bound is about what is worth holding at all.
+fn clip(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    text.chars().take(limit).collect()
 }
 
 /// The text an entity reference stands for.
@@ -220,6 +250,54 @@ fn local_name(name: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The bound that was missing. Everything downstream of a story runs per
+    /// *frame* — the title is wrapped on every draw, the source uppercased on
+    /// every draw — so an unbounded field here is unbounded work sixty times a
+    /// minute. Measured before the fix: a 2 MB headline wrapped to 40,000 lines
+    /// and cost 72 ms a frame, and `ureq`'s body cap allows five times that.
+    ///
+    /// A feed is the one input to this program that somebody else writes.
+    #[test]
+    fn a_hostile_feed_cannot_decide_how_much_work_the_dashboard_does() {
+        let huge = "word ".repeat(400_000);
+        let xml = format!(
+            "<rss><channel><item><title>{huge}</title>\
+             <link>http://example.com/{huge}</link></item></channel></rss>"
+        );
+        let stories = parse(&xml).expect("parses");
+        let story = stories.first().expect("one story");
+
+        assert!(
+            story.title.chars().count() <= MAX_TITLE,
+            "a {} character headline survived",
+            story.title.chars().count()
+        );
+        assert!(
+            story.link.chars().count() <= MAX_LINK,
+            "a {} character link survived",
+            story.link.chars().count()
+        );
+
+        // The property that actually matters: what it costs to draw.
+        let wrapped = crate::grid::wrap(&story.title, 50);
+        assert!(
+            wrapped.len() <= 40,
+            "the headline still wraps to {} lines a frame",
+            wrapped.len()
+        );
+    }
+
+    /// And an ordinary headline is untouched — a bound that clips real news is
+    /// worse than no bound.
+    #[test]
+    fn a_headline_of_ordinary_length_is_not_clipped() {
+        let title = "Astronomers find a planet where it rains glass sideways, \
+                     and the discovery may rewrite how we think gas giants form";
+        let xml = format!("<rss><channel><item><title>{title}</title></item></channel></rss>");
+        let stories = parse(&xml).expect("parses");
+        assert_eq!(stories[0].title, title, "a real headline was clipped");
+    }
 
     /// Captured from real feeds, and deliberately awkward: CDATA titles, an
     /// entity inside a link, an entity that splits a title into three text

--- a/src/glyphs.rs
+++ b/src/glyphs.rs
@@ -123,13 +123,23 @@ fn pad_to(line: &mut String, target: u16) {
 }
 
 /// Columns `text` will occupy at `scale`.
+///
+/// Saturating rather than wrapping. The arithmetic is `u16` and every factor
+/// comes from the caller, so a string of about ten thousand characters overflows
+/// and panics in a debug build. Nothing passes one — the two callers hand it
+/// `"00:00:00"` and a formatted clock — but a width that reports "wider than the
+/// terminal" for absurd input is the right answer, and `fitting_scale` then
+/// returns `None` and the panel falls back, which is what it does anyway.
 pub fn width_of(text: &str, scale: u16) -> u16 {
     let scale = scale.max(1);
     let count = u16::try_from(text.chars().count()).unwrap_or(u16::MAX);
     if count == 0 {
         return 0;
     }
-    count * CELL_W * scale + (count - 1) * GAP
+    count
+        .saturating_mul(CELL_W)
+        .saturating_mul(scale)
+        .saturating_add(count.saturating_sub(1).saturating_mul(GAP))
 }
 
 /// The largest scale at which `text` fits in `available` columns, or `None` if
@@ -143,6 +153,12 @@ pub fn fitting_scale(text: &str, available: u16, max_scale: u16) -> Option<u16> 
 /// Render text in the utility face: uppercase, normally spaced.
 ///
 /// `utility("next hours")` becomes `NEXT HOURS`.
+///
+/// **The result can be wider than the input**, so measure it rather than the
+/// argument. Uppercasing is not a one-to-one map: `ß` becomes `SS` and `ﬄ`
+/// becomes `FFL`, so ten characters in can be thirty cells out. Every caller
+/// today either passes a literal or truncates afterwards; the one that took
+/// unbounded text is bounded at its source now, in `feed`.
 ///
 /// This face used to be letterspaced — `N E X T  H O U R S` — on the theory
 /// that tracking separates a label from data without leaning on colour. In

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -23,7 +23,15 @@ pub fn capacity(configured: usize, graph_cells: usize) -> usize {
 /// Trims in a loop rather than popping one sample: the capacity *shrinks* when
 /// the panel is narrowed, and one pop per push would leave the buffer oversized
 /// for as many ticks as the window lost cells.
+///
+/// A capacity of zero means "keep one", not "keep none". `buffer.len() >= 0` is
+/// always true for a `usize`, so the loop had no way to end: `pop_front` on an
+/// empty deque returns `None` without breaking anything, and the call spun for
+/// ever. [`capacity`] floors at 1 and both callers go through it, so nothing
+/// reached it — but this is a public function with a spin-forever hole in it,
+/// and the floor costs one line.
 pub fn push_bounded(buffer: &mut VecDeque<u64>, value: u64, capacity: usize) {
+    let capacity = capacity.max(1);
     while buffer.len() >= capacity {
         buffer.pop_front();
     }
@@ -53,6 +61,19 @@ mod tests {
         let mut buffer: VecDeque<u64> = (0..200).collect();
         push_bounded(&mut buffer, 999, 10);
         assert_eq!(buffer.len(), 10);
+    }
+
+    /// `buffer.len() >= 0` is always true for a `usize`, so this used to spin
+    /// for ever rather than keeping nothing. Unreachable through `capacity`,
+    /// which floors at 1 — but the function is public and a hang is the one
+    /// class of bug this release cycle exists to remove.
+    #[test]
+    fn a_capacity_of_zero_keeps_one_sample_rather_than_spinning_for_ever() {
+        let mut buffer: VecDeque<u64> = VecDeque::new();
+        push_bounded(&mut buffer, 1, 0);
+        push_bounded(&mut buffer, 2, 0);
+        assert_eq!(buffer.len(), 1, "a zero capacity means one, not none");
+        assert_eq!(buffer.back().copied(), Some(2), "and it is the newest");
     }
 
     #[test]

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -406,7 +406,12 @@ fn fetch_loop(
                 Ok(mut found) => {
                     found.truncate(per_feed);
                     for mut story in found {
-                        story.source.clone_from(name);
+                        // Bounded for the same reason the feed's own fields are:
+                        // `masthead` uppercases this on every frame, so an
+                        // over-long name — this one comes from the config rather
+                        // than from the feed, but still — would be re-allocated
+                        // sixty times a minute.
+                        story.source = name.chars().take(crate::feed::MAX_SOURCE).collect();
                         stories.push(story);
                     }
                 }


### PR DESCRIPTION
Phase 1 over `chart`, `samples` and `glyphs`. The interesting thing is the split: **four findings are latent** — a hole in a public function that no current caller can reach — and **one is live**, in a module these three led to rather than in any of them.

## Latent (guards cost a line each)

| Module | Hole |
| --- | --- |
| `samples` | `push_bounded` **spun for ever** on capacity 0 — `buffer.len() >= 0` is always true for a `usize`, and `pop_front` on an empty deque returns `None` without breaking the loop. Unreachable through `capacity`, which floors at 1. |
| `chart` | `BrailleGraph::render` **panicked** when handed an area larger than the buffer. Every ratatui widget clamps; this one did not. |
| `glyphs` | `width_of` overflows `u16` at ~10,000 characters and panics in debug. Callers pass `"00:00:00"`. |
| `glyphs` | `utility` can make text **wider** — `ß`→`SS`, `ﬄ`→`FFL`, ten chars in and thirty cells out. Documented rather than changed: the behaviour is right; the warning not to measure the argument was missing. |

## Live: `feed` bounded nothing it parsed

Following `utility` back to its one caller that takes text mirador did not write — `news::masthead` — led to the parser, where a story's title, link and source had **no length limit at all**.

Everything downstream runs per *frame*: the title is wrapped on every draw, the source uppercased on every draw. Measured before fixing:

```
title of        50 chars ->     1 wrapped line,   398µs per frame
title of   100,000 chars ->  2,000 wrapped lines,  5.7ms per frame
title of 2,000,000 chars -> 40,000 wrapped lines, 72.1ms per frame
```

`ureq`'s body cap allows 10 MB — five times the worst case above. A feed is the one input to this program that somebody else writes, and it could decide how much work the dashboard did.

Titles now clip to 400 characters at parse, links to 1,000, source names to 80. All are far above anything real, and a test pins that an ordinary headline is untouched — a bound that clips real news would be worse than no bound.

**This is Phase 2's exit criterion for `feed`, reached from Phase 1.**

## Non-findings

Checked rather than assumed: the graph survives `u64::MAX` data against a `u64::MAX` scale, data far above its scale, and a scale of zero; `level()` is safe against NaN and infinity, because `f64::max` returns the non-NaN operand and an infinite cast saturates; and `lerp` cannot leave `0..=255`, because `step` is clamped to `span` first.

## Verification

The feed and chart fixes were checked by reverting them and watching their tests go red. Verified afterwards against the three real shipped feeds in a live terminal: headlines, mastheads, interleaving and both graphs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)