### PR TITLE
Phase 2: stop handing untrusted text to ratatui's wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,8 +918,54 @@ from all possible bytes. 40,000 generated calendars run clean at a worst case of
 235µs; the committed test runs a subset that fits CI, and `probe_wide_sweep` is
 `#[ignore]`d for the full run.
 
+**`grid::wrap`: done.** Three findings. The module's own arithmetic was the
+smaller half — the larger one was that mirador was handing the same text to
+*ratatui's* wrapper, which crashes on it.
+
+**The live crash: `Paragraph::wrap` indexes past the end of the buffer.** Two
+ways in, both reachable without doing anything unusual. A double-width glyph
+inside a word too long for a **two-cell** area — `"a🌞b"` is enough — and a
+**leading combining mark**, a grapheme with no base character, which throws the
+accounting off at *any* width. It is a panic, not a misdraw: the dashboard dies.
+Reachable from a note, a task's notes, or a fetch error, and emoji in prose is
+ordinary. The height matters as much as the width, which is why nothing had ever
+seen it: the fault lands on a *later* row, so a one-row pane never reaches it.
+
+The fix is that **ratatui never wraps anything mirador did not write**.
+`grid::wrapped` wraps first and the `Paragraph` is given no `Wrap` at all, which
+keeps wrapping in the one module that measures in cells and is tested against a
+corpus of wide glyphs. Four sites moved: the note title and body, the task form's
+message, and the task notes; plus weather's fetch error, which comes off the
+network. Two `Wrap` calls remain on purpose — the help overlay and the delete
+confirmation are code-written ASCII, and the confirmation's one variable line is
+already `truncate`d to the width, so neither ever wraps untrusted text.
+
+`ratatuis_own_wrapper_is_why_this_module_wraps_first` pins the dependency bug the
+way the TOML nesting bound is pinned, and **says in its failure message that a
+fix upstream is good news** rather than something to delete the assertion over.
+
+The other two were in this module, and both are the Phase 1 pattern again:
+
+- **`wrap` and `wrapped_height` had drifted**, in both directions. The height
+  measured an over-long word by subtracting `width` a row at a time, which is
+  only right when every glyph is one cell — `日本語` at width 3 wraps to three
+  rows and measured two, and `中文标题` at width 1 wraps to four and measured
+  eight. A panel sizes itself with one and draws with the other. They are one
+  function with two consumers now, so they agree by construction; the counting
+  path still allocates nothing, which is what a scroll clamp over a whole note
+  body needs.
+- **A blank row after a line consumed exactly.** `wrap("🌞🌞", 1)` came out as
+  three rows, the last one empty — a wasted line under every headline that ends
+  on a boundary. A blank line the author *wrote* still gets its row.
+
+`wrapping_produces_exactly_as_many_rows_as_it_measures` sat directly on top of
+the first of those and passed throughout, because every sample in it was ASCII
+and every width was 8 or more. Not a test that could not fail — a test that was
+never handed the input that would fail it, which is the same thing in practice.
+Both fixes were checked by breaking them on purpose.
+
 *Exit:* no arbitrary input to any of the five produces a panic, a hang, or
-unbounded memory.
+unbounded memory. `layout_edit` and `themes` remain.
 
 ### Phase 3 — soak
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -943,6 +943,12 @@ already `truncate`d to the width, so neither ever wraps untrusted text.
 `ratatuis_own_wrapper_is_why_this_module_wraps_first` pins the dependency bug the
 way the TOML nesting bound is pinned, and **says in its failure message that a
 fix upstream is good news** rather than something to delete the assertion over.
+Reported as [ratatui#2679](https://github.com/ratatui/ratatui/issues/2679), with
+a standalone repro and two passing controls — the same text without the leading
+mark, and plain ASCII at width 2 — since what makes the report useful is the
+pair that *does not* crash. The root cause is `render_line` advancing `x` by each
+grapheme's width and indexing the buffer unguarded, trusting `WordWrapper` never
+to yield a line wider than the area; that invariant is what breaks.
 
 The other two were in this module, and both are the Phase 1 pattern again:
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -66,71 +66,134 @@ pub fn char_width(c: char) -> usize {
     unicode_width::UnicodeWidthChar::width(c).unwrap_or(0)
 }
 
-/// Break `text` into lines no wider than `width` display cells.
+/// Break `text` into rows of at most `width` cells, handing each to `emit`.
 ///
-/// The companion to [`wrapped_height`], which counts the same rows without
-/// producing them. `wrap(t, w).len()` and `wrapped_height(t, w)` are held equal
-/// by a test — they were written from the same rules and would otherwise drift,
-/// which for a panel that sizes itself from one and draws with the other means
-/// content sitting outside the box it was measured for.
+/// **The single source of the wrapping rules.** [`wrap`] collects what this
+/// yields and [`wrapped_height`] counts it without building anything, so the
+/// two cannot drift. They used to be two transcriptions of the same rules held
+/// equal by a test, and they *had* drifted: `wrapped_height` measured an
+/// over-long word by subtracting `width` a row at a time, which assumes the
+/// overflow can be split at any cell. A double-width glyph cannot be split, so
+/// the two disagreed in both directions the moment a headline was not ASCII —
+/// `日本語` at width 3 wraps to three rows and measured two. A panel that sizes
+/// itself with one and draws with the other then puts content outside the box
+/// it was measured for. The test that was supposed to catch this only ever fed
+/// it ASCII.
 ///
-/// Measured in cells rather than characters, per the rule the whole module
-/// exists for: a headline with an em dash or an accent breaks in the wrong
-/// place otherwise.
-pub fn wrap(text: &str, width: usize) -> Vec<String> {
+/// Rows are emitted as slices of `text`, so nothing here allocates. Measured in
+/// cells rather than characters, per the rule the whole module exists for.
+fn break_lines<'a>(text: &'a str, width: usize, mut emit: impl FnMut(&'a str)) {
     if width == 0 {
-        return Vec::new();
+        return;
     }
 
-    let mut out = Vec::new();
+    let mut any = false;
     for line in text.lines() {
-        let mut current = String::new();
+        // Byte offsets into `line`: where the row being built starts, and how
+        // far the words consumed so far reach.
+        let mut start = 0usize;
+        let mut cursor = 0usize;
         let mut used = 0usize;
+        let mut emitted_here = false;
 
         for word in line.split_inclusive(' ') {
             let w = display_width(word);
             if used > 0 && used + w > width {
-                out.push(std::mem::take(&mut current));
+                emit(&line[start..cursor]);
+                (any, emitted_here) = (true, true);
+                start = cursor;
                 used = 0;
             }
-            current.push_str(word);
+            cursor += word.len();
             used += w;
 
-            // A single word longer than the line breaks inside itself, rather
+            // A single word longer than the row breaks inside itself, rather
             // than running off the edge.
             while used > width {
-                let mut keep: String = current
-                    .chars()
-                    .scan(0usize, |taken, c| {
-                        *taken += display_width(&c.to_string());
-                        (*taken <= width).then_some(c)
-                    })
-                    .collect();
-                // Always take at least one character. A glyph wider than the
-                // whole line — any CJK character or emoji in a one-cell column
-                // — otherwise fits nowhere, so nothing is taken, nothing is
-                // consumed, and this loops for ever. That is a hang, not a
-                // slow path: the dashboard freezes and has to be killed.
-                //
-                // The line then exceeds `width` by a cell, which is the honest
-                // outcome. A terminal cannot draw half a wide glyph either.
-                if keep.is_empty() {
-                    keep.extend(current.chars().next());
+                let mut cut = start;
+                let mut taken = 0usize;
+                for c in line[start..cursor].chars() {
+                    let cw = char_width(c);
+                    if taken + cw > width {
+                        break;
+                    }
+                    taken += cw;
+                    cut += c.len_utf8();
                 }
-                let rest = current[keep.len()..].to_string();
-                out.push(keep);
-                current = rest;
-                used = display_width(&current);
+                // Always take at least one character. A glyph wider than the
+                // whole row — any CJK character or emoji in a one-cell column —
+                // otherwise fits nowhere, so nothing is taken, nothing is
+                // consumed, and this loops for ever. That is a hang, not a slow
+                // path: the dashboard freezes and has to be killed.
+                //
+                // The row then exceeds `width` by a cell, which is the honest
+                // outcome. A terminal cannot draw half a wide glyph either.
+                if cut == start {
+                    match line[start..cursor].chars().next() {
+                        Some(c) => cut += c.len_utf8(),
+                        None => break,
+                    }
+                }
+                emit(&line[start..cut]);
+                (any, emitted_here) = (true, true);
+                start = cut;
+                used = display_width(&line[start..cursor]);
             }
         }
-        out.push(current);
+
+        // The remainder — but only if there is one. Emitting it unconditionally
+        // appended a blank row whenever the break above consumed the line
+        // exactly, which is what an over-long run of wide glyphs always does:
+        // `wrap("🌞🌞", 1)` came out as three rows, the last one empty. A
+        // genuinely empty source line still gets its row, hence `emitted_here`.
+        if start < cursor || !emitted_here {
+            emit(&line[start..cursor]);
+            any = true;
+        }
     }
-    // `wrapped_height` floors at one row, on the grounds that an empty line
-    // still occupies one. These two are held equal by a test, so this has to
-    // agree — and `"".lines()` yields nothing at all.
-    if out.is_empty() {
-        out.push(String::new());
+
+    // An empty string has no lines at all, and still occupies one row.
+    if !any {
+        emit("");
     }
+}
+
+/// Break `text` into lines no wider than `width` display cells.
+///
+/// The companion to [`wrapped_height`], which counts the same rows without
+/// producing them. Both are [`break_lines`] with a different consumer, so
+/// `wrap(t, w).len()` and `wrapped_height(t, w)` agree by construction rather
+/// than by a test that has to remember to try a wide glyph.
+pub fn wrap(text: &str, width: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    break_lines(text, width, |line| out.push(line.to_string()));
+    out
+}
+
+/// `text` wrapped to `width` and rejoined, ready for a `Paragraph` that must
+/// **not** be given `Wrap`.
+///
+/// This exists because ratatui's own word wrapper panics on text mirador did
+/// not write. `Paragraph::new("a🌞b").wrap(…)` rendered two cells wide indexes
+/// past the end of the buffer and brings the whole dashboard down, and a
+/// leading combining mark — a grapheme with no base character — does the same
+/// at any width. Both are reachable from a note, a task's notes, or a fetch
+/// error: emoji in prose is ordinary, and the panic is a crash rather than a
+/// misdraw.
+///
+/// So the rule is that ratatui never wraps anything a user or a server wrote.
+/// Wrapping here first means its wrapper never runs, and the wrapping is the
+/// one in this module, which is measured in cells and tested against a corpus
+/// of wide glyphs and combining marks.
+pub fn wrapped(text: &str, width: u16) -> String {
+    let width = usize::from(width);
+    let mut out = String::with_capacity(text.len());
+    break_lines(text, width, |line| {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(line);
+    });
     out
 }
 
@@ -142,35 +205,20 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
 /// longer than the box, and then it is short by exactly the amount that
 /// matters.
 ///
-/// Matches `Paragraph::new(text).wrap(Wrap { trim: false })`, whose own
-/// `line_count` is private. An empty line still occupies a row.
+/// Counts the rows [`wrap`] would produce, without producing them — the whole
+/// point, since a scroll clamp runs against a note's entire body and must not
+/// allocate in proportion to it. An empty line still occupies a row.
+///
+/// This used to be documented as matching `Paragraph::wrap`, whose own
+/// `line_count` is private. It no longer needs to: nothing is handed to
+/// ratatui's wrapper any more (see [`wrapped`]), so the thing worth agreeing
+/// with is mirador's own wrapping, which is what gets drawn.
 pub fn wrapped_height(text: &str, width: u16) -> u16 {
     if width == 0 {
         return 0;
     }
-    let width = usize::from(width);
     let mut rows: usize = 0;
-
-    for line in text.lines() {
-        let mut used = 0usize;
-        let mut rows_here = 1usize;
-        for word in line.split_inclusive(' ') {
-            let w = display_width(word);
-            if used > 0 && used + w > width {
-                rows_here += 1;
-                used = w;
-            } else {
-                used += w;
-            }
-            // A single word longer than the line wraps within itself.
-            while used > width {
-                rows_here += 1;
-                used -= width;
-            }
-        }
-        rows += rows_here;
-    }
-
+    break_lines(text, usize::from(width), |_| rows += 1);
     u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
 }
 
@@ -428,9 +476,19 @@ fn fit(text: &str, width: u16, align: Align) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::widgets::{Paragraph, Wrap};
 
     /// The two must agree: a panel sizes itself with one and draws with the
     /// other, so a disagreement puts content outside the box measured for it.
+    ///
+    /// They are one function with two consumers now, so this cannot fail by
+    /// drift any more — but it could once, and for a long time it did not
+    /// notice. Every sample was ASCII, and the bug was that `wrapped_height`
+    /// measured an over-long word by subtracting `width` a row at a time, which
+    /// is only right when every glyph is one cell. The wide glyphs and the
+    /// widths below 8 are the part of this test that ever had a chance.
     #[test]
     fn wrapping_produces_exactly_as_many_rows_as_it_measures() {
         let samples = [
@@ -440,9 +498,19 @@ mod tests {
             "a supercalifragilisticexpialidociousandthensomeword in a line",
             "Europa Clipper returns its first images — and they are extraordinary",
             "line one\nline two is a good deal longer than the first one is",
+            // A headline is somebody else's text, and it is not always Latin.
+            "\u{4E2D}\u{6587}\u{6807}\u{9898}",
+            "\u{65E5}\u{672C}\u{8A9E}\u{306E}\u{30CB}\u{30E5}\u{30FC}\u{30B9}\u{3067}\u{3059}",
+            "a\u{1F31E}b\u{1F31E}c",
+            "\u{1F31E}\u{1F31E}\u{1F31E}\u{1F31E}",
+            "mixed \u{4E2D}\u{6587} and english \u{1F31E} together",
+            // A combining mark with no base character, which is a grapheme all
+            // the same and measures zero cells.
+            "\u{0301}\u{0301}leading marks",
+            "blank\n\nline in the middle",
         ];
         for text in samples {
-            for width in 8..40u16 {
+            for width in 1..40u16 {
                 assert_eq!(
                     u16::try_from(wrap(text, usize::from(width)).len()).unwrap(),
                     wrapped_height(text, width),
@@ -450,6 +518,23 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// An over-long run of wide glyphs consumes the row exactly, and the
+    /// remainder is then empty. Emitting it anyway appended a blank row that
+    /// nothing asked for — `wrap("🌞🌞", 1)` came out as three rows, the last
+    /// one empty, which in the news panel is a wasted line at the bottom of
+    /// every headline that ends on a boundary.
+    #[test]
+    fn a_row_consumed_exactly_leaves_no_blank_behind() {
+        assert_eq!(wrap("\u{1F31E}\u{1F31E}", 1), ["\u{1F31E}", "\u{1F31E}"]);
+        assert_eq!(wrap("abcdef", 3), ["abc", "def"]);
+        assert_eq!(wrap("\u{65E5}\u{672C}", 2), ["\u{65E5}", "\u{672C}"]);
+
+        // But a blank line the author actually wrote still gets its row.
+        assert_eq!(wrap("a\n\nb", 4), ["a", "", "b"]);
+        assert_eq!(wrap("", 4), [""]);
+        assert_eq!(wrap("\n", 4), [""]);
     }
 
     /// A glyph wider than the whole line fits nowhere, so "take as many
@@ -476,6 +561,99 @@ mod tests {
                 assert_eq!(joined, text, "at {width}");
             }
         }
+    }
+
+    /// The corpus that crashes ratatui: narrow and wide glyphs at every offset,
+    /// spaces, newlines, and a combining mark with no base character.
+    ///
+    /// Deterministic and hand-rolled for the same reason as `ical`'s — what
+    /// matters is that every fragment is in it because of something the
+    /// wrapper does, not that the bytes are random.
+    fn crashing_corpus() -> Vec<String> {
+        let alphabet = ["a", "\u{1F31E}", "\u{65E5}", " ", "\n", "\u{0301}"];
+        let mut seed = 0x2545_F491_4F6C_DD1Du64;
+        let mut next = move || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        (0..600)
+            .map(|_| {
+                let len = (next() % 9) as usize + 1;
+                (0..len)
+                    .map(|_| alphabet[(next() % alphabet.len() as u64) as usize])
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn renders_without_panicking(paragraph: impl Fn() -> Paragraph<'static>, width: u16) -> bool {
+        let mut terminal = Terminal::new(TestBackend::new(width, 12)).unwrap();
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            terminal
+                .draw(|frame| frame.render_widget(paragraph(), frame.area()))
+                .unwrap();
+        }))
+        .is_ok()
+    }
+
+    /// The reason [`wrapped`] exists, pinned rather than described.
+    ///
+    /// ratatui's own word wrapper indexes past the end of the buffer and
+    /// panics, which for a dashboard is a crash rather than a misdraw. Two ways
+    /// in: a double-width glyph inside a word too long for a two-cell area, and
+    /// a leading combining mark, which throws the accounting off at any width.
+    /// Neither needs unusual input — emoji in a note is ordinary.
+    ///
+    /// **If this test starts failing, ratatui has fixed it.** That is good
+    /// news, and the thing to do is check whether `wrapped` can go, not to
+    /// delete the assertion. The bound lives in a dependency and would leave
+    /// with it.
+    #[test]
+    fn ratatuis_own_wrapper_is_why_this_module_wraps_first() {
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let straddles_a_two_cell_row = renders_without_panicking(
+            || Paragraph::new("a\u{1F31E}b").wrap(Wrap { trim: false }),
+            2,
+        );
+        let leading_combining_mark = renders_without_panicking(
+            || {
+                Paragraph::new("\u{0301} \u{1F31E}\u{65E5}\u{65E5}\u{65E5}\u{1F31E}\u{1F31E}a")
+                    .wrap(Wrap { trim: false })
+            },
+            8,
+        );
+        std::panic::set_hook(hook);
+
+        assert!(
+            !straddles_a_two_cell_row && !leading_combining_mark,
+            "ratatui no longer panics here (two-cell row: {}, combining mark: {}). \
+             Check whether `grid::wrapped` is still needed before removing this.",
+            !straddles_a_two_cell_row,
+            !leading_combining_mark
+        );
+    }
+
+    /// And the fix: the same corpus, wrapped here and handed to a `Paragraph`
+    /// with no `Wrap`, draws at every width without bringing the dashboard
+    /// down.
+    #[test]
+    fn pre_wrapping_survives_what_crashes_ratatui() {
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let mut crashed = Vec::new();
+        for text in crashing_corpus() {
+            for width in 1..12u16 {
+                let wrapped_text = wrapped(&text, width);
+                if !renders_without_panicking(|| Paragraph::new(wrapped_text.clone()), width) {
+                    crashed.push(format!("{text:?} at {width}"));
+                }
+            }
+        }
+        std::panic::set_hook(hook);
+        assert!(crashed.is_empty(), "still panics: {crashed:?}");
     }
 
     #[test]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -606,6 +606,8 @@ mod tests {
     /// a leading combining mark, which throws the accounting off at any width.
     /// Neither needs unusual input — emoji in a note is ordinary.
     ///
+    /// Reported upstream as <https://github.com/ratatui/ratatui/issues/2679>.
+    ///
     /// **If this test starts failing, ratatui has fixed it.** That is good
     /// news, and the thing to do is check whether `wrapped` can go, not to
     /// delete the assertion. The bound lives in a dependency and would leave

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -16,7 +16,7 @@ use ratatui::crossterm::event::{
 use ratatui::layout::{Constraint, Layout, Position, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 
 use crate::config::NotesConfig;
 use crate::frame::Binding;
@@ -460,14 +460,15 @@ impl NotesPanel {
         ])
         .split(area);
 
+        // Wrapped by `grid` rather than by ratatui, whose own wrapper panics on
+        // text mirador did not write — and a note is exactly that. See
+        // `grid::wrapped`.
         frame.render_widget(
-            Paragraph::new(Span::styled(
-                note.title.clone(),
+            Paragraph::new(crate::grid::wrapped(&note.title, rows[0].width)).style(
                 Style::default()
                     .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),
-            ))
-            .wrap(Wrap { trim: false }),
+            ),
             rows[0],
         );
 
@@ -489,7 +490,8 @@ impl NotesPanel {
         let body = if note.body.trim().is_empty() {
             Paragraph::new(Span::styled("(no body)", Style::default().fg(theme.muted)))
         } else {
-            Paragraph::new(note.body.clone()).style(Style::default().fg(theme.text))
+            Paragraph::new(crate::grid::wrapped(&note.body, rows[2].width))
+                .style(Style::default().fg(theme.text))
         };
         // The reader wraps even though the editor does not: prose written at
         // one width has to be readable at another.
@@ -498,11 +500,7 @@ impl NotesPanel {
         // written as one paragraph — the normal way — reported a single line
         // and would not scroll at all however long it was.
         self.body_area = Some(rows[2]);
-        frame.render_widget(
-            body.wrap(Wrap { trim: false })
-                .scroll((self.body_scroll, 0)),
-            rows[2],
-        );
+        frame.render_widget(body.scroll((self.body_scroll, 0)), rows[2]);
     }
 
     /// The count line above the split, plus the active search if there is one.
@@ -1145,6 +1143,54 @@ mod tests {
                 KeyOutcome::Consumed,
                 "`{key}` is documented but the list ignores it"
             );
+        }
+    }
+
+    /// A note is prose somebody wrote, and prose contains emoji. Handing that
+    /// to ratatui's word wrapper crashes the dashboard — see `grid::wrapped`,
+    /// which is why this panel wraps its own title and body and renders a
+    /// `Paragraph` with no `Wrap`.
+    ///
+    /// This is the guard against putting `.wrap(…)` back. The grid has its own
+    /// test for the wrapping; this one exists because the mistake is made here.
+    #[test]
+    fn a_note_full_of_wide_glyphs_draws_at_every_width() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+
+        let (mut p, _g) = panel("wide-glyphs");
+        add_note(
+            &mut p,
+            "a\u{1F31E}b \u{4E2D}\u{6587}\u{6807}\u{9898}",
+            "\u{0301} \u{1F31E}\u{65E5}\u{65E5}\u{65E5}\u{1F31E}\u{1F31E}a\n\
+             prose with a \u{1F31E} in it and a \u{65E5}\u{672C}\u{8A9E} word",
+        );
+
+        // The height matters as much as the width, and that is not obvious: the
+        // fault is on a later row, so a one-row pane never reaches it. This
+        // test passed against the very bug it exists for until the panes were
+        // given room to wrap into.
+        for width in 1..24u16 {
+            for height in 1..40u16 {
+                let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+                terminal
+                    .draw(|frame| {
+                        p.render(
+                            frame,
+                            frame.area(),
+                            RenderContext {
+                                theme: &config.theme,
+                                gradients: &gradients,
+                                focused: true,
+                                watch: &crate::watch::WatchLog::default(),
+                            },
+                        );
+                    })
+                    .unwrap();
+            }
         }
     }
 

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -827,14 +827,17 @@ impl TodoPanel {
         }
 
         // Hint or validation error.
-        let message = match &form.error {
-            Some(err) => Span::styled(err.clone(), Style::default().fg(theme.error)),
-            None => Span::styled(
-                hint_for(form.field).to_string(),
-                Style::default().fg(theme.muted),
-            ),
+        // Wrapped by `grid` rather than by ratatui — a save error carries text
+        // from the operating system, and ratatui's wrapper panics on text
+        // mirador did not write. See `grid::wrapped`.
+        let (message, style) = match &form.error {
+            Some(err) => (err.as_str(), Style::default().fg(theme.error)),
+            None => (hint_for(form.field), Style::default().fg(theme.muted)),
         };
-        frame.render_widget(Paragraph::new(message).wrap(Wrap { trim: true }), rows[6]);
+        frame.render_widget(
+            Paragraph::new(crate::grid::wrapped(message, rows[6].width)).style(style),
+            rows[6],
+        );
 
         frame.render_widget(
             Paragraph::new(Span::styled(
@@ -1111,8 +1114,8 @@ impl Panel for TodoPanel {
                 .and_then(|t| t.notes.clone())
         {
             frame.render_widget(
-                Paragraph::new(Span::styled(notes, Style::default().fg(theme.muted)))
-                    .wrap(Wrap { trim: true }),
+                Paragraph::new(crate::grid::wrapped(&notes, rows[3].width))
+                    .style(Style::default().fg(theme.muted)),
                 rows[3],
             );
         }

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -19,7 +19,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::widgets::Paragraph;
 use serde::Deserialize;
 
 use crate::config::WeatherConfig;
@@ -890,25 +890,31 @@ impl Panel for WeatherPanel {
         let Some(reading) = state.data.take() else {
             // Nothing has ever landed. Only here is the panel genuinely empty.
             let lines = match &state.error {
-                Some(message) => vec![
-                    Line::from(Span::styled(
+                Some(message) => {
+                    let muted = Style::default().fg(theme.muted);
+                    let mut lines = vec![Line::from(Span::styled(
                         "Weather unavailable",
                         Style::default()
                             .fg(theme.error)
                             .add_modifier(Modifier::BOLD),
-                    )),
-                    Line::from(Span::styled(
-                        message.clone(),
-                        Style::default().fg(theme.muted),
-                    )),
-                    Line::from(Span::styled("r to retry", Style::default().fg(theme.muted))),
-                ],
+                    ))];
+                    // Wrapped here rather than by ratatui: the message comes
+                    // from the network stack, and ratatui's own wrapper panics
+                    // on text mirador did not write. See `grid::wrapped`.
+                    lines.extend(
+                        crate::grid::wrap(message, usize::from(area.width))
+                            .into_iter()
+                            .map(|row| Line::from(Span::styled(row, muted))),
+                    );
+                    lines.push(Line::from(Span::styled("r to retry", muted)));
+                    lines
+                }
                 None => vec![Line::from(Span::styled(
                     "Fetching weather\u{2026}",
                     Style::default().fg(theme.muted),
                 ))],
             };
-            frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+            frame.render_widget(Paragraph::new(lines), area);
             return;
         };
 


### PR DESCRIPTION
Phase 2 of the road to 1.0 — the untrusted-input boundary. This is the
`grid::wrap` item, and it found more outside the module than in it.

## The live one is in ratatui, not in `grid`

`Paragraph::wrap` indexes past the end of the buffer and panics. Two ways in,
neither exotic:

- a double-width glyph inside a word too long for a **two-cell** area —
  `"a🌞b"` is enough;
- a **leading combining mark**, a grapheme with no base character, which throws
  the accounting off at *any* width.

It is a crash rather than a misdraw: the dashboard dies. Reachable from a note,
a task's notes, or a fetch error, and emoji in prose is ordinary.

The reason nothing had ever seen it is worth recording: **the fault lands on a
later row**, so a one-row pane never reaches it. The first version of the
regression test here passed against the very bug it exists for, until the panes
were given room to wrap into.

### The fix

**ratatui no longer wraps anything mirador did not write.** `grid::wrapped`
wraps first and the `Paragraph` is given no `Wrap` at all, which keeps wrapping
in the one module that measures in cells and is tested against a corpus of wide
glyphs and combining marks.

Four sites moved — the note title and body, the task form's message, and the
task notes — plus weather's fetch error, which comes off the network.

Two `Wrap` calls remain **on purpose**: the help overlay and the delete
confirmation are code-written ASCII, and the confirmation's one variable line is
already `truncate`d to the width, so neither ever wraps untrusted text.

`ratatuis_own_wrapper_is_why_this_module_wraps_first` pins the dependency bug the
way the TOML nesting bound in `themes` is pinned, and its failure message says a
fix upstream is good news rather than something to delete the assertion over.

## Two more, in `grid` itself

**`wrap` and `wrapped_height` had drifted, in both directions.** The height
measured an over-long word by subtracting `width` a row at a time, which is only
right when every glyph is one cell — `日本語` at width 3 wraps to three rows and
measured two, and `中文标题` at width 1 wraps to four and measured eight. A panel
sizes itself with one and draws with the other. They are one function with two
consumers now, so they agree by construction; the counting path still allocates
nothing, which is what a scroll clamp over a whole note body needs.

**A blank row after a line consumed exactly.** `wrap("🌞🌞", 1)` came out as
three rows, the last one empty — a wasted line under every headline that ends on
a boundary. A blank line the author *wrote* still gets its row.

## The test that sat on top of it

`wrapping_produces_exactly_as_many_rows_as_it_measures` was directly above the
drift and passed throughout, because every sample in it was ASCII and every
width was 8 or more. Not a test that could not fail — a test that was never
handed the input that would fail it, which is the same thing in practice. Both
fixes were checked by breaking them on purpose and watching it go red.

## Checks

`cargo test` (615 passing), `clippy --all-targets -D warnings`, `fmt --check`
and `RUSTDOCFLAGS="-D warnings" cargo doc` are all clean.

Phase 2 has `themes` and `layout_edit` left after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
