### PR TITLE
Release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-30
+
 ### Fixed
 
 - **The news panel scrolled, which its own rule said it must not.** Every story
@@ -1186,7 +1188,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/jchultarsky/mirador/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/jchultarsky/mirador/compare/v0.16.3...v0.17.0
 [0.16.3]: https://github.com/jchultarsky/mirador/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/jchultarsky/mirador/compare/v0.16.1...v0.16.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Patch release for #118 — the news panel scrolled, contrary to its own rule.

### Fixed
- News panel no longer scrolls (#118) — #126

### Before this commit

The built binary was driven in a real terminal against live feeds, per the rule
that a release must not be the first time its code meets one: thirty presses of
`j` leave the first story at the top, the rest of the dashboard behaves as
before, and `q` exits cleanly.

`lto = true` intact, `dist plan` announces v0.17.1, all four gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)