### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-30
+
 ### Added
 
 - **The clock's zone list can be reordered, edited and located.** `Shift+↑`/`↓`
@@ -1173,7 +1175,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.16.3...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/jchultarsky/mirador/compare/v0.16.3...v0.17.0
 [0.16.3]: https://github.com/jchultarsky/mirador/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/jchultarsky/mirador/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/jchultarsky/mirador/compare/v0.16.0...v0.16.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.16.3"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump, CHANGELOG roll and the two link-reference lines.

First release since the freeze lifted in #122, and the first to carry features
again.

### Added
- `--reset-config` (#111) — #123
- Clock zone list reorder / edit / show-path (#109) — #124

### Fixed
- Agenda stuck on `reloading…` (#120) — #121
- Watch log claiming no calendar was set (#119) — #121

### Before this commit

The built binary was driven in a real terminal, per the rule that a release must
not be the first time its code meets one. Both new features exercised, the panel
surface smoke-tested, `w`/`t`/`m`/`?` opened and closed, a clean `q`, and the
CLI paths checked outside the TUI.

`lto = true` confirmed intact in `[profile.release]`, MSRV floor still 1.95 from
`cargo metadata`, and `dist plan` announces v0.17.0.

All four gates: 649 tests, clippy, fmt, rustdoc — clean on exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)