### PR TITLE
Windows has now run mirador-update too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1290,16 +1290,17 @@ and had to be added back was the one that did not.
   255) and its own prerelease detection from the semver hyphen, which is why
   the hand-written versions of both were dropped when it took the file over.
 
-- **Windows runs**, confirmed by the owner on 25 July 2026 — so all three
-  shipped targets have now been started, not merely built. Treat it as the
-  least-travelled of the three rather than as unknown: macOS and Linux are used
-  daily and Windows has been checked once.
+- **Windows runs**, confirmed by the owner on 25 July 2026 and again on
+  28 July — so all three shipped targets have been started, not merely built.
+  Treat it as the least-travelled of the three rather than as unknown: macOS and
+  Linux are used daily and Windows has been checked twice.
 
-  That run also came through the **PowerShell installer** (`irm … | iex`) in
-  the default Windows terminal, which is the first real-world exercise of that
-  path — everything else about the installers had only been checked from macOS.
-  `mirador-update` is installed alongside by the same installer but has not been
-  run on Windows; the macOS one has.
+  Both runs came through the **PowerShell installer** (`irm … | iex`) in the
+  default Windows terminal, which is the only real-world exercise of that path —
+  everything else about the installers has only been checked from macOS. The
+  second run also exercised **`mirador-update` on Windows**, which until then had
+  been installed alongside by the same installer and never run there. Every
+  shipped binary on every shipped target has now been executed at least once.
 
   `aarch64-pc-windows-msvc` is deliberately absent because `ring`, reached
   through `ureq`'s TLS, does not build for it. musl is absent for the same


### PR DESCRIPTION
Documentation only.

The housekeeping note said `mirador-update` "is installed alongside by the same
installer but has not been run on Windows". The owner installed and ran mirador
on Windows again on 28 July 2026, including `mirador-update`, so that sentence
is now stale.

A stale claim about what has been *exercised* is worse than no claim: it is
exactly the sentence the next reader trusts when deciding what still needs
checking, and it would have sent them to re-verify something already done — or
worse, left them believing a gap existed where it does not.

Every shipped binary on every shipped target has now been executed at least
once. Windows stays described as the least-travelled of the three, because it
is: checked twice, against daily use of macOS and Linux.

This closes the fourth and last item of **Phase 3's** soak list that does not
need time to pass. The remaining two — a real midnight, and a second memory
reading after a full idle day — close themselves overnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
