### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-28
+
+Four adversarial review passes, completing the first phase of the work towards
+1.0. Two of them found crashes, one found a way for a third-party news feed to
+grind the dashboard down, and one found a bug in code three days old.
+
+### Removed
+
+- **The unused-widget notice.** mirador used to name the widgets your layout
+  does not place — once in the status bar at startup, and permanently in the
+  help overlay. The status bar line retired on your first keypress; the overlay
+  section did not, so if you had deliberately switched four panels off you were
+  told about them every time you pressed `?`.
+
+  A dashboard cannot tell "has not discovered this yet" from "decided against
+  it", so a hint aimed at the first reminds the second for ever. `w` is still on
+  the status bar and in the help, so the way to switch a panel on is unchanged;
+  what is gone is being told that you should.
+
+### Changed
+
+- **The default watchlist leads with the major US indexes** — S&P 500, Dow,
+  Nasdaq Composite, Russell 2000 and Nasdaq-100 — keeping `AAPL` and `MSFT` so
+  the panel shows both kinds on a first run. This seeds the watchlist file on a
+  *first run only*, so an existing installation is untouched.
+
+- **News headlines are clipped to 400 characters when read**, links to 1,000 and
+  feed names to 80. See below for why; no real headline comes close.
+
+### Fixed
+
+- **A one-column terminal could bring the dashboard down.** The prompt dialog
+  computed its cursor position as `popup.x + popup.width - 2`, which underflowed
+  once the popup was clamped to a screen narrower than itself. Reachable by
+  resizing your terminal while a prompt is open.
+
+- **A news feed could decide how much work mirador does.** Nothing bounded the
+  text read out of a feed, and everything downstream of a story runs on every
+  frame — the headline is wrapped, the feed name uppercased. A 2 MB headline
+  wrapped to 40,000 lines and cost **72ms a frame**, and the HTTP body limit
+  allows five times that. A feed is the one input to this program that somebody
+  else writes.
+
+- **Place names and paths in non-Latin scripts drew over their own edges.** The
+  text field measured its scroll window in *characters* rather than display
+  cells, so a six-column field holding `北京市中心` decided five characters fit
+  and drew ten cells, with the caret landing in the middle of a glyph.
+
+- **A long line in a note body took the cursor off the screen.** The editor
+  deliberately does not wrap — a soft wrap that moves as you type makes the
+  cursor impossible to follow — and that had quietly come to mean you could keep
+  typing past the right-hand edge and see none of it. It scrolls sideways now.
+
+- **Arrange mode could rescale rows you had not touched.** Pushing a panel off
+  the edge of a thin row grew the total of the layout weights, so a dashboard
+  written as two equal rows became three unequal ones. Layouts written without
+  explicit heights were the ones affected.
+
+- **A list that got shorter left its cursor stranded.** Pressing Up walked the
+  selection down from wherever it had been, one row at a time, with nothing
+  highlighted the whole way. Down had always pulled it back into range; both do
+  now.
+
+- **`Alt` and a letter typed the letter into a note body**, where the task title
+  field had always ignored it.
+
+- **Moving the text cursor in the timezone picker threw away your place in the
+  list.** Left and Right were handled as though you had typed.
+
+- **A panel graph handed an area larger than the screen panicked** rather than
+  drawing what fits, and a sample buffer given a capacity of zero spun for ever.
+  Neither was reachable from any current caller; both are closed.
+
+- **Rearranging a layout written with `[[layout.rows]]` sections** said only
+  "no `[layout]` rows found", about a file that visibly has rows. It now names
+  the form it can rewrite. That form is still the only one mirador edits.
+
 ## [0.15.0] - 2026-07-27
 
 ### Added
@@ -996,7 +1073,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/jchultarsky/mirador/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/jchultarsky/mirador/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/jchultarsky/mirador/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/jchultarsky/mirador/compare/v0.13.0...v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog for 0.16.0 — four adversarial review passes, completing **Phase 1** of the road to 1.0.

**Minor rather than patch**, and deliberately: the unused-widget notice is gone, the default watchlist changed, and feed text is now clipped when read. None of those is a bug fix.

### Removed
- The unused-widget notice, from the status bar and the help overlay.

### Changed
- Default watchlist leads with the five major US indexes (first run only — existing installs untouched).
- News headlines clipped to 400 characters at parse, links to 1,000, feed names to 80.

### Fixed
- A one-column terminal could bring the dashboard down (prompt cursor underflow).
- A news feed could decide how much work mirador does — a 2 MB headline cost 72ms a frame, and the HTTP body limit allows five times that.
- Place names and paths in non-Latin scripts drew over their own edges (characters measured where cells were meant).
- A long line in a note body took the cursor off screen; the editor scrolls sideways now.
- Arrange mode could rescale rows you had not touched.
- A list that got shorter left its cursor stranded on the way up.
- `Alt`+letter typed the letter into a note body.
- Moving the text cursor in the timezone picker threw away your place in the list.
- A graph handed an oversized area panicked; a sample buffer given capacity 0 spun for ever. Neither reachable from a current caller; both closed.
- Rearranging a `[[layout.rows]]` layout now names the form it can rewrite.

Merge before tagging — `main` is protected, so the tag belongs on the squashed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)