### PR TITLE
Phase 4: freeze the formats, and check the promise before making it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1092,7 +1092,55 @@ documented, every data file (`todos.toml`, notes, `watchlist.toml`,
 `zones.toml`, `state.toml`, `update-check.toml`) either forward-compatible or
 migrated, and `migrate.rs` covering every rename ever shipped.
 
-*Exit:* a compatibility statement in the README that is true.
+**Done.** The audit found the formats in better shape than expected and one
+real defect, and the useful part is which of the three sub-questions had a
+mechanical answer.
+
+**No option that ever shipped has been removed.** Checked by extracting every
+key from `assets/default_config.toml` at all twenty-two release tags and
+diffing: 78 keys, none lost. So `migrate.rs` covering "every rename ever
+shipped" was already true — its four rules are all pre-`0.1.0`, and there has
+been nothing to migrate since.
+
+Two cautions about that check, because it was wrong twice before it was right.
+The first version used `awk` with `[ \t]`, which BSD awk does not read as a tab,
+and it produced *zero* keys for every tag — an empty diff that looked exactly
+like "nothing was removed". The second correctly found two keys that appeared to
+have vanished, `calendar.chime_command` and `agenda.chime_command`; both were
+artifacts of counting `#   chime_command = [...]` *examples inside a prose block*
+and attributing them to whatever section header came before. A commented default
+in this file is written `# key = value` with one space, and an illustration is
+indented further; the rule that tells them apart is what makes the audit mean
+anything.
+
+**The commented-out defaults were documentation nothing verified.**
+`deny_unknown_fields` proves every *live* key is real — a stale one would fail to
+parse — but says nothing about the six commented ones, which are precisely the
+ones a user uncomments. `every_commented_out_default_is_a_key_that_still_exists`
+uncomments each on its own and parses the result, so a key renamed in the code
+with its example left behind fails here rather than on somebody's config.
+
+**The one defect: `state.toml` used `deny_unknown_fields`.** One key from a newer
+mirador made an older one discard *every* preference in the file rather than the
+key it did not know. `UiState` gained fields at `0.9.0` and again at `0.15.0`, so
+two versions against one synced config directory hit it twice already. The old
+behaviour was recorded as deliberate — "silently keeping half a file is worse" —
+and that reasoning does not survive contact with this particular file: nobody
+hand-writes it, so there is no typo for strictness to catch, and an older binary
+drops the unknown value on its next save regardless. Ignoring it is strictly less
+loss. Now the only strict one is `update-check.toml`, which is a cache; the worst
+a stale one costs is one extra version check.
+
+Everything else was already right. `todos.toml`, the notes file and
+`watchlist.toml` have not changed shape since `0.1.0` — verified by diffing the
+structs against the `v0.1.0` tree, not by reading them — and none of the data
+files refuse an unknown key.
+
+*Exit met:* the README has a **Compatibility** section, and its claims are
+pinned by tests rather than asserted — `the_compatibility_promise_about_configs_holds`
+for the config half and `a_task_file_survives_a_version_in_either_direction`
+for the data half. A promise nothing checks is the same shape as a test that
+cannot fail.
 
 ### Phase 5 — cut 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -959,6 +959,34 @@ disk, and renamed over the original — so an interrupted save or a full disk ca
 never truncate your tasks. The same goes for your notes, your watchlist and the
 config itself.
 
+## Compatibility
+
+**A config or data file that works today will keep working.** That is a promise
+about the files mirador reads, and it is worth being precise about what it
+covers.
+
+**Your config.** No option that has ever shipped in a released version has been
+removed — every key in every `mirador.toml` written since `0.1.0` is still
+accepted, checked against all twenty-two releases. Options are added, never
+renamed out from under you. The four keys that predate `0.1.0` are handled by
+`mirador --migrate-config`, which edits the file in place and tells you what it
+changed.
+
+Unknown keys in the config are an *error* rather than a warning, on purpose: a
+silently ignored setting is a setting you think you have set. If mirador refuses
+your config, it names the key and the line.
+
+**Your data files.** `todos.toml`, your notes and `watchlist.toml` have not
+changed shape since `0.1.0`. All of them — plus `zones.toml` and `state.toml` —
+ignore keys they do not recognise, so a file written by a newer mirador still
+opens in an older one with the settings it understands intact. The one exception
+is `update-check.toml`, which is a cache: the worst a stale one costs is a single
+extra version check.
+
+**What this does not promise.** Running an older mirador after a newer one may
+drop a preference the older version has no idea about — it cannot write back
+what it never understood. Nothing else is lost, and nothing is corrupted.
+
 ## Contributing
 
 Bug reports, feature requests and pull requests are welcome. See

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -463,6 +463,108 @@ mod tests {
             .expect("the bundled default config must always validate");
     }
 
+    /// Every commented-out default in the shipped config is a real key.
+    ///
+    /// `shipped_default_config_parses` proves the *live* keys are real, because
+    /// `deny_unknown_fields` refuses anything that is not a field. It says
+    /// nothing about the commented ones — and those are the ones a user
+    /// uncomments, which makes them the half of the file most likely to be
+    /// acted on and the half nothing was checking. A key renamed in the code
+    /// with its commented example left behind would be found by whoever
+    /// uncommented it, and the error would say their config was wrong.
+    ///
+    /// Each is uncommented on its own rather than all at once, so a failure
+    /// names the line rather than the file, and because some of them are
+    /// alternatives that are not meant to be set together.
+    ///
+    /// This is the mechanical half of Phase 4's "every key reachable and
+    /// documented": a promise that a config keeps working is not worth making
+    /// about a file whose documentation nothing verifies.
+    #[test]
+    fn every_commented_out_default_is_a_key_that_still_exists() {
+        // `# key = value`, with at most one space. An example inside a prose
+        // block is indented further — `#   chime_command = [...]` — and is
+        // illustration rather than a default to uncomment.
+        let is_commented_default = |line: &str| -> Option<String> {
+            let rest = line.strip_prefix('#')?;
+            let rest = rest.strip_prefix(' ').unwrap_or(rest);
+            if rest.starts_with(' ') {
+                return None;
+            }
+            let key = rest.split('=').next()?.trim();
+            let looks_like_a_key = !key.is_empty()
+                && key
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+            (looks_like_a_key && rest.contains('=')).then(|| rest.to_string())
+        };
+
+        let lines: Vec<&str> = DEFAULT_CONFIG.lines().collect();
+        let mut checked = 0;
+        for (index, line) in lines.iter().enumerate() {
+            let Some(uncommented) = is_commented_default(line) else {
+                continue;
+            };
+            checked += 1;
+
+            let mut edited = lines.clone();
+            edited[index] = &uncommented;
+            let text = edited.join("\n");
+
+            let parsed = toml::from_str::<Config>(&text).unwrap_or_else(|e| {
+                panic!(
+                    "line {}: uncommenting `{}` does not parse, so the shipped \
+                     config documents an option that no longer exists: {e}",
+                    index + 1,
+                    line.trim()
+                )
+            });
+            parsed.validate().unwrap_or_else(|e| {
+                panic!(
+                    "line {}: uncommenting `{}` parses but does not validate: {e}",
+                    index + 1,
+                    line.trim()
+                )
+            });
+        }
+
+        // Coverage asserted, not assumed: if the comment style ever changes,
+        // this test would quietly check nothing and still pass.
+        assert!(
+            checked >= 6,
+            "only {checked} commented-out defaults were found; the shipped \
+             config had six, so either they have gone or this no longer \
+             recognises them"
+        );
+    }
+
+    /// The README's compatibility section makes three claims about configs.
+    /// A promise is only worth making if it is checked, so they are checked
+    /// here rather than believed.
+    #[test]
+    fn the_compatibility_promise_about_configs_holds() {
+        // 1. Every option the shipped config documents is accepted. (The live
+        //    keys; the commented ones are
+        //    `every_commented_out_default_is_a_key_that_still_exists`.)
+        toml::from_str::<Config>(DEFAULT_CONFIG).expect("the shipped config parses");
+
+        // 2. An unknown key is refused rather than ignored, and the message
+        //    names the key — "it names the key and the line" is in the README.
+        let err = toml::from_str::<Config>("[weather]\nunits = \"metric\"\nunts = \"metric\"\n")
+            .expect_err("an unknown key must be refused, not ignored");
+        let message = err.to_string();
+        assert!(
+            message.contains("unts"),
+            "the error must name the key the user got wrong: `{message}`"
+        );
+
+        // 3. A config that sets nothing at all is valid, which is what makes
+        //    "delete anything you do not want to override" true.
+        let bare: Config = toml::from_str("").expect("an empty config is valid");
+        bare.validate()
+            .expect("an empty config must validate, since every key has a default");
+    }
+
     #[test]
     fn the_rust_default_layout_matches_the_shipped_one() {
         let shipped: Config = toml::from_str(DEFAULT_CONFIG).expect("must parse");

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,8 +27,24 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 /// The persisted preferences, all optional.
+///
+/// **Unknown keys are ignored rather than refused**, which is a departure from
+/// every other file mirador parses and is deliberate. Elsewhere
+/// `deny_unknown_fields` earns its place by catching a typo in something a
+/// person wrote; nobody writes this file by hand, so there is no typo to catch
+/// and the strictness bought nothing.
+///
+/// What it cost was real. This struct gained fields at 0.9.0 and again at
+/// 0.15.0, and `deny_unknown_fields` meant a file written by the newer version
+/// made the older one discard **all** of it — theme, sort order, units and
+/// pomodoro lengths — rather than just the key it did not recognise. Two
+/// mirador versions on one synced config directory is enough to hit it.
+///
+/// Ignoring the key is strictly less loss: an older binary would drop the
+/// unknown value on its next save either way, and now it stops dropping the
+/// other nine with it.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct UiState {
     /// `u` in the weather panel.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -271,16 +287,56 @@ mod tests {
         );
     }
 
+    /// A key from a newer mirador costs that key and nothing else.
+    ///
+    /// This used to assert the opposite: `deny_unknown_fields` rejected the
+    /// whole file, so one unrecognised key discarded every preference in it.
+    /// That was recorded as deliberate, and it was the wrong call for a file
+    /// mirador writes itself — the struct gained fields at 0.9.0 and 0.15.0, so
+    /// anyone running two versions against one config directory lost the lot,
+    /// twice. Settled under Phase 4, where the promise being made is that a
+    /// data file keeps working.
     #[test]
-    fn a_file_from_a_newer_version_does_not_wedge_an_older_one() {
+    fn a_key_from_a_newer_version_costs_only_that_key() {
         let (path, _g) = dir("unknown-key");
-        std::fs::write(&path, "weather_units = \"metric\"\nfuture_thing = 3\n").unwrap();
-        // `deny_unknown_fields` means the whole file is rejected, which drops
-        // the preferences but still starts. Recorded as a test because the
-        // alternative — silently keeping half a file — is worse, and because
-        // the next person to add a field should know the older binary's
-        // behaviour rather than discover it.
-        assert_eq!(UiState::load(&path), UiState::default());
+        std::fs::write(
+            &path,
+            "weather_units = \"metric\"\ntodo_sort = \"due\"\nfuture_thing = 3\n",
+        )
+        .unwrap();
+
+        let loaded = UiState::load(&path);
+        assert_eq!(
+            loaded.weather_units.as_deref(),
+            Some("metric"),
+            "a preference the older binary understands must survive"
+        );
+        assert_eq!(loaded.todo_sort.as_deref(), Some("due"));
+        assert_ne!(
+            loaded,
+            UiState::default(),
+            "one unknown key must not empty the file"
+        );
+    }
+
+    /// The real shape of the problem, rather than an invented key: a file
+    /// carrying every field 0.15.0 added, read by something that predates them.
+    #[test]
+    fn the_fields_added_after_0_9_0_do_not_cost_the_ones_before_them() {
+        let (path, _g) = dir("version-skew");
+        std::fs::write(
+            &path,
+            "weather_units = \"imperial\"\n\
+             theme = \"nord\"\n\
+             agenda_file = \"/tmp/x.ics\"\n\
+             weather_location = \"Boston\"\n\
+             something_from_1_2_0 = true\n",
+        )
+        .unwrap();
+
+        let loaded = UiState::load(&path);
+        assert_eq!(loaded.weather_units.as_deref(), Some("imperial"));
+        assert_eq!(loaded.theme.as_deref(), Some("nord"));
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -587,6 +587,46 @@ mod tests {
             "and that the optional fields really are optional"
         );
     }
+
+    /// The README's compatibility section promises a task file keeps working in
+    /// both directions. Both are checked here rather than asserted there.
+    ///
+    /// `Task` has not changed shape since `0.1.0`, so the backward half is a
+    /// statement about history — pinned so that adding a *required* field, which
+    /// is the one change that would break every existing file, fails here rather
+    /// than on somebody's tasks.
+    #[test]
+    fn a_task_file_survives_a_version_in_either_direction() {
+        // As 0.1.0 would have written it: only the three fields that have
+        // always been required, and none of the optional ones.
+        let ancient = "\
+[[task]]
+id = 1
+title = \"Renew the domain\"
+created = \"2026-08-01\"
+";
+        let parsed: TaskFile =
+            toml::from_str(ancient).expect("a task file from 0.1.0 must still open");
+        assert_eq!(parsed.tasks.len(), 1);
+        assert_eq!(parsed.tasks[0].title, "Renew the domain");
+
+        // And from a mirador newer than this one: an unknown field is ignored
+        // rather than refusing the file. `TaskFile` deliberately does not set
+        // `deny_unknown_fields` — unlike the config, nobody hand-writes a typo
+        // here that a refusal would helpfully catch, and refusing would mean a
+        // newer mirador's file locks an older one out of every task in it.
+        let from_the_future = "\
+[[task]]
+id = 1
+title = \"Renew the domain\"
+created = \"2026-08-01\"
+energy_level = \"high\"
+";
+        let parsed: TaskFile =
+            toml::from_str(from_the_future).expect("an unknown field must not cost the whole file");
+        assert_eq!(parsed.tasks.len(), 1, "the task itself must survive");
+        assert_eq!(parsed.tasks[0].title, "Renew the domain");
+    }
     use jiff::civil::date;
 
     fn today() -> Date {


### PR DESCRIPTION
Phase 4 of the road to 1.0. The formats turned out to be in better shape than
expected, with one real defect — and the useful part is which of the three
sub-questions had a mechanical answer.

## No option that ever shipped has been removed

Checked by extracting every key from `assets/default_config.toml` at all
**twenty-two release tags** and diffing. 78 keys, none lost.

So "`migrate.rs` covers every rename ever shipped" was already true: its four
rules are all pre-`0.1.0`, and there has been nothing to migrate since.

**That check was wrong twice before it was right**, which is worth recording
because both failures looked like success:

- The first used `awk` with `[ \t]`, which BSD awk does not read as a tab. It
  produced **zero** keys for every tag — an empty diff that looks exactly like
  "nothing was removed".
- The second correctly found two keys that appeared to have vanished,
  `calendar.chime_command` and `agenda.chime_command`. Both were artifacts of
  counting `#   chime_command = [...]` *examples inside a prose block* and
  attributing them to whichever section header came before.

A commented default in that file is `# key = value` with one space; an
illustration is indented further. The rule telling them apart is what makes the
audit mean anything.

## The commented-out defaults were documentation nothing verified

`deny_unknown_fields` proves every *live* key is real — a stale one fails to
parse. It says nothing about the six commented ones, which are precisely the
ones a user uncomments.

`every_commented_out_default_is_a_key_that_still_exists` uncomments each on its
own and parses the result, so a key renamed in the code with its example left
behind fails there rather than on somebody's config. Verified by renaming one
and watching it name the line.

## The defect: `state.toml` used `deny_unknown_fields`

One key from a newer mirador made an older one discard **every** preference in
the file — theme, sort order, units, pomodoro lengths — rather than the key it
did not recognise. `UiState` gained fields at `0.9.0` and again at `0.15.0`, so
two versions against one synced config directory have hit this twice already.

The old behaviour was recorded as deliberate ("silently keeping half a file is
worse"). That reasoning does not survive contact with this particular file:
nobody hand-writes it, so there is no typo for strictness to catch, and an older
binary drops the unknown value on its next save regardless. Ignoring it is
strictly less loss.

`update-check.toml` stays strict — it is a cache, and the worst a stale one
costs is one extra version check.

## Everything else was already right

`todos.toml`, the notes file and `watchlist.toml` have not changed shape since
`0.1.0` — verified by diffing the structs against the `v0.1.0` tree rather than
by reading them — and none of the data files refuse an unknown key.

## Exit criterion

The README has a **Compatibility** section, and its claims are pinned by tests
rather than asserted: `the_compatibility_promise_about_configs_holds` for the
config half, `a_task_file_survives_a_version_in_either_direction` for the data
half. A promise nothing checks is the same shape as a test that cannot fail.

That leaves **Phase 3 (soak)**, which needs a person and a real terminal, and
**Phase 5 (cut 1.0.0)**.

## Checks

`cargo test` (626 passing), `clippy --all-targets -D warnings`, `fmt --check`
and `RUSTDOCFLAGS="-D warnings" cargo doc` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
