### PR TITLE
Put the row-move gap back on the open work list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1161,10 +1161,23 @@ going to guess that from reading.
 
 ## Open work
 
-Nothing. All three gaps named in the original product analysis are built — the
-`.ics` agenda, the watch log, and the on-fire signal — along with named themes
-and the `t` picker over them, arrange mode, and in-panel editing for everything
-the UI can change.
+**Arrange mode cannot move a row, only a panel** —
+[#100](https://github.com/jchultarsky/mirador/issues/100), deferred past 1.0
+because it adds behaviour to a key rather than fixing a defect.
+
+The reason it matters, since that is what this list is for: `promote` is the only
+thing that creates a row, and it is reachable only when the panel is in the
+**top or bottom** row. So a panel alone in a *middle* row can only ever merge
+into a neighbour — going from `[clocks] [watchlog] [notes] [cpu]` to
+`[clocks] [notes] [watchlog] [cpu]` is not expressible with the current keys at
+all, and the row count falls when you try. Found by the owner rearranging a tall
+vertical monitor, whose first reading was that four rows was a cap. It is not:
+six rows build fine and nothing limits the count.
+
+Everything else from the original product analysis is built — the `.ics` agenda,
+the watch log, and the on-fire signal — along with named themes and the `t`
+picker over them, arrange mode, and in-panel editing for everything the UI can
+change.
 
 That is a fact about the *list*, not a claim the program is finished. Two things
 shipped recently have never run in the conditions they were built for, and both


### PR DESCRIPTION
Documentation only — no code change.

Arrange mode moves **panels**, not rows. `promote` is the only thing that
creates a row, and it is reachable only when the panel is in the top or bottom
row, so a panel alone in a *middle* row can only ever merge into a neighbour.
Going from `[clocks] [watchlog] [notes] [cpu]` to `[clocks] [notes] [watchlog]
[cpu]` is not expressible with the current keys at all, and the row count falls
when you try.

Filed as #100 and deferred past 1.0: it adds behaviour to a key rather than
fixing a defect, and features are frozen ahead of 1.0.0.

`CLAUDE.md`'s "Open work" section said *Nothing*, and asks that anything going
back on the list carries the reason beside it — "the one that got quietly
dropped and had to be added back was the one that did not". So it is recorded
with the reason rather than left to the issue tracker alone.

Worth noting what this is **not**: there is no cap on the number of rows. Six
rows build fine, and nothing in `arrange.rs`, `Config::validate` or the layout
code limits the count. That was the first reading when the behaviour was hit on
a tall vertical monitor, and it is wrong — the note says so explicitly, since a
wrong diagnosis in the file is worse than no note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
