### PR TITLE
Fix two stale-state defects in the agenda and watch log

### DIFF
--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -35,6 +35,13 @@ use crate::frame::{Binding, FRAME_HEIGHT, FRAME_WIDTH};
 use crate::ical;
 use crate::panel::{KeyOutcome, Panel, RenderContext, describe_age};
 
+/// The status shown while a reload is in flight.
+///
+/// Named rather than repeated because `tick` has to recognise it: a reload that
+/// has landed must take its own message down, and only its own. A path put up
+/// by `o` has to survive the next background read.
+const RELOADING: &str = "reloading…";
+
 const BINDINGS: &[Binding] = &[
     Binding::primary("f", "file"),
     Binding::primary("r", "reload"),
@@ -218,7 +225,7 @@ impl AgendaPanel {
                 }
                 self.set_path(path);
                 self.asking = None;
-                self.status = Some("reloading…".into());
+                self.status = Some(RELOADING.into());
             }
         }
     }
@@ -525,6 +532,17 @@ impl Panel for AgendaPanel {
             // One copy, at the one moment the data can have changed.
             self.shown = self.snapshot();
             self.note_new_entries();
+            // The generation only moves when a read lands, so this is where a
+            // reload finishes. Taking the message down here rather than on the
+            // next keypress matters because a dashboard is read without being
+            // touched: left up, an idle panel claims to be mid-operation, which
+            // reads as a hang rather than as a stale label.
+            //
+            // Only its own message. A path put up by `o` has to survive the
+            // next background read.
+            if self.status.as_deref() == Some(RELOADING) {
+                self.status = None;
+            }
         }
         moved
     }
@@ -606,7 +624,7 @@ impl Panel for AgendaPanel {
             }
             KeyCode::Char('r') => {
                 self.ask_for_reload();
-                self.status = Some("reloading…".into());
+                self.status = Some(RELOADING.into());
             }
             KeyCode::Char('o') => {
                 self.status = Some(current_path(&self.path).display().to_string());
@@ -1068,5 +1086,53 @@ mod tests {
             .map(|s| s.content.as_ref())
             .collect();
         assert!(wide.contains("meeting room"), "got `{wide}`");
+    }
+
+    /// A panel pointed at nothing. The reader thread finds no file and says so,
+    /// which is all these two need — they are about the status line, not the
+    /// calendar.
+    fn idle_panel() -> AgendaPanel {
+        AgendaPanel::new(&AgendaConfig::default(), PathBuf::from("/nonexistent.ics"))
+    }
+
+    /// Pretend a read has just landed, the way the reader thread does.
+    fn land_a_read(panel: &mut AgendaPanel) {
+        panel
+            .generation
+            .store(panel.seen + 1, std::sync::atomic::Ordering::Release);
+        panel.tick();
+    }
+
+    /// The bug: `reloading…` was set when the reload was *asked for* and cleared
+    /// only by the next keypress, so a panel nobody touched went on claiming to
+    /// be mid-operation after the reload had landed. Measured at 83 seconds in a
+    /// real terminal, with the reloaded events already on screen above it.
+    ///
+    /// This is the whole point of a dashboard you leave open: the reader is not
+    /// pressing keys, so "cleared on the next keypress" is "never".
+    #[test]
+    fn a_landed_reload_takes_its_own_message_down() {
+        let mut panel = idle_panel();
+        panel.status = Some(RELOADING.into());
+        land_a_read(&mut panel);
+        assert_eq!(
+            panel.status, None,
+            "a reload that has landed must stop saying it is reloading"
+        );
+    }
+
+    /// The other half, and the reason `tick` matches on the message rather than
+    /// clearing whatever is there: `o` puts the calendar's path up, and a
+    /// background re-read must not wipe it out from under the reader.
+    #[test]
+    fn a_path_shown_by_o_survives_a_background_read() {
+        let mut panel = idle_panel();
+        panel.status = Some("/home/someone/calendar.ics".into());
+        land_a_read(&mut panel);
+        assert_eq!(
+            panel.status.as_deref(),
+            Some("/home/someone/calendar.ics"),
+            "a read landing must not clear a status it did not put up"
+        );
     }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -57,7 +57,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
             config.stocks_path()?,
         )?),
         "calendar" => Box::new(calendar::CalendarPanel::new(config.calendar.clone())),
-        "watchlog" => Box::new(watchlog::WatchLogPanel::new(config)),
+        "watchlog" => Box::new(watchlog::WatchLogPanel::new()),
         "news" => Box::new(news::NewsPanel::new(&config.news)),
         "agenda" => Box::new(agenda::AgendaPanel::new(
             &config.agenda,

--- a/src/widgets/watchlog.rs
+++ b/src/widgets/watchlog.rs
@@ -40,18 +40,28 @@ pub struct WatchLogPanel {
     scroll: ListState,
     /// Entries drawn last frame, so `tick` can answer honestly.
     drawn: usize,
-    /// Whether a calendar is configured, so the empty panel can say that one
-    /// of the two things it watches is not switched on.
-    watching_calendar: bool,
 }
 
 impl WatchLogPanel {
-    pub fn new(config: &crate::config::Config) -> Self {
+    /// Takes no configuration, and that is the point.
+    ///
+    /// It used to take `&Config`, for one `bool` recording whether the agenda
+    /// had a file. Reading another panel's settings is the coupling this design
+    /// avoids: the value was true or false for ever from the moment it was
+    /// read, so a calendar set later through `f` was never noticed. Panels stay
+    /// independent, so the log describes what it watches rather than reporting
+    /// on a panel it cannot see.
+    pub fn new() -> Self {
         Self {
             scroll: ListState::default(),
             drawn: 0,
-            watching_calendar: config.agenda.file.is_some(),
         }
+    }
+}
+
+impl Default for WatchLogPanel {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -175,18 +185,27 @@ impl Panel for WatchLogPanel {
                  a task falling overdue, an entry appearing in your calendar.",
                 theme.muted,
             );
-            if !self.watching_calendar {
-                lines.push(Line::from(""));
-                // Milder than it was, and correctly so: the day always turns,
-                // so the panel is no longer inert without a calendar — it is
-                // merely watching one thing fewer.
-                explain(
-                    &mut lines,
-                    "No calendar set, so that last one cannot happen. Press f \
-                     on the agenda panel to add one.",
-                    theme.muted,
-                );
-            }
+            lines.push(Line::from(""));
+            // Says where calendar entries come from, and asserts nothing about
+            // whether you have one. The previous wording — "No calendar set, so
+            // that last one cannot happen. Press f on the agenda panel to add
+            // one." — was decided once at construction, so setting a calendar
+            // with `f` left this panel telling you to set the calendar you had
+            // just set, until a restart.
+            //
+            // Not fixed by re-deriving the flag, because a *correct* version of
+            // that sentence is still the wrong shape. A hint aimed at someone
+            // who has not set a calendar reaches someone who decided against one
+            // just as often, and the dashboard cannot tell them apart — the
+            // reasoning that retired the unused-widget notice. A statement of
+            // where the entries come from is useful to the first reader and
+            // merely true for the second.
+            explain(
+                &mut lines,
+                "Calendar entries come from [agenda].file, which f on the \
+                 agenda panel sets.",
+                theme.muted,
+            );
             frame.render_widget(Paragraph::new(lines), area);
             self.drawn = 0;
             return;
@@ -246,6 +265,74 @@ mod tests {
         }
     }
 
+    /// Render the empty panel and read the words back off the screen.
+    fn empty_panel_text(config: &crate::config::Config) -> String {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let gradients = config.theme.gradients();
+        let mut panel = WatchLogPanel::new();
+        let (w, h) = (60u16, 14u16);
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal
+            .draw(|frame| {
+                panel.render(
+                    frame,
+                    frame.area(),
+                    RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: false,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..h)
+            .map(|y| {
+                (0..w)
+                    .filter_map(|x| buffer.cell((x, y)).map(|c| c.symbol().to_string()))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The empty panel must not claim anything about whether a calendar is set,
+    /// because it cannot know: panels are independent, and the agenda owns its
+    /// own path.
+    ///
+    /// The bug this replaces: the wording was chosen from `config.agenda.file`
+    /// once at construction, so setting a calendar with `f` left the log saying
+    /// "No calendar set... Press f on the agenda panel to add one" — telling you
+    /// to do the thing you had just done — until a restart.
+    ///
+    /// Re-deriving the flag would have fixed the staleness and kept the wrong
+    /// shape. A hint aimed at someone who has not set a calendar reaches someone
+    /// who decided against one just as often, and this dashboard cannot tell
+    /// them apart; that is what retired the unused-widget notice.
+    ///
+    /// The obvious test — render with and without `agenda.file` and assert the
+    /// text matches — was written first and **deleted**, because it cannot fail:
+    /// `WatchLogPanel::new` takes no configuration, so nothing about the agenda
+    /// can reach this panel to differ in the first place. It passed with the old
+    /// wording pasted back in, which is the tell. The assertion below is the one
+    /// that goes red when the claim returns, and it was checked by restoring the
+    /// old sentence and watching it fail.
+    #[test]
+    fn the_empty_panel_still_says_where_calendar_entries_come_from() {
+        let text = empty_panel_text(&crate::config::Config::default());
+        assert!(
+            text.contains("[agenda].file"),
+            "the empty log should name the setting; got:\n{text}"
+        );
+        assert!(
+            !text.contains("No calendar set"),
+            "the empty log must not assert whether a calendar is set; got:\n{text}"
+        );
+    }
+
     /// The frame carries no counter, and that is a decision rather than an
     /// omission. Every other list panel here has one — `4 open`, `2 today` —
     /// so the obvious "improvement" is to give this one `3 new`. That number is
@@ -254,10 +341,7 @@ mod tests {
     /// fails, the question to ask is not how to fix the test.
     #[test]
     fn the_panel_never_offers_a_counter() {
-        assert_eq!(
-            WatchLogPanel::new(&crate::config::Config::default()).counter(),
-            None
-        );
+        assert_eq!(WatchLogPanel::new().counter(), None);
     }
 
     /// The log is read, never edited. A key that dismissed an entry would make
@@ -265,7 +349,7 @@ mod tests {
     /// obligation this panel is designed to avoid.
     #[test]
     fn nothing_dismisses_acknowledges_or_clears_an_entry() {
-        let mut panel = WatchLogPanel::new(&crate::config::Config::default());
+        let mut panel = WatchLogPanel::new();
         panel.drawn = 5;
         for code in [
             KeyCode::Char('d'),


### PR DESCRIPTION
Two stale-state defects found by driving 0.16.3 in a real terminal (tmux,
150x42, macOS) during the pre-1.0 testing. Both are bug fixes, so both are
allowed under the feature freeze. No behaviour is added and no key changes.

Closes #119. Closes #120.

## #120 — the agenda kept saying "reloading…" after the reload had finished

The status was set when a reload was *asked for* and cleared only by the next
keypress, so a panel nobody touched went on claiming to be mid-operation. This
matters more than a stale label sounds: a dashboard is read without being
touched, so "cleared on the next keypress" is, for a reader who is only
glancing, never — and an idle panel saying `reloading…` reads as a hang.

Measured before: pressed `r` at 08:58:17, touched nothing, still `reloading…` at
08:59:40 with the reloaded events already on screen above it.
Measured after, on the rebuilt binary: cleared itself 12 seconds later with no
keypress.

The generation only moves when a read lands, so `tick` is where a reload
finishes. It matches on the message rather than clearing whatever is there,
because `o` puts the calendar's path in the same slot and a background re-read
must not wipe it out from under the reader.

## #119 — the watch log told you to set the calendar you had just set

`WatchLogPanel` read `config.agenda.file` once at construction to choose between
two empty-state wordings. The value never changed after that, so setting a
calendar with `f` left the log saying "No calendar set... Press f on the agenda
panel to add one" while the agenda beside it listed the events. Only a restart
cleared it.

Re-deriving the flag would have fixed the staleness and kept two wrong things:

- It reads another panel's settings. Widgets are independent here, and the log
  cannot see the agenda's path — the agenda owns it.
- A *correct* version of that sentence is still the wrong shape. A hint aimed at
  someone who has not set a calendar reaches someone who decided against one just
  as often, and the dashboard cannot tell them apart. That is the reasoning that
  retired the unused-widget notice.

So the wording states where entries come from and asserts nothing about whether
you have any:

> Calendar entries come from `[agenda].file`, which `f` on the agenda panel sets.

With the question gone, the field had nothing left to do, so it goes — along with
the `&Config` parameter. **`WatchLogPanel::new()` now takes no configuration at
all**, which removes the coupling rather than repairing it.

## On the tests

Three added, and one deliberately deleted — the deletion is the part worth
reading.

The obvious test for #119 renders with and without `agenda.file` and asserts the
text matches. It was written, and it **passed with the old broken wording pasted
back in**: once the panel cannot see the config, nothing can make the two differ,
so it cannot fail. It is the pattern `CLAUDE.md` names — an assertion about a
consequence the bug does not change — so it was removed rather than kept for
reassurance, and the reasoning left in a doc comment so it does not get helpfully
re-added.

What survives was checked by breaking it in each direction:

| Test | Made to fail by |
| --- | --- |
| `a_landed_reload_takes_its_own_message_down` | removing the clear in `tick` |
| `a_path_shown_by_o_survives_a_background_read` | widening it to clear unconditionally |
| `the_empty_panel_still_says_where_calendar_entries_come_from` | restoring the old "No calendar set" sentence |

## Checks

All four gates run with exit codes read directly rather than through a pipe:
636 tests pass, `clippy --all-targets -D warnings` silent, `fmt --check` clean,
`RUSTDOCFLAGS="-D warnings" cargo doc` clean.

Both fixes were then verified on screen in a real terminal on the rebuilt
release binary, not only under `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
