### PR TITLE
Release 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-07-30
+
+### Fixed
+
+- **The news panel did not show which story the cursor was on.** It kept a
+  selection that `j`/`k` moved and that `o` read the link from, and drew no
+  highlight at all — so the link at the foot of the panel belonged to a story
+  you had no way to identify. The task, notes and watchlist panels have always
+  marked their selection; this one never did.
+  [#114](https://github.com/jchultarsky/mirador/issues/114).
+
 ## [0.16.2] - 2026-07-30
 
 The first round of bug reports from people who are not the author, and one
@@ -1127,7 +1138,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.16.2...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.16.3...HEAD
+[0.16.3]: https://github.com/jchultarsky/mirador/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/jchultarsky/mirador/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/jchultarsky/mirador/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/jchultarsky/mirador/compare/v0.15.0...v0.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump, `Cargo.lock`, and the changelog entry. The fix is #115, already on
`main`.

**#114** — the news panel kept a selection that `j`/`k` moved and `o` acted on,
and drew no highlight at all, so the link at the foot belonged to a story you
could not identify. Found by the owner while verifying the 0.16.2 fixes on a real
terminal, which is exactly what that day's run is for.

Cut as its own release rather than folded into 1.0.0 so that 1.0 is not the first
time this code meets a terminal — the same reasoning that put 0.16.2 on the soak
machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)