### PR TITLE
Add --reset-config, a way out of a broken config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--reset-config`, a way out of a config that has gone past fixing.** Writes
+  the shipped defaults and copies the old file to `config.toml.bak` first. The
+  name sounds harmless and the effect is not, so it says what it is about to do
+  and waits for a `y`; piped somewhere with no terminal to ask on, it refuses
+  rather than assuming, and `--yes` is there for scripts that mean it. An
+  existing backup is never overwritten — resetting twice is exactly what a stuck
+  reader does, and with a fixed name the second run would have replaced the real
+  config with the defaults written by the first.
+  [#111](https://github.com/jchultarsky/mirador/issues/111).
+
+### Fixed
+
+- **The agenda kept saying `reloading…` after the reload had finished.** The
+  status was cleared only by the next keypress, so a panel nobody touched went
+  on claiming to be mid-operation — measured at 83 seconds with the reloaded
+  events already on screen. A dashboard is read without being touched, so
+  "cleared on the next keypress" was, for anyone glancing at it, never.
+  [#120](https://github.com/jchultarsky/mirador/issues/120).
+- **The watch log told you to set a calendar you had already set.** It read
+  `[agenda].file` once at construction, so a calendar added later with `f` was
+  never noticed and the panel went on advertising `f` until a restart. It now
+  says where calendar entries come from and asserts nothing about whether you
+  have one. [#119](https://github.com/jchultarsky/mirador/issues/119).
+
 ## [0.16.3] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ rejected at startup and would leave you with a config that will not open.
 `mirador --migrate-config` is still there for keys renamed between versions,
 and leaves a backup beside the original.
 
+If a config has gone past fixing, `mirador --reset-config` writes the shipped
+defaults over it and copies the old one to `config.toml.bak` first. It says what
+it is about to do and waits for a `y`, and it will not run at all without a
+terminal to ask on unless you add `--yes`. An existing backup is never
+overwritten, so resetting twice still leaves your original recoverable.
+
 ## The panels
 
 Twelve widgets, each answering one question. Put the ones you want in the

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -173,6 +173,43 @@ impl Config {
         Ok(Self::default_data_dir()?.join("todos.toml"))
     }
 
+    /// Replace the config at `path` with the shipped defaults, keeping the old
+    /// one. Returns where the old one went, or `None` if there was no file to
+    /// keep.
+    ///
+    /// **This destroys work**, which is why it takes a backup rather than
+    /// overwriting and why the caller is expected to have asked first. The
+    /// reader reaching for it is usually stuck rather than finished: `[layout]`
+    /// is the part people curate by hand, and a config broken by one typo still
+    /// holds an evening's arrangement.
+    ///
+    /// Backups follow `migrate`'s convention — `config.toml.bak` beside the
+    /// original — with one deliberate difference: an existing backup is never
+    /// clobbered. Resetting twice is exactly what a stuck user does, and with a
+    /// fixed name the second run would replace their real config with the
+    /// defaults written by the first, which is the one outcome this whole
+    /// function exists to prevent.
+    pub fn reset(path: &Path) -> Result<Option<PathBuf>> {
+        let backup = match path.try_exists() {
+            Ok(true) => {
+                let to = free_backup_path(path);
+                std::fs::copy(path, &to).with_context(|| {
+                    format!("backing up {} to {}", path.display(), to.display())
+                })?;
+                Some(to)
+            }
+            // Nothing to keep. Writing the defaults is still the right outcome:
+            // the reader asked for a config they can edit, and not having one is
+            // a reason to write it rather than to refuse.
+            Ok(false) => None,
+            Err(e) => anyhow::bail!("could not check whether {} exists: {e}", path.display()),
+        };
+
+        crate::store::write_atomic(path, DEFAULT_CONFIG)
+            .with_context(|| format!("writing default config to {}", path.display()))?;
+        Ok(backup)
+    }
+
     /// Platform data directory for mirador's own files.
     fn default_data_dir() -> Result<PathBuf> {
         let dir =
@@ -404,6 +441,30 @@ impl Config {
     }
 }
 
+/// A backup path beside `path` that nothing is using yet.
+///
+/// `config.toml.bak` first, matching `migrate`, then `.bak.2`, `.bak.3` and so
+/// on. The counter is not tidiness: without it a second reset would overwrite
+/// the first backup with the defaults the first reset had just written, and the
+/// user's real config would be gone with no way back.
+///
+/// Racy in principle — the name is checked and then written — but the loser of
+/// that race is a person running two resets at the same instant, and the bound
+/// stops a directory of stale backups from making this loop for ever.
+fn free_backup_path(path: &Path) -> PathBuf {
+    let first = path.with_extension("toml.bak");
+    if !first.exists() {
+        return first;
+    }
+    for n in 2..1000 {
+        let candidate = path.with_extension(format!("toml.bak.{n}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    first
+}
+
 /// Turn a parse failure into an error that says how to fix it.
 ///
 /// The common case by far is a config written by an older version: mirador
@@ -453,6 +514,89 @@ fn expand_tilde(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A scratch directory named for the calling test, so the reset tests do
+    /// not share files with each other or with a parallel run.
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mirador-reset-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn resetting_writes_the_defaults_and_keeps_the_old_config() {
+        let dir = scratch("keeps");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "theme = \"nord\"\n# an evening's work\n").unwrap();
+
+        let backup = Config::reset(&path)
+            .unwrap()
+            .expect("a backup must be kept");
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), DEFAULT_CONFIG);
+        assert_eq!(
+            std::fs::read_to_string(&backup).unwrap(),
+            "theme = \"nord\"\n# an evening's work\n",
+            "the backup must be the config that was replaced, byte for byte"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The failure this guards is the one a stuck user actually walks into:
+    /// reset once, still stuck, reset again. With a fixed `.bak` name the
+    /// second run would copy the *defaults* over the backup and the real config
+    /// would be gone for good.
+    #[test]
+    fn a_second_reset_does_not_destroy_the_first_backup() {
+        let dir = scratch("twice");
+        let path = dir.join("config.toml");
+        let original = "theme = \"nord\"\n# irreplaceable\n";
+        std::fs::write(&path, original).unwrap();
+
+        let first = Config::reset(&path).unwrap().expect("first backup");
+        let second = Config::reset(&path).unwrap().expect("second backup");
+
+        assert_ne!(first, second, "the second reset must not reuse the name");
+        assert_eq!(
+            std::fs::read_to_string(&first).unwrap(),
+            original,
+            "the user's real config must still be recoverable after two resets"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&second).unwrap(),
+            DEFAULT_CONFIG,
+            "the second backup is what the first reset wrote"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Asking for a config where there is none is a reason to write one, not to
+    /// fail: the reader wants something to edit either way.
+    #[test]
+    fn resetting_with_no_config_yet_writes_one_and_reports_no_backup() {
+        let dir = scratch("absent");
+        let path = dir.join("config.toml");
+
+        assert!(Config::reset(&path).unwrap().is_none());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), DEFAULT_CONFIG);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Whatever it writes has to be a config mirador can actually load —
+    /// otherwise the recovery command leaves the user exactly as stuck.
+    #[test]
+    fn what_a_reset_writes_is_a_loadable_config() {
+        let dir = scratch("loadable");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "this is not = = valid toml\n").unwrap();
+
+        Config::reset(&path).unwrap();
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        toml::from_str::<Config>(&text).expect("a reset config must load");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn shipped_default_config_parses() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,8 @@ mod watch;
 mod widgets;
 mod zones;
 
-use std::path::PathBuf;
+use std::io::{IsTerminal, Write};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
@@ -60,6 +61,8 @@ OPTIONS:
         --print-config     Print the default config to stdout and exit
         --config-path      Print the resolved config path and exit
         --migrate-config   Update a config written by an older version
+        --reset-config     Replace the config with the defaults, keeping a copy
+    -y, --yes              Do not ask for confirmation
     -h, --help             Print this help and exit
     -V, --version          Print the version and exit
 
@@ -88,6 +91,9 @@ struct Args {
     print_config: bool,
     show_config_path: bool,
     migrate_config: bool,
+    reset_config: bool,
+    /// Skip the confirmation `--reset-config` would otherwise ask for.
+    assume_yes: bool,
     help: bool,
     version: bool,
 }
@@ -104,6 +110,8 @@ fn parse_args(raw: impl Iterator<Item = String>) -> Result<Args> {
             "--print-config" => args.print_config = true,
             "--config-path" => args.show_config_path = true,
             "--migrate-config" => args.migrate_config = true,
+            "--reset-config" => args.reset_config = true,
+            "-y" | "--yes" => args.assume_yes = true,
             "-c" | "--config" => {
                 let value = iter.next().ok_or_else(|| {
                     anyhow::anyhow!("`{arg}` needs a path, e.g. `{arg} ~/mirador.toml`")
@@ -132,6 +140,57 @@ fn main() -> ExitCode {
     }
 }
 
+/// `--reset-config`: replace the config with the defaults, keeping the old one.
+///
+/// The confirmation is the point of this function rather than an afterthought.
+/// The name sounds harmless and the effect is not — `[layout]` is the part
+/// people curate, and someone reaching for this because mirador will not start
+/// may have one salvageable typo and an evening's arrangement.
+///
+/// It refuses rather than assuming when it cannot ask: piped into a script with
+/// no `--yes`, "no answer" must not read as "go ahead". A prompt written to a
+/// terminal nobody is watching is the same silent overwrite with extra steps.
+fn reset_config(path: &Path, assume_yes: bool) -> Result<()> {
+    let exists = path.try_exists().unwrap_or(false);
+
+    if !assume_yes {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!(
+                "refusing to reset {} without a confirmation.\n\nThere is no \
+                 terminal to ask on, so re-run with `--yes` if you mean it.",
+                path.display()
+            );
+        }
+        if exists {
+            println!("This replaces {} with the defaults.", path.display());
+            println!("Your current config will be copied alongside it first.");
+        } else {
+            println!("There is no config at {}.", path.display());
+            println!("This writes the defaults there.");
+        }
+        print!("Go ahead? [y/N] ");
+        std::io::stdout().flush().context("writing the prompt")?;
+
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("reading your answer")?;
+        // Anything but an explicit yes is a no, including an empty line. The
+        // default has to be the outcome that loses nothing.
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("Left {} alone.", path.display());
+            return Ok(());
+        }
+    }
+
+    let backup = Config::reset(path)?;
+    println!("Wrote the default config to {}.", path.display());
+    if let Some(backup) = backup {
+        println!("Your previous config is at {}.", backup.display());
+    }
+    Ok(())
+}
+
 fn run() -> Result<()> {
     let args = parse_args(std::env::args().skip(1))?;
 
@@ -154,6 +213,14 @@ fn run() -> Result<()> {
         };
         println!("{}", path.display());
         return Ok(());
+    }
+
+    if args.reset_config {
+        let path = match args.config.clone() {
+            Some(p) => p,
+            None => Config::default_path()?,
+        };
+        return reset_config(&path, args.assume_yes);
     }
 
     if args.migrate_config {
@@ -277,6 +344,18 @@ mod tests {
         assert!(parse(&["--print-config"]).unwrap().print_config);
         assert!(parse(&["--config-path"]).unwrap().show_config_path);
         assert!(parse(&["--migrate-config"]).unwrap().migrate_config);
+        assert!(parse(&["--reset-config"]).unwrap().reset_config);
+        assert!(parse(&["-y"]).unwrap().assume_yes);
+        assert!(parse(&["--yes"]).unwrap().assume_yes);
+    }
+
+    /// `--yes` only ever *removes* a question. On its own it must not be
+    /// mistaken for a request to reset anything.
+    #[test]
+    fn yes_on_its_own_resets_nothing() {
+        let args = parse(&["--yes"]).unwrap();
+        assert!(args.assume_yes);
+        assert!(!args.reset_config);
     }
 
     #[test]
@@ -321,6 +400,8 @@ mod tests {
             "--print-config",
             "--config-path",
             "--migrate-config",
+            "--reset-config",
+            "--yes",
             "--help",
             "--version",
         ] {


### PR DESCRIPTION
Adds `--reset-config`: a way out of a config mirador will not load. Refs #111.

First feature since the freeze lifted (#122). Targets an 0.x release —
`[Unreleased]` in the CHANGELOG, no version bump here.

## Scope note: `--config-path` already exists

#111 suggests "a `--config-path` command that only prints the location may solve
a good share of the same problem". It shipped in the **initial commit on
2026-07-25**, five days before the issue was filed — it is in `HELP`, respects
`-c`, and the README already points people at it. Verified rather than assumed:

```
$ mirador --config-path
/Users/…/Library/Application Support/mirador/config.toml
$ mirador --config-path -c /tmp/custom.toml
/tmp/custom.toml
```

So this PR is the other half only. The issue text is worth correcting when it is
closed, since it reads as though the command does not exist.

## What `--reset-config` does

Writes the shipped defaults over the config, keeping the old one. The issue's
three requirements, each with the reasoning that shaped it:

**Keeps the old file**, through `store::write_atomic` like everything else
mirador writes.

**Says what it will do and waits for a `y`.** The name sounds harmless and the
effect is not: `[layout]` is the part people curate, and someone reaching for
this because mirador will not start may have one salvageable typo and an
evening's arrangement. Anything but an explicit yes — including a bare Enter —
leaves the file alone.

**Prints the path it wrote**, since half of why anyone is here is not knowing
where the config lives.

## Two decisions worth reviewing

**It refuses when it cannot ask.** Piped somewhere with no terminal and no
`--yes`, it errors rather than proceeding. "No answer" must not read as "go
ahead", and a prompt written to a terminal nobody is watching is a silent
overwrite with extra steps. `--yes` exists for scripts that mean it.

**It never overwrites an existing backup — a deliberate departure from
`migrate`.** `migrate` uses a fixed `config.toml.bak`. For reset that is unsafe:
resetting twice is exactly what a stuck reader does, and the second run would
copy the *defaults written by the first* over their real config, destroying the
thing the backup exists to protect. Subsequent backups become `.bak.2`,
`.bak.3`. `a_second_reset_does_not_destroy_the_first_backup` pins it, and it was
checked by reverting to the fixed name and watching it go red.

## Verified in a real terminal

Not only under `cargo test` — this is a command that destroys work, so it was
driven by hand:

| Case | Result |
| --- | --- |
| Piped, no `--yes` | Refuses, exit 1, file untouched |
| Prompt, bare Enter | "Left … alone", nothing written, no backup |
| Prompt, `y` | Resets, reports both paths |
| Reset twice | `.bak` still holds the original; the second went to `.bak.2` |
| Broken config → reset → launch | Dashboard starts |

The last one is the whole point of the feature: a config that fails to parse,
reset, and mirador running again.

## Also in this PR

- README: a paragraph beside the `--migrate-config` note.
- CHANGELOG: an `[Unreleased]` section covering this and the two fixes already
  merged in #121, which had none.

## Checks

All four gates, exit codes read directly rather than through a pipe: 641 tests
pass, `clippy --all-targets -D warnings` silent, `fmt --check` clean,
`RUSTDOCFLAGS="-D warnings" cargo doc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
