### PR TITLE
Let the clock zone list be reordered, edited and located

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The clock's zone list can be reordered, edited and located.** `Shift+↑`/`↓`
+  (or `J`/`K`) moves the selected clock through the table, `e` opens it in the
+  same `Label = Zone` dialog `a` uses, pre-filled, and `o` shows where
+  `zones.toml` lives. Previously the only way to change an order or fix a label
+  was to delete entries and re-add them in the order you wanted, which is what
+  the reporter did. The first entry is still the big clock and still cannot be
+  displaced — reordering the table is what was asked for; choosing the primary
+  is a different decision and would want its own key.
+  [#109](https://github.com/jchultarsky/mirador/issues/109).
 - **`--reset-config`, a way out of a config that has gone past fixing.** Writes
   the shipped defaults and copies the old file to `config.toml.bak` first. The
   name sounds harmless and the effect is not, so it says what it is about to do

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ Some settings you change with a keystroke are remembered across restarts:
 | Seconds on the clock | `s` | Clock |
 | Pomodoro durations | `+` / `-` | Pomodoro |
 | Watchlist symbols | `a` / `d` | Markets |
-| World clocks | `a` / `d` | Clock |
+| World clocks | `a` / `e` / `d` | Clock |
+| World clock order | `Shift+↑`/`↓` | Clock |
 | Weather location | `L` | Weather |
 | Agenda file | `f` | Agenda |
 | Which panels are shown | `w` | — |
@@ -382,10 +383,15 @@ ends up in your config is never a surprise.
 Anything not on the list still works: type a zone it does not carry and it is
 taken as written, with `HQ = Europe/Berlin` naming it yourself.
 
+`e` reopens that dialog on the selected clock, pre-filled, so fixing a label
+does not mean deleting the entry and adding it back. `Shift+↑` and `Shift+↓`
+(or `J` and `K`) move the selected clock through the table, and `o` shows where
+the file lives.
+
 Like the watchlist, the live list is a data file (`zones.toml`) rather than
 config, which is what lets the panel own it; `[clocks].zones` seeds your first
-run. The large clock is not removable, because a clock panel with nothing to
-draw large is not a clock panel.
+run. The large clock is not removable, and nothing can be moved into its place
+either, because a clock panel with nothing to draw large is not a clock panel.
 
 ```
 ╭┤1 Calendar├───────────────────╮

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -7,7 +7,7 @@
 
 use jiff::tz::TimeZone;
 use ratatui::Frame;
-use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Span;
@@ -23,9 +23,13 @@ use crate::panel::{KeyOutcome, Panel, RenderContext};
 const BINDINGS: &[Binding] = &[
     Binding::primary("s", "seconds"),
     Binding::primary("a", "add zone"),
+    Binding::primary("e", "edit"),
     Binding::primary("d", "remove"),
     Binding::extra("↑ / ↓", "select a clock"),
     Binding::extra("j / k", "select a clock"),
+    Binding::extra("Shift+↑/↓", "move it"),
+    Binding::extra("J / K", "move it"),
+    Binding::extra("o", "show file path"),
 ];
 
 /// The largest scale the numerals are ever drawn at. Past this a clock stops
@@ -69,8 +73,13 @@ pub struct ClocksPanel {
     /// Which secondary clock is selected, for `d`. The primary is index 0 and
     /// cannot be selected, because it cannot be removed.
     selected: usize,
-    /// The `a` dialog, while it is open.
+    /// The `a` or `e` dialog, while it is open.
     asking: Option<crate::prompt::Prompt>,
+    /// Which entry `e` opened the dialog on, when it was `e` rather than `a`.
+    ///
+    /// The two dialogs are the same prompt, and this is what tells them apart
+    /// on submit — an add appends, an edit replaces. `None` means `a`.
+    editing: Option<usize>,
     status: Option<String>,
     /// The instant the last frame showed, in whichever unit is on screen.
     ///
@@ -118,6 +127,7 @@ impl ClocksPanel {
             zones,
             selected: 1,
             asking: None,
+            editing: None,
             status: None,
             last_shown: None,
         })
@@ -154,21 +164,57 @@ impl ClocksPanel {
         self.last_shown = None;
     }
 
-    /// Deal with a keypress while the add-zone prompt is open.
+    /// Move the selected clock one row up, keeping the cursor on it.
+    ///
+    /// The cursor follows the clock rather than staying put, because the reader
+    /// is moving a *thing*: holding the key should walk one entry up the table,
+    /// not shuffle a different entry on every press.
+    fn move_selected_up(&mut self) {
+        if self.zones.move_up(self.selected) {
+            self.selected -= 1;
+            self.reload();
+        } else {
+            // The only way to fail from a valid selection is trying to displace
+            // the primary, so this says the same thing `d` does.
+            self.status = Some("the big clock stays".into());
+        }
+    }
+
+    /// Move the selected clock one row down, keeping the cursor on it.
+    ///
+    /// Silent at the bottom, unlike [`Self::move_selected_up`]: running out of
+    /// list is obvious from the screen, where the rule protecting the big clock
+    /// is not.
+    fn move_selected_down(&mut self) {
+        if self.zones.move_down(self.selected) {
+            self.selected += 1;
+            self.reload();
+        }
+    }
+
+    /// Deal with a keypress while the add-or-edit prompt is open.
     fn handle_prompt_key(&mut self, key: KeyEvent) {
         let Some(prompt) = self.asking.as_mut() else {
             return;
         };
         match prompt.handle_key(key) {
             crate::prompt::Outcome::Editing => {}
-            crate::prompt::Outcome::Cancelled => self.asking = None,
+            crate::prompt::Outcome::Cancelled => {
+                self.asking = None;
+                self.editing = None;
+            }
             // Picked from the list: the city the reader recognised becomes
             // the clock's label, which is the whole reason the outcome carries
             // both. Nothing needs validating — the list only holds zones that
             // resolve, and a test holds it to that.
             crate::prompt::Outcome::Chose { label, value } => {
-                if self.zones.add(label, value) {
+                let applied = match self.editing {
+                    Some(index) => self.zones.edit(index, label, value),
+                    None => self.zones.add(label, value),
+                };
+                if applied {
                     self.asking = None;
+                    self.editing = None;
                     self.reload();
                 } else if let Some(prompt) = self.asking.as_mut() {
                     prompt.reject("that clock is already on the panel");
@@ -185,11 +231,16 @@ impl ClocksPanel {
                     prompt.reject(format!("unknown timezone `{timezone}`"));
                     return;
                 }
-                if !self.zones.add(label, timezone) {
+                let applied = match self.editing {
+                    Some(index) => self.zones.edit(index, label, timezone),
+                    None => self.zones.add(label, timezone),
+                };
+                if !applied {
                     prompt.reject("that clock is already on the panel");
                     return;
                 }
                 self.asking = None;
+                self.editing = None;
                 self.reload();
             }
         }
@@ -368,6 +419,7 @@ impl Panel for ClocksPanel {
         match key.code {
             KeyCode::Char('s') => self.show_seconds = !self.show_seconds,
             KeyCode::Char('a') => {
+                self.editing = None;
                 self.asking = Some(crate::prompt::Prompt::new(
                     "ADD A CLOCK",
                     "Type to narrow · ↑↓ to choose · Enter adds · Esc cancels",
@@ -375,6 +427,35 @@ impl Panel for ClocksPanel {
                     crate::prompt::Completion::Places(crate::zones::PLACES),
                 ));
             }
+            KeyCode::Char('e') => {
+                // Pre-filled with what the entry already says, in the same
+                // `Label = Zone` the add dialog accepts. Relabelling is the
+                // common case, so the text you want to change is already there
+                // rather than something you retype from scratch.
+                if let Some(zone) = self.zones.zones().get(self.selected) {
+                    self.editing = Some(self.selected);
+                    self.asking = Some(crate::prompt::Prompt::new(
+                        "EDIT THIS CLOCK",
+                        "`Label = Zone` · Enter saves · Esc cancels",
+                        &format!("{} = {}", zone.label, zone.timezone),
+                        crate::prompt::Completion::Places(crate::zones::PLACES),
+                    ));
+                }
+            }
+            KeyCode::Char('o') => {
+                self.status = Some(self.zones.path().display().to_string());
+            }
+            // Shift moves the clock rather than the cursor, which is the same
+            // shape as `Ctrl+arrows` resizing a panel rather than moving focus.
+            // `J`/`K` do it too, because this panel already offers arrows and
+            // `j`/`k` as equals for the selection and it would be strange for
+            // only one of the pair to gain the modifier.
+            KeyCode::Up if key.modifiers.contains(KeyModifiers::SHIFT) => self.move_selected_up(),
+            KeyCode::Char('K') => self.move_selected_up(),
+            KeyCode::Down if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                self.move_selected_down();
+            }
+            KeyCode::Char('J') => self.move_selected_down(),
             KeyCode::Char('d') => {
                 if self.zones.remove(self.selected) {
                     self.reload();

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -8,7 +8,7 @@
 //! `[layout]` is the exception that proves the rule — it goes back to the
 //! config because people read and curate it. A list of cities is not that.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -692,6 +692,76 @@ impl Zones {
         true
     }
 
+    /// Move the zone at `index` one place towards the top of the list.
+    ///
+    /// Refuses to move into the first slot, for the same reason [`Self::remove`]
+    /// refuses to empty it: that entry is the big clock, and promoting a
+    /// secondary would silently demote the one the reader chose to see from
+    /// across the room. Reordering the *table* is what was asked for; choosing
+    /// the primary is a different decision and would want its own key.
+    pub fn move_up(&mut self, index: usize) -> bool {
+        if index <= 1 || index >= self.clocks.len() {
+            return false;
+        }
+        self.clocks.swap(index, index - 1);
+        self.dirty = true;
+        true
+    }
+
+    /// Move the zone at `index` one place towards the bottom of the list.
+    pub fn move_down(&mut self, index: usize) -> bool {
+        if index == 0 || index + 1 >= self.clocks.len() {
+            return false;
+        }
+        self.clocks.swap(index, index + 1);
+        self.dirty = true;
+        true
+    }
+
+    /// Replace the label and timezone of the zone at `index`.
+    ///
+    /// Returns false when the timezone is blank, or when it names a zone some
+    /// *other* entry already shows. Comparing against other entries rather than
+    /// all of them is what lets an edit change only the label — the common case,
+    /// and the one the reporter wanted — without the entry colliding with
+    /// itself.
+    pub fn edit(&mut self, index: usize, label: &str, timezone: &str) -> bool {
+        let timezone = timezone.trim();
+        if timezone.is_empty() || index >= self.clocks.len() {
+            return false;
+        }
+        if self
+            .clocks
+            .iter()
+            .enumerate()
+            .any(|(i, z)| i != index && z.timezone == timezone)
+        {
+            return false;
+        }
+        // Same rule as `add`: an emptied label falls back to the city in the
+        // timezone, so clearing the field is a way to get the default back
+        // rather than a way to end up with a nameless clock.
+        let label = match label.trim() {
+            "" => timezone
+                .rsplit('/')
+                .next()
+                .unwrap_or(timezone)
+                .replace('_', " "),
+            given => given.to_string(),
+        };
+        self.clocks[index] = ClockZone {
+            label,
+            timezone: timezone.to_string(),
+        };
+        self.dirty = true;
+        true
+    }
+
+    /// Where the zones are stored, for the panel's `o`.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
     /// Write atomically if there are pending changes.
     pub fn save(&mut self) -> Result<()> {
         if !self.dirty {
@@ -768,6 +838,111 @@ mod tests {
         let mut zones = seeded();
         assert!(!zones.add("Nowhere", "   "));
         assert_eq!(zones.zones().len(), 2);
+    }
+
+    fn three() -> Zones {
+        Zones {
+            path: PathBuf::from("/nonexistent/zones.toml"),
+            clocks: vec![
+                zone("Local", "local"),
+                zone("Tokyo", "Asia/Tokyo"),
+                zone("London", "Europe/London"),
+            ],
+            dirty: false,
+            last_error: None,
+        }
+    }
+
+    fn labels(zones: &Zones) -> Vec<&str> {
+        zones.zones().iter().map(|z| z.label.as_str()).collect()
+    }
+
+    #[test]
+    fn a_clock_can_be_moved_through_the_list() {
+        let mut zones = three();
+        assert!(zones.move_down(1));
+        assert_eq!(labels(&zones), ["Local", "London", "Tokyo"]);
+        assert!(zones.move_up(2));
+        assert_eq!(labels(&zones), ["Local", "Tokyo", "London"]);
+    }
+
+    /// The first entry is the big clock. `remove` refuses to take it and this
+    /// refuses to displace it, for the same reason: promoting a secondary would
+    /// silently demote the clock the reader chose to see from across the room.
+    #[test]
+    fn nothing_can_be_moved_into_the_big_clocks_slot() {
+        let mut zones = three();
+        assert!(!zones.move_up(1), "moving the top secondary up must refuse");
+        assert!(!zones.move_up(0), "the primary itself cannot move either");
+        assert!(!zones.move_down(0));
+        assert_eq!(labels(&zones), ["Local", "Tokyo", "London"]);
+    }
+
+    #[test]
+    fn moving_off_either_end_is_refused_rather_than_wrapping() {
+        let mut zones = three();
+        assert!(!zones.move_down(2), "the last entry has nowhere to go");
+        assert!(!zones.move_down(9), "and neither has one off the end");
+        assert!(!zones.move_up(9));
+        assert_eq!(labels(&zones), ["Local", "Tokyo", "London"]);
+    }
+
+    /// Relabelling without touching the timezone is the case the reporter
+    /// actually wanted, and the one a naive duplicate check breaks: the entry
+    /// collides with itself and the edit is refused.
+    #[test]
+    fn an_entry_can_be_relabelled_without_changing_its_zone() {
+        let mut zones = three();
+        assert!(zones.edit(1, "Japan", "Asia/Tokyo"));
+        assert_eq!(labels(&zones), ["Local", "Japan", "London"]);
+        assert_eq!(zones.zones()[1].timezone, "Asia/Tokyo");
+    }
+
+    #[test]
+    fn an_edit_onto_a_zone_another_clock_shows_is_refused() {
+        let mut zones = three();
+        assert!(
+            !zones.edit(1, "Britain", "Europe/London"),
+            "that zone is already on the panel"
+        );
+        assert_eq!(labels(&zones), ["Local", "Tokyo", "London"]);
+    }
+
+    /// Same rule as `add`: an emptied label falls back to the city in the
+    /// timezone, so clearing the field restores the default rather than
+    /// leaving a nameless clock.
+    #[test]
+    fn clearing_the_label_falls_back_to_the_city_in_the_zone() {
+        let mut zones = three();
+        assert!(zones.edit(1, "   ", "America/New_York"));
+        assert_eq!(labels(&zones), ["Local", "New York", "London"]);
+    }
+
+    #[test]
+    fn an_edit_out_of_range_or_with_a_blank_zone_changes_nothing() {
+        let mut zones = three();
+        assert!(!zones.edit(9, "Nowhere", "Asia/Tokyo"));
+        assert!(!zones.edit(1, "Tokyo", "   "));
+        assert_eq!(labels(&zones), ["Local", "Tokyo", "London"]);
+    }
+
+    /// Every mutation has to mark the list dirty, or the change is on screen
+    /// and never reaches the file — the failure is invisible until a restart.
+    #[test]
+    fn every_change_marks_the_list_for_saving() {
+        for (name, mutate) in [
+            (
+                "move_down",
+                &(|z: &mut Zones| z.move_down(1)) as &dyn Fn(&mut Zones) -> bool,
+            ),
+            ("move_up", &|z: &mut Zones| z.move_up(2)),
+            ("edit", &|z: &mut Zones| z.edit(1, "Japan", "Asia/Tokyo")),
+        ] {
+            let mut zones = three();
+            assert!(!zones.dirty, "starts clean");
+            assert!(mutate(&mut zones), "{name} should have applied");
+            assert!(zones.dirty, "{name} left the list unsaved");
+        }
     }
 
     /// Every zone in the picker has to be one jiff will actually accept.


### PR DESCRIPTION
Closes #109. Reported by email, on Linux:

> There is no way to change order of TZ list via kbd or to edit the current
> entry. Or could not see a way.

Three keys, in the order of value the issue set out.

## `Shift+↑` / `↓` — reorder

Moves the selected clock through the table. `J`/`K` do the same, because this
panel already treats arrows and `j`/`k` as equals for the selection and it would
be strange for only one of the pair to gain the modifier.

The cursor follows the clock rather than staying put. The reader is moving a
*thing*, so holding the key walks one entry up the table instead of shuffling a
different entry on every press.

## `e` — edit

Reopens the add dialog on the selected entry, pre-filled with `Label = Zone`.

Relabelling is the common case, and it is the one a naive duplicate check
breaks: the entry collides with itself and the edit is refused. So `edit`
compares the new zone against the *other* entries only. Clearing the label falls
back to the city in the timezone, matching `add`, so emptying the field restores
the default rather than leaving a nameless clock.

## `o` — show the file's path

Matching the task and notes panels. The issue observed that the reporter found
`zones.toml` hard to discover, which is half of why he took the long way round.

## What is deliberately not here

**The big clock cannot be displaced.** Nothing moves into slot 0, for the same
reason `remove` refuses to empty it: promoting a secondary would silently demote
the clock the reader chose to see from across the room. Reordering the *table*
is what was asked for; choosing the primary is a different decision and would
want its own key and its own thinking. The refusal reuses `d`'s existing wording
rather than inventing a second phrasing for the same rule.

Say the word if you want promotion too — it is a small addition on top of this,
but it is a design call rather than a gap.

## Tests

Eight added. The two that matter were checked by breaking the code:

| Break | Test that fails |
| --- | --- |
| let `move_up` reach index 0 | `nothing_can_be_moved_into_the_big_clocks_slot` |
| make `edit` compare against every entry | `an_entry_can_be_relabelled_without_changing_its_zone` |

`every_change_marks_the_list_for_saving` covers the failure that would otherwise
be invisible until a restart: a mutation that changes the screen without setting
`dirty` never reaches the file.

## Verified in a real terminal

Not only under `cargo test` — this is a keyboard feature:

- both key forms reorder, and the cursor stays on the moved clock
- pushing past the top refuses with `the big clock stays`
- a relabel keeps its zone (`UTC = UTC` → `Zulu = UTC`)
- an edit onto a zone already shown is rejected
- `o` prints the path
- the new order reaches `zones.toml`
- all three keys appear in the border hints **and** the help overlay, from the
  one `BINDINGS` declaration

## Checks

All four gates, exit codes read directly: 649 tests pass, clippy silent, fmt
clean, rustdoc clean. README and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
