### PR TITLE
Review theme_picker, and fix the test that could not fail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,33 @@ filled once per tick.
 Also bounded the `.ics` read at 10MB, matching what `ureq` already enforces on
 the network side. Reading a calendar costs several times its size.
 
+**`theme_picker`: done.** One finding, which is a thin haul and worth saying so
+rather than dressing up — the module is mostly declarative drawing, and it was
+written with `prompt`'s lessons already in hand.
+
+`render` reserved `self.names.len() + 2` lines and drew at most `ROWS`. With
+five thousand themes on disk that is room for 5,012 lines every frame to push
+14. Nobody has five thousand themes; the number was never the point. The rule
+about allocating in proportion to what is on screen rather than to how much data
+sits behind it was written down three days before this module broke it, which is
+the useful part of the finding.
+
+**The first test written for it could not fail**, and that is the second useful
+part. It counted theme rows reaching the screen — but `take(ROWS)` caps those
+whichever way the reservation is written, so it passed with the bug in place.
+The fix was to split the line building into `ThemePicker::lines` and weigh the
+`Vec`'s own capacity, which is the thing that was wrong. Same trap as the id
+reuse test and the `default.toml` drift test; the tell each time is that the
+assertion is about a *consequence* that the bug does not actually change.
+
+Non-findings: no panic anywhere from 1x1 to 5x5, with and without a list long
+enough to scroll — unlike `prompt`, this module never indexes the buffer itself,
+so ratatui's own clipping covers it. And live preview costs about **30µs per
+keystroke**, measured across all ten bundled themes, including the filesystem
+stat that checks for a user override. That is a fair question to ask of a dialog
+that re-resolves a theme on every cursor move, and the answer is that it does not
+matter.
+
 **`chart`, `samples` and `glyphs`: done.** Five findings, and the interesting
 thing about them is the split: four were *latent* — a hole in a public function
 that no current caller can reach — and one was live, in a module these three
@@ -830,9 +857,17 @@ exists to make impossible.
 One pass covered the code written on 27 July and found a hang and two per-frame
 allocation faults. The rest of the program has not had the same treatment.
 
-Not yet reviewed: `theme_picker`, which is newer than this list.
+**Phase 1 is complete.** Every module has been read adversarially, and every
+finding is either fixed or recorded above with the reason it was left.
 
-*Exit:* every module reviewed, findings fixed or recorded with a reason.
+Two patterns ran through the whole pass and are worth carrying into Phase 2.
+**Most findings sat next to a test that could not fail** — counting characters
+where cells were the bug, summing weights where proportions were the bug,
+counting drawn rows where the allocation was the bug. The tell is always that
+the assertion is about a consequence the bug does not change. And **the live
+defects clustered at the edges**: unbounded third-party feed text, a terminal
+resized to one column, a list that got shorter. The interior arithmetic was
+mostly right.
 
 ### Phase 2 — harden the untrusted-input boundary
 

--- a/src/theme_picker.rs
+++ b/src/theme_picker.rs
@@ -147,22 +147,16 @@ impl ThemePicker {
         }
     }
 
-    /// Draw the dialog centred over whatever is behind it.
-    pub fn render(&self, frame: &mut ratatui::Frame, area: Rect, theme: &Theme) {
-        let width = 44u16.min(area.width);
-        let rows = u16::try_from(self.names.len().min(ROWS)).unwrap_or(u16::MAX);
-        // List, the two frame rows, the blank row and the footer. Nothing more:
-        // a spare row inside the border reads as a list that has run out rather
-        // than as breathing space.
-        let height = rows.saturating_add(4).min(area.height);
-        let rect = Rect {
-            x: area.x + (area.width.saturating_sub(width)) / 2,
-            y: area.y + (area.height.saturating_sub(height)) / 2,
-            width,
-            height,
-        };
-
-        let mut lines: Vec<Line<'static>> = Vec::with_capacity(self.names.len() + 2);
+    /// The rows to draw: the visible slice of the list, a blank, and the footer.
+    ///
+    /// Split out of `render` so a test can weigh it. The bug it exists to pin
+    /// was invisible on screen — `render` reserved `self.names.len() + 2` lines
+    /// and drew at most `ROWS`, so with five thousand themes on disk it
+    /// allocated room for 5,012 every frame and pushed 14. Nothing looked
+    /// wrong, which is exactly why a test that only checks what reaches the
+    /// screen cannot catch it.
+    fn lines(&self, theme: &Theme) -> Vec<Line<'static>> {
+        let mut lines: Vec<Line<'static>> = Vec::with_capacity(ROWS + 2);
         for (index, name) in self.names.iter().enumerate().skip(self.offset).take(ROWS) {
             let chosen = index == self.selected;
             let marker = if chosen { "▸ " } else { "  " };
@@ -196,6 +190,25 @@ impl ThemePicker {
             ),
             Span::styled(" put back", Style::default().fg(theme.muted)),
         ]));
+        lines
+    }
+
+    /// Draw the dialog centred over whatever is behind it.
+    pub fn render(&self, frame: &mut ratatui::Frame, area: Rect, theme: &Theme) {
+        let width = 44u16.min(area.width);
+        let rows = u16::try_from(self.names.len().min(ROWS)).unwrap_or(u16::MAX);
+        // List, the two frame rows, the blank row and the footer. Nothing more:
+        // a spare row inside the border reads as a list that has run out rather
+        // than as breathing space.
+        let height = rows.saturating_add(4).min(area.height);
+        let rect = Rect {
+            x: area.x + (area.width.saturating_sub(width)) / 2,
+            y: area.y + (area.height.saturating_sub(height)) / 2,
+            width,
+            height,
+        };
+
+        let lines = self.lines(theme);
 
         let block = Block::default()
             .borders(Borders::ALL)
@@ -367,14 +380,69 @@ mod tests {
         assert_eq!(picker.names().len(), crate::themes::bundled_names().len());
     }
 
+    /// Every size down to one cell. `prompt` had a panic that only appeared at
+    /// width 1, found by sweeping rather than by reasoning, so this sweeps —
+    /// and it holds with a list long enough to scroll, which is when the
+    /// arithmetic has something to get wrong.
     #[test]
-    fn it_draws_without_panicking_in_a_small_terminal() {
-        for (w, h) in [(80, 24), (30, 10), (10, 5)] {
-            let mut terminal = Terminal::new(TestBackend::new(w, h)).expect("terminal");
-            let picker = ThemePicker::new(None, None);
-            terminal
-                .draw(|f| picker.render(f, f.area(), &Theme::default()))
-                .expect("draw");
+    fn it_draws_without_panicking_at_every_size_down_to_one_cell() {
+        let dir = themes_dir("tiny");
+        for i in 0..30 {
+            write(&dir.0, &format!("mine-{i:02}"));
+        }
+
+        for (w, h) in [(80u16, 24u16), (30, 10), (10, 5), (2, 2), (1, 1)] {
+            for themes in [None, Some(&dir.0)] {
+                let mut terminal = Terminal::new(TestBackend::new(w, h)).expect("terminal");
+                let mut picker = ThemePicker::new(None, themes.map(std::path::PathBuf::as_path));
+                // Draw at the top, part-way down, and at the end, so the
+                // scrolled window is exercised as well as the initial one.
+                for _ in 0..3 {
+                    terminal
+                        .draw(|f| picker.render(f, f.area(), &Theme::default()))
+                        .unwrap_or_else(|e| panic!("{w}x{h} failed to draw: {e}"));
+                    for _ in 0..15 {
+                        picker.handle_key(key(KeyCode::Down));
+                    }
+                }
+            }
+        }
+    }
+
+    /// A dialog may allocate in proportion to what it draws. It must not
+    /// allocate in proportion to how many themes happen to be on disk.
+    ///
+    /// Weighs the buffer rather than the screen, deliberately. `take(ROWS)`
+    /// caps what is *drawn* whichever way the reservation is written, so a test
+    /// that counted rows on screen would pass with the bug in place — the trap
+    /// this repository keeps walking into. What was wrong was the size of the
+    /// allocation, so that is what this measures.
+    #[test]
+    fn drawing_reserves_room_for_the_window_not_for_the_whole_list() {
+        let dir = themes_dir("many");
+        for i in 0..400 {
+            write(&dir.0, &format!("mine-{i:03}"));
+        }
+        let mut picker = ThemePicker::new(None, Some(&dir.0));
+        assert!(picker.names().len() > 400, "there is a big list behind it");
+
+        // At the top, part-way down, and at the end.
+        for _ in 0..4 {
+            let lines = picker.lines(&Theme::default());
+            assert!(
+                lines.len() <= ROWS + 2,
+                "{} lines built for a {ROWS}-row window",
+                lines.len()
+            );
+            assert!(
+                lines.capacity() <= ROWS + 2,
+                "reserved room for {} lines to draw {}",
+                lines.capacity(),
+                lines.len()
+            );
+            for _ in 0..150 {
+                picker.handle_key(key(KeyCode::Down));
+            }
         }
     }
 }


### PR DESCRIPTION
The last module in Phase 1 — and my own recent code, so it gets the same treatment rather than a pass for being new.

## One finding

`render` reserved `self.names.len() + 2` lines and drew at most `ROWS`. With five thousand themes on disk that is room for **5,012 lines every frame to push 14**.

Nobody has five thousand themes; the number was never the point. The rule about allocating in proportion to what is on screen rather than to how much data sits behind it was written down three days before this module broke it.

## The more useful half: the first test could not fail

I wrote a test that counted theme rows reaching the screen. But `take(ROWS)` caps those **whichever way the reservation is written** — so it passed with the bug in place.

Splitting the line building into `ThemePicker::lines` lets the test weigh the `Vec`'s own capacity, which is the thing that was actually wrong. Reverting the fix now gives:

```
reserved room for 412 lines to draw 14
```

Same trap as the id reuse test and the `default.toml` drift test. The tell each time is that the assertion is about a *consequence* the bug does not change.

## Non-findings

- No panic anywhere from 1x1 to 5x5, with and without a list long enough to scroll. Unlike `prompt`, this module never indexes the buffer itself, so ratatui's clipping covers it.
- Live preview costs **~30µs per keystroke**, measured across all ten bundled themes including the filesystem stat that checks for a user override. Fair question for a dialog that re-resolves on every cursor move; the answer is that it does not matter.

## Phase 1 is complete

Every module read adversarially, every finding fixed or recorded with a reason. Two patterns ran through the whole pass, now written into `CLAUDE.md`:

- **Most findings sat next to a test that could not fail** — counting characters where cells were the bug, summing weights where proportions were the bug, counting drawn rows where the allocation was the bug.
- **The live defects clustered at the edges** — unbounded third-party feed text, a terminal resized to one column, a list that got shorter. The interior arithmetic was mostly right.

Verified afterwards in a live terminal: the picker draws and previews as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)