### PR TITLE
Phase 2: bound what a theme file can cost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,8 +1029,45 @@ rows come out in order. And every byte-offset slice in the module — `strip_com
 `quoted_value`, `after_key`, `set_number` — indexes at a character boundary by
 construction, so the multi-byte panic that `ical` had cannot happen here.
 
-*Exit:* no arbitrary input to any of the five produces a panic, a hang, or
-unbounded memory. `themes` is the last one.
+**`themes`: done.** Two findings, and both are about the same thing Phase 1
+missed here: it read this module for *correctness* and found the path traversal,
+but never asked what anything **cost**.
+
+**Nothing bounded the size of a theme file.** `ical` got a 10MB cap for exactly
+this and `themes` had none, which matters far more than the size of a theme
+suggests — **the `t` picker re-resolves from disk on every cursor move.** That
+is what makes live preview work, and it puts the cost of reading a theme on an
+arrow key. Measured: an 8MB file took **233ms** to resolve against the ~30µs
+the bundled ones cost, which is not a slow picker but one that appears to have
+hung. `inherits` then multiplies it by up to `MAX_DEPTH`, and the depth check
+runs *after* each file is read — a chain of twenty 2MB files read 34MB before
+refusing on depth. `MAX_THEME_BYTES` is 256KB, more than a hundred times the
+largest bundled theme at 1,788 bytes, and the read is bounded with `take` rather
+than by trusting a length from `metadata` — asking how big a file is and then
+reading it are two different facts, and only one of them bounds the allocation.
+
+**The error message quoted the offending value whole.** A two-megabyte colour
+string produced a two-megabyte error, built and then *discarded* on every cursor
+move in the picker. Same shape as the unbounded headline in `feed`, reached from
+the other end. Clipped to 40 characters, which is still twice any real colour.
+
+Non-findings, recorded because they were checked. Three thousand generated theme
+documents — palette tables shadowing colour keys, `inherits` pointing at itself,
+values of the wrong type, empty and multi-byte colour strings, unclosed
+gradients — produced no panic and no hang. Cycle detection is by name and holds.
+And `parse_color` cannot panic on any input, because ratatui's `Color: FromStr`
+returns a `Result`; the danger there was never the parse, only what the failure
+message did with what it was handed.
+
+*Exit criterion met.* No arbitrary input to any of the five produces a panic, a
+hang, or unbounded memory.
+
+**Phase 2 is complete.** The pattern across all five is worth carrying into
+Phase 4: the interior logic was mostly right, and what was missing was a
+*bound* — on a headline, on a calendar's line count, on a wrapped row, on a
+theme file, on the text an error message quotes back. Four of the five findings
+in the last two modules were reached by asking "what does this cost when the
+input is hostile", not "is this correct".
 
 ### Phase 3 — soak
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -18,12 +18,22 @@ use serde::{Deserialize, Deserializer};
 
 use crate::chart::Gradient;
 
+/// The most of an unusable value worth quoting back.
+///
+/// A colour is at most a couple of dozen characters, so anything past this is
+/// not a typo to point at. The message otherwise embeds whatever was in the
+/// file: a two-megabyte string produced a two-megabyte error, built — and then
+/// discarded — on **every cursor move in the `t` picker**, which re-resolves
+/// from disk to preview. Same shape as the unbounded headline in `feed`.
+const MAX_QUOTED: usize = 40;
+
 /// Parse a `Color` from its string form, reporting a useful error on failure.
 fn parse_color<E: serde::de::Error>(raw: &str) -> Result<Color, E> {
     raw.parse::<Color>().map_err(|_| {
         serde::de::Error::custom(format!(
-            "`{raw}` is not a colour; use a name (`red`, `light-blue`), \
-             a hex string (`#ff8800`), a 256-colour index (`12`), or `reset`"
+            "`{}` is not a colour; use a name (`red`, `light-blue`), \
+             a hex string (`#ff8800`), a 256-colour index (`12`), or `reset`",
+            crate::grid::truncate(raw, MAX_QUOTED)
         ))
     })
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -82,6 +82,21 @@ const BUNDLED: &[(&str, &str)] = &[
 /// Cycles are caught by name, so this only bounds the honest-but-silly case.
 const MAX_DEPTH: usize = 16;
 
+/// The largest theme file mirador will read.
+///
+/// The largest bundled theme is 1,788 bytes, so this is more than a hundred
+/// times the biggest real one — the point is to have a bound at all, not to
+/// have a tight one.
+///
+/// It matters more than the size of a theme suggests, because **the `t` picker
+/// re-resolves from disk on every cursor move**. That is what makes live preview
+/// work, and it puts the cost of reading a theme on an arrow key: measured, an
+/// 8MB file took 233ms to resolve, which is a visibly stuck picker rather than
+/// the ~30µs the bundled ones cost. `inherits` then multiplies it by up to
+/// [`MAX_DEPTH`], and the depth check happens *after* each file is read, so a
+/// chain of large files is read in full before being refused.
+const MAX_THEME_BYTES: u64 = 256 * 1024;
+
 /// The names that ship, for error messages.
 pub fn bundled_names() -> Vec<&'static str> {
     BUNDLED.iter().map(|(name, _)| *name).collect()
@@ -185,8 +200,7 @@ fn read(name: &str, themes_dir: Option<&Path>) -> Result<toml::Table> {
     if let Some(path) = themes_dir.map(|dir| dir.join(format!("{name}.toml")))
         && path.exists()
     {
-        let raw = std::fs::read_to_string(&path)
-            .with_context(|| format!("reading theme {}", path.display()))?;
+        let raw = read_bounded(&path)?;
         return toml::from_str(&raw).with_context(|| format!("parsing theme {}", path.display()));
     }
 
@@ -205,6 +219,34 @@ fn read(name: &str, themes_dir: Option<&Path>) -> Result<toml::Table> {
          `{name}.toml` in {where_to_put_it}.",
         known.join(", ")
     )
+}
+
+/// Read a theme file, refusing one larger than [`MAX_THEME_BYTES`].
+///
+/// Bounded with `take` rather than by checking the length first, so the refusal
+/// costs one buffer of the limit rather than a copy of the file: asking the
+/// filesystem how big something is and then trusting the answer while reading it
+/// is two different facts, and only one of them bounds the allocation.
+fn read_bounded(path: &Path) -> Result<String> {
+    use std::io::Read;
+
+    let file =
+        std::fs::File::open(path).with_context(|| format!("reading theme {}", path.display()))?;
+    let mut raw = String::new();
+    file.take(MAX_THEME_BYTES + 1)
+        .read_to_string(&mut raw)
+        .with_context(|| format!("reading theme {}", path.display()))?;
+
+    if raw.len() as u64 > MAX_THEME_BYTES {
+        bail!(
+            "theme {} is larger than {}KB, which is far past anything a theme \
+             needs — the largest one mirador ships is under 2KB. Check it is \
+             the file you meant.",
+            path.display(),
+            MAX_THEME_BYTES / 1024
+        );
+    }
+    Ok(raw)
 }
 
 /// Catch colour keys that have fallen inside `[palette]`.
@@ -293,6 +335,60 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    /// A theme file is read on **every cursor move in the `t` picker**, which
+    /// re-resolves from disk to preview. Before the cap an 8MB file took 233ms
+    /// to resolve against the ~30µs the bundled ones cost, which is a picker
+    /// that appears to have hung; `inherits` then multiplies it by up to
+    /// `MAX_DEPTH`, and the depth check runs *after* each file is read, so a
+    /// chain of large files is read in full before being refused.
+    #[test]
+    fn a_theme_file_far_larger_than_any_real_one_is_refused() {
+        let (dir, _guard) = themes_dir("oversized");
+        let mut text = String::from("text = \"reset\"\n");
+        while text.len() as u64 <= MAX_THEME_BYTES {
+            text.push_str("# padding padding padding padding padding padding\n");
+        }
+        std::fs::write(dir.join("oversized.toml"), &text).unwrap();
+
+        let err = resolve("oversized", Some(&dir)).expect_err("an oversized theme is refused");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("larger than"),
+            "say what is wrong: `{message}`"
+        );
+
+        // And the bound is not so tight that an ordinary theme trips it: every
+        // bundled theme is orders of magnitude below it.
+        for (name, raw) in BUNDLED {
+            assert!(
+                raw.len() as u64 <= MAX_THEME_BYTES / 8,
+                "bundled theme `{name}` is {} bytes, close enough to the cap to \
+                 make it a real risk",
+                raw.len()
+            );
+        }
+    }
+
+    /// The error quoted whatever was in the file, so a two-megabyte value
+    /// produced a two-megabyte message — built and discarded on every cursor
+    /// move in the picker. Same shape as the unbounded headline in `feed`.
+    #[test]
+    fn an_unusable_value_is_not_quoted_back_in_full() {
+        let (dir, _guard) = themes_dir("longvalue");
+        let huge = "z".repeat(100_000);
+        std::fs::write(dir.join("longvalue.toml"), format!("accent = \"{huge}\"\n")).unwrap();
+
+        let err = resolve("longvalue", Some(&dir)).expect_err("not a colour");
+        let message = format!("{err:#}");
+        assert!(
+            message.len() < 1_000,
+            "the message is {} bytes long",
+            message.len()
+        );
+        // Still useful: it names the key and says what a colour looks like.
+        assert!(message.contains("is not a colour"), "`{message}`");
     }
 
     fn themes_dir(name: &str) -> (PathBuf, TempDir) {


### PR DESCRIPTION
The last of Phase 2's five. Two findings, and both are the thing Phase 1 missed
here: it read this module for *correctness* and found the path traversal, but
never asked what anything **cost**.

## Nothing bounded the size of a theme file

`ical` got a 10MB cap for exactly this. `themes` had none — and that matters
far more than the size of a theme suggests, because **the `t` picker
re-resolves from disk on every cursor move**. That is what makes live preview
work, and it puts the cost of reading a theme on an arrow key.

Measured: an 8MB file took **233ms** to resolve, against the ~30µs the bundled
ones cost. That is not a slow picker, it is one that appears to have hung.

`inherits` then multiplies it by up to `MAX_DEPTH`, and the depth check runs
*after* each file is read — a chain of twenty 2MB files read 34MB before
refusing on depth.

`MAX_THEME_BYTES` is 256KB, more than a hundred times the largest bundled theme
(1,788 bytes). The point is to have a bound, not a tight one.

The read is bounded with `take` rather than by checking a length from
`metadata` first: asking the filesystem how big something is and then trusting
that while reading it are two different facts, and only one of them bounds the
allocation.

## The error message quoted the offending value whole

A two-megabyte colour string produced a two-megabyte error — built, and then
*discarded*, on every cursor move in the picker. Same shape as the unbounded
headline in `feed`, reached from the other end. Clipped to 40 characters, still
twice any real colour, and the message still names the key and says what a
colour looks like.

## Non-findings, recorded because they were checked

Three thousand generated theme documents — palette tables shadowing colour
keys, `inherits` pointing at itself, values of the wrong type, empty and
multi-byte colour strings, unclosed gradients — produced no panic and no hang.
Cycle detection is by name and holds.

`parse_color` cannot panic on any input, because ratatui's `Color: FromStr`
returns a `Result`. The danger there was never the parse; only what the failure
message did with what it was handed.

## Both fixes were checked by breaking them

Revert the cap and `a_theme_file_far_larger_than_any_real_one_is_refused` goes
red; revert the clip and `an_unusable_value_is_not_quoted_back_in_full` reports
a 100KB message. The size test also asserts the bound is not so tight that a
real theme could trip it.

## Phase 2 is complete

The pattern across all five is worth carrying into Phase 4: the interior logic
was mostly right, and what was missing was a **bound** — on a headline, on a
calendar's line count, on a wrapped row, on a theme file, on the text an error
message quotes back. Four of the five findings in the last two modules were
reached by asking "what does this cost when the input is hostile", not "is this
correct".

## Checks

`cargo test` (622 passing), `clippy --all-targets -D warnings`, `fmt --check`
and `RUSTDOCFLAGS="-D warnings" cargo doc` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
