### PR TITLE
Let arrange mode move a row, not just a panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Arrange mode can move a row, not just a panel.** `Shift+↑`/`↓` (or `J`/`K`)
+  moves the whole row the focused panel sits in. Before this, a new row was only
+  ever created by pushing a panel off the top or bottom edge, so a panel alone in
+  a *middle* row could not travel at all — `Down` merged it into its neighbour
+  and the row count fell. Going from `[clocks] [watchlog] [notes] [cpu]` to
+  `[clocks] [notes] [watchlog] [cpu]` was not expressible with any sequence of
+  keys. Moving a panel between rows still merges, exactly as before.
+  [#100](https://github.com/jchultarsky/mirador/issues/100).
+
 ## [0.17.1] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ space around afterwards, and that is written too.
 The last panel cannot be switched off, because a layout with nothing in it is
 rejected at startup and would leave you with a config that will not open.
 
+`Shift+↑` and `Shift+↓` move the whole row the focused panel is in, which is
+how you reorder rows rather than move a panel between them. Plain `↑`/`↓` still
+moves the panel itself, merging it into the neighbouring row.
+
 `mirador --migrate-config` is still there for keys renamed between versions,
 and leaves a backup beside the original.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -845,6 +845,23 @@ impl App {
     fn handle_arrange_key(&mut self, key: KeyEvent) {
         use crate::arrange::Direction;
 
+        // Shift moves the whole row rather than the panel, which is the same
+        // escalation the clock panel uses: the bare key moves the small thing,
+        // the shifted key moves the thing it sits in. Claimed before the plain
+        // arrows below, or `Shift+Down` would fall through and merge the panel.
+        //
+        // Not `Ctrl+arrows`, which #100 proposed: those already resize inside
+        // this mode, advertised in the legend and pinned by
+        // `ctrl_arrows_still_resize_inside_arrange_mode`.
+        let shifted = key.modifiers.contains(KeyModifiers::SHIFT);
+        match key.code {
+            KeyCode::Up if shifted => return self.move_focused_row(false),
+            KeyCode::Char('K') => return self.move_focused_row(false),
+            KeyCode::Down if shifted => return self.move_focused_row(true),
+            KeyCode::Char('J') => return self.move_focused_row(true),
+            _ => {}
+        }
+
         let direction = match key.code {
             KeyCode::Left | KeyCode::Char('h') => Some(Direction::Left),
             KeyCode::Right | KeyCode::Char('l') => Some(Direction::Right),
@@ -911,6 +928,33 @@ impl App {
 
         // Focus follows the panel by name, so the moved panel keeps the
         // highlight wherever it lands and nothing here has to chase it.
+        if let Err(e) = self.rebuild_panels() {
+            self.config.layout = before;
+            let _ = self.rebuild_panels();
+            self.layout_error = Some(format!("{e:#}"));
+            return;
+        }
+        self.layout_error = None;
+        self.layout_dirty = true;
+    }
+
+    /// Move the row the focused panel sits in, up or down.
+    ///
+    /// Shares `move_focused`'s recovery: a layout the panels cannot be rebuilt
+    /// from is put back and reported, rather than leaving the dashboard in a
+    /// state the config cannot describe.
+    fn move_focused_row(&mut self, down: bool) {
+        let Some(&(row, _)) = self.positions.get(self.focus) else {
+            return;
+        };
+        let before = self.config.layout.clone();
+        if crate::arrange::move_row(&mut self.config.layout, row, down).is_none() {
+            return;
+        }
+
+        // Focus follows the panel by name, as it does for a panel move, so the
+        // highlight stays on whatever the reader was moving even though every
+        // panel in the row changed its flat index.
         if let Err(e) = self.rebuild_panels() {
             self.config.layout = before;
             let _ = self.rebuild_panels();
@@ -1484,12 +1528,19 @@ impl App {
             // terminal: knowing how to get out of a mode beats knowing every
             // trick inside it.
             let mut used = crate::grid::display_width(" ARRANGE");
+            // Both vertical hints were shortened when `Shift+↑↓` was added in
+            // #100: a sixth entry does not fit beside the old wording at an
+            // ordinary 110 columns, and dropping one was not an option —
+            // the help overlay carries only the *global* keys, so this legend
+            // is the only place any of these are documented. A key that ships
+            // undiscoverable is the mistake the resize keys already made once.
             for (key, action) in [
                 ("←→↑↓", "move"),
                 ("Enter", "keep"),
                 ("Esc", "cancel"),
+                ("Shift+↑↓", "move row"),
                 ("Ctrl+arrows", "resize"),
-                ("↑↓ at the edge", "opens a new row"),
+                ("↑↓ at edge", "new row"),
             ] {
                 // Dropped whole rather than clipped: half a hint reads as a
                 // rendering fault, where a missing one just reads as a narrow
@@ -1955,8 +2006,16 @@ mod tests {
         let bar = status_bar_at(&mut app, 110);
         assert!(bar.contains("ARRANGE"), "the mode names itself: {bar}");
         assert!(
-            bar.contains("opens a new row"),
+            bar.contains("new row"),
             "and says rows can be opened: {bar}"
+        );
+        // #100 added `Shift+↑↓`, and this legend is the only place the mode's
+        // keys are written down — the help overlay carries global keys only. So
+        // an ordinary terminal has to show every one of them, which is what
+        // forced both vertical hints to be shortened rather than one dropped.
+        assert!(
+            bar.contains("move row"),
+            "and says a row can be moved: {bar}"
         );
     }
 
@@ -2129,6 +2188,66 @@ mod tests {
         assert_eq!(
             app.slots[app.focus].widget, moving,
             "the highlight went with the panel"
+        );
+    }
+
+    /// #100, tested through the shell rather than through `arrange::move_row`.
+    ///
+    /// The arithmetic having its own tests is not enough — #106 shipped a
+    /// correct helper that was simply never called, and two unit tests passed
+    /// throughout. This presses the key.
+    #[test]
+    fn shift_arrows_move_the_whole_row_in_arrange_mode() {
+        let mut app = App::new(resizable()).expect("builds");
+        // `resizable` is [clocks, calendar] over [cpu]. Focus the lone panel in
+        // the second row — before #100 it could only ever merge upward.
+        app.focus = 2;
+        let moving = app.slots[2].widget.clone();
+        assert_eq!(moving, "cpu", "fixture changed under this test");
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('m')));
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::SHIFT));
+
+        assert_eq!(
+            app.config.layout.rows.len(),
+            2,
+            "moving a row must not merge it away"
+        );
+        assert_eq!(
+            app.config.layout.rows[0].panels[0].widget, "cpu",
+            "the cpu row should now be first"
+        );
+        assert_eq!(
+            app.slots[app.focus].widget, moving,
+            "the highlight went with the panel"
+        );
+        assert!(app.arranging.is_some(), "and the mode stayed open");
+    }
+
+    /// `J`/`K` are the same gesture without a modifier, matching the clock
+    /// panel. Bare `j`/`k` must still move the *panel*, or the shifted pair
+    /// would have quietly replaced the plain one.
+    #[test]
+    fn capital_and_plain_movement_keys_do_different_things() {
+        let mut app = App::new(resizable()).expect("builds");
+        app.focus = 2;
+        app.handle_key(KeyEvent::from(KeyCode::Char('m')));
+        app.handle_key(KeyEvent::from(KeyCode::Char('K')));
+        assert_eq!(
+            app.config.layout.rows[0].panels[0].widget, "cpu",
+            "K should have moved the row"
+        );
+
+        // And the plain key still merges, which is the behaviour #100 was
+        // careful not to take away.
+        let mut app = App::new(resizable()).expect("builds");
+        app.focus = 2;
+        app.handle_key(KeyEvent::from(KeyCode::Char('m')));
+        app.handle_key(KeyEvent::from(KeyCode::Char('k')));
+        assert_eq!(
+            app.config.layout.rows.len(),
+            1,
+            "plain k should still merge the panel into the row above"
         );
     }
 

--- a/src/arrange.rs
+++ b/src/arrange.rs
@@ -54,6 +54,44 @@ pub fn move_panel(
     }
 }
 
+/// Move the whole row at `row` one place up or down, returning where it landed.
+///
+/// `None` means the move was refused: the row is already at the edge it was
+/// pushed at.
+///
+/// **The gap this fills (#100).** `move_panel` moves panels, and a new row is
+/// only ever created by promoting one off the top or bottom edge. So a panel
+/// alone in a *middle* row could never travel — `Down` merged it into the row
+/// below and `close_if_empty` deleted the row it left, dropping the row count.
+/// Going from `[clocks] [watchlog] [notes] [cpu]` to
+/// `[clocks] [notes] [watchlog] [cpu]` was not expressible with any sequence of
+/// keys. Found by the owner rearranging a tall vertical monitor, whose first
+/// reading was that four rows was a cap; it is not, and nothing limits the
+/// count.
+///
+/// This is additive rather than a change to what the arrows already do. Merging
+/// a panel into a neighbouring row stays exactly as it was — the issue calls
+/// that "the right reading of *move this panel into that row*" — and moving a
+/// row is a separate gesture on a separate key.
+///
+/// Swapping whole [`LayoutRow`] entries is what carries each row's `height`
+/// with it. Swapping only the panel lists would leave every row's height where
+/// it was and silently resize both, which is the failure
+/// `a_move_never_changes_what_the_weights_add_up_to` was rewritten to catch:
+/// what matters is not the total but that an untouched row keeps its *share*.
+pub fn move_row(layout: &mut Layout, row: usize, down: bool) -> Option<usize> {
+    if row >= layout.rows.len() {
+        return None;
+    }
+    let target = if down {
+        (row + 1 < layout.rows.len()).then_some(row + 1)?
+    } else {
+        row.checked_sub(1)?
+    };
+    layout.rows.swap(row, target);
+    Some(target)
+}
+
 /// Move a panel to the row above or below, or off the edge into a row of its
 /// own.
 fn vertical(layout: &mut Layout, row: usize, column: usize, down: bool) -> Option<(usize, usize)> {
@@ -416,5 +454,78 @@ mod tests {
                 heights(&l)
             );
         }
+    }
+
+    /// The move #100 was filed for: a panel alone in a middle row travelling
+    /// down past its neighbour, which no sequence of keys could express.
+    #[test]
+    fn a_row_can_travel_past_its_neighbour() {
+        let mut l = layout(&[
+            (10, &[("clocks", 10)]),
+            (10, &[("watchlog", 10)]),
+            (10, &[("notes", 10)]),
+            (10, &[("cpu", 10)]),
+        ]);
+
+        assert_eq!(move_row(&mut l, 1, true), Some(2));
+        assert_eq!(
+            shape(&l),
+            vec![vec!["clocks"], vec!["notes"], vec!["watchlog"], vec!["cpu"]],
+            "the watch log should have swapped with the notes row"
+        );
+        assert_eq!(l.rows.len(), 4, "moving a row must not change the count");
+    }
+
+    /// A row carries its own height. Swapping the panel lists alone would leave
+    /// the heights behind and silently resize both rows — and the reader who
+    /// tuned them never asked for that.
+    #[test]
+    fn a_row_takes_its_height_with_it() {
+        let mut l = layout(&[
+            (30, &[("clocks", 10)]),
+            (10, &[("watchlog", 10)]),
+            (60, &[("notes", 10)]),
+        ]);
+
+        move_row(&mut l, 0, true);
+        assert_eq!(
+            heights(&l),
+            vec![10, 30, 60],
+            "each row's height should have travelled with it"
+        );
+    }
+
+    /// Both refusals, and neither may quietly do something else instead.
+    #[test]
+    fn a_row_at_the_edge_has_nowhere_to_go() {
+        let mut l = layout(&[(10, &[("clocks", 10)]), (10, &[("notes", 10)])]);
+        let before = shape(&l);
+
+        assert_eq!(move_row(&mut l, 0, false), None, "the top row cannot rise");
+        assert_eq!(move_row(&mut l, 1, true), None, "the last cannot sink");
+        assert_eq!(
+            move_row(&mut l, 9, true),
+            None,
+            "nor can a row that is not there"
+        );
+        assert_eq!(shape(&l), before, "a refused move must change nothing");
+    }
+
+    /// Moving a row moves everything in it, not just the panel the cursor is
+    /// on. That is what makes it a *row* move rather than a second way to move
+    /// a panel.
+    #[test]
+    fn a_shared_row_travels_whole() {
+        let mut l = layout(&[
+            (10, &[("clocks", 5), ("weather", 5)]),
+            (10, &[("notes", 10)]),
+        ]);
+
+        assert_eq!(move_row(&mut l, 0, true), Some(1));
+        assert_eq!(
+            shape(&l),
+            vec![vec!["notes"], vec!["clocks", "weather"]],
+            "both panels should have moved together"
+        );
     }
 }

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -58,9 +58,28 @@ pub fn apply(source: &str, desired: &Layout) -> Result<String> {
     let duplicates = duplicated_widgets(&map);
     let pairing = pair_rows(&map, desired);
 
+    let mut out: Vec<String> = lines.iter().map(|line| (*line).to_string()).collect();
+
+    // Rows reordered. Nothing below can express that: every other edit changes
+    // a row where it already sits, so a pairing that crosses over would leave
+    // the rows in their original order and the check at the end would throw the
+    // whole edit away. That is what #100 hit the moment `Shift+↑↓` could move a
+    // row — the move worked on screen and could not be saved.
+    //
+    // Handled by rewriting the rows region as a whole, each row emitted from
+    // its captured text so its comments and formatting travel with it. Kept to
+    // the case that needs it: any layout whose rows stay in order goes through
+    // the per-row edits below, so an ordinary resize still rewrites one number
+    // on one line.
+    if let Some(reordered) = reorder_rows(&lines, &map, &blocks, &duplicates, &pairing, desired)? {
+        let from = map.rows[0].from;
+        let to = map.rows[map.rows.len() - 1].closing_line + 1;
+        out.splice(from..to, reordered);
+        return finish(source, &out, desired);
+    }
+
     // Work back to front so an insertion or deletion cannot shift the line
     // numbers of an edit that has not happened yet.
-    let mut out: Vec<String> = lines.iter().map(|line| (*line).to_string()).collect();
     let mut edits: Vec<Edit> = Vec::new();
 
     // Rows nothing in the new layout claimed. Their panels have already been
@@ -154,6 +173,14 @@ pub fn apply(source: &str, desired: &Layout) -> Result<String> {
         }
     }
 
+    finish(source, &out, desired)
+}
+
+/// Rejoin the edited lines and refuse anything that does not say what was asked.
+///
+/// Both paths through [`apply`] end here, so the round-trip check cannot be
+/// skipped by whichever one is taken.
+fn finish(source: &str, out: &[String], desired: &Layout) -> Result<String> {
     // Rejoined with the ending the file already had. `str::lines()` strips
     // `\r`, so joining with `\n` would quietly convert a CRLF config to LF and
     // rewrite every line in it because one panel moved.
@@ -172,6 +199,104 @@ pub fn apply(source: &str, desired: &Layout) -> Result<String> {
     }
 
     Ok(result)
+}
+
+/// The whole rows region rewritten in the desired order, or `None` when the
+/// rows have not moved and the cheaper per-row edits will do.
+///
+/// A row that has a counterpart in the text is emitted from its own lines, so
+/// its comments, indentation and hand-alignment survive being moved; only its
+/// `height` is corrected and its panels rebuilt when their order changed. A row
+/// with no counterpart is a new one and is written fresh.
+fn reorder_rows(
+    lines: &[&str],
+    map: &LayoutMap,
+    blocks: &HashMap<String, PanelBlock>,
+    duplicates: &HashSet<&str>,
+    pairing: &[Option<usize>],
+    desired: &Layout,
+) -> Result<Option<Vec<String>>> {
+    let paired: Vec<usize> = pairing.iter().flatten().copied().collect();
+    let in_order = paired.windows(2).all(|pair| pair[0] < pair[1]);
+    // Rows still in their original relative order: the per-row path handles it,
+    // and handles it more gently.
+    if in_order {
+        return Ok(None);
+    }
+
+    let mut out = Vec::new();
+    for (want_index, want) in desired.rows.iter().enumerate() {
+        let Some(text_index) = pairing[want_index] else {
+            out.extend(row_block(lines, map, blocks, duplicates, want)?);
+            continue;
+        };
+        let row = &map.rows[text_index];
+
+        // Reusing a row's lines only works when it has lines to reuse: mirador
+        // writes the header, each panel and the closing bracket on their own,
+        // in that order. A hand-compacted row — a whole row on one line — does
+        // not, and slicing it as though it did read backwards and **panicked**,
+        // taking the dashboard down when the move was committed. Found by
+        // driving it; a config written that way loads perfectly well.
+        //
+        // Such a row is refused, not guessed at. Rebuilding it is not the
+        // escape it looks like: a panel's captured entry is its own lines, and
+        // for a compacted row that entry *is* the whole row, so writing it back
+        // inside a fresh block nests the row within itself. Refusing is what
+        // this module already promises for text it cannot edit confidently, and
+        // it costs the reader a message rather than a mangled config.
+        let reusable = row.header_line < row.closing_line
+            && row
+                .panels
+                .iter()
+                .all(|p| p.from > row.header_line && p.line < row.closing_line);
+        if !reusable {
+            bail!(
+                "moving a row needs each row written across several lines, as \
+                 mirador writes them — `{{ height = … , panels = [`, then one \
+                 line per panel, then `] }},`. Row {} is on a single line, so \
+                 its panels have no entries of their own to move.",
+                text_index + 1
+            );
+        }
+
+        // Everything above the row's own `height = …` line, which is its
+        // comments — the explanation someone wrote for this row.
+        out.extend(
+            lines[row.from..row.header_line]
+                .iter()
+                .map(|l| (*l).to_string()),
+        );
+        out.push(set_number(lines[row.header_line], "height", want.height));
+
+        let unchanged_order = row
+            .panels
+            .iter()
+            .map(|panel| panel.widget.as_str())
+            .eq(want.panels.iter().map(|panel| panel.widget.as_str()));
+
+        if unchanged_order {
+            // Reuse the panel lines as they stand, fixing only the widths, so a
+            // row that merely changed place keeps its alignment.
+            let first = row.panels.first().map_or(row.header_line + 1, |p| p.from);
+            let mut cursor = first;
+            for (panel, wanted) in row.panels.iter().zip(&want.panels) {
+                out.extend(lines[cursor..panel.line].iter().map(|l| (*l).to_string()));
+                out.push(set_number(lines[panel.line], "width", wanted.width));
+                cursor = panel.line + 1;
+            }
+            out.extend(
+                lines[cursor..row.closing_line]
+                    .iter()
+                    .map(|l| (*l).to_string()),
+            );
+        } else {
+            let template = row.panels.first().map_or(row.header_line, |p| p.line);
+            out.extend(panel_lines(lines, blocks, duplicates, want, template)?);
+        }
+        out.push(lines[row.closing_line].to_string());
+    }
+    Ok(Some(out))
 }
 
 /// A layout reduced to what this module promises to reproduce.
@@ -228,6 +353,10 @@ struct PanelSite {
 }
 
 struct RowSite {
+    /// The first line of the row's own comments, or `header_line` when it has
+    /// none. Rows are moved whole by #100, and a row's explanation has to travel
+    /// with it for the same reason a panel's does.
+    from: usize,
     /// The line carrying `height = …`, which is also where a row with no panels
     /// gets its first one inserted after.
     header_line: usize,
@@ -437,7 +566,16 @@ fn map_layout(lines: &[&str]) -> Result<LayoutMap> {
         }
 
         if line.contains("panels") && line.contains('[') {
+            // The row's own comments, walked up the same way a panel's are —
+            // never crossing the row that ended above, so a trailing comment
+            // stays with the row it was written under.
+            let floor = rows.last().map_or(0, |r: &RowSite| r.closing_line + 1);
+            let mut from = index;
+            while from > floor && lines[from - 1].trim().starts_with('#') {
+                from -= 1;
+            }
             rows.push(RowSite {
+                from,
                 header_line: index,
                 // Corrected when the closing line is reached. A row whose block
                 // never closes keeps its header here, which produces a span
@@ -1272,6 +1410,132 @@ rows = [
             actual, CITED,
             "the default config now has {actual} comment lines. Update this \
              constant and `CLAUDE.md` invariant 16 — both quote {CITED}."
+        );
+    }
+
+    /// #100: swapping two rows. Before this, `pair_rows` produced a crossed
+    /// pairing, every per-row edit wrote its row where it already was, and the
+    /// round-trip check threw the whole thing away — so the move worked on
+    /// screen and could never be saved.
+    #[test]
+    fn two_rows_can_swap_places() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows.swap(0, 1);
+
+        let edited = apply(SAMPLE, &desired).expect("a row swap must be writable");
+        assert_eq!(
+            shape(&layout_of(&edited)),
+            shape(&desired),
+            "the file must describe the swapped layout"
+        );
+    }
+
+    /// A row's explanation travels with it, which is the whole reason this
+    /// module edits text instead of reserialising. The round-trip check cannot
+    /// see a lost comment — it compares shapes — so this has to be asserted
+    /// directly. Same lesson as the duplicate-widget refusal.
+    #[test]
+    fn a_moved_row_takes_its_comments_with_it() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows.swap(0, 1);
+
+        let edited = apply(SAMPLE, &desired).expect("applies");
+        assert!(
+            edited.contains("Wide enough for two months side by side."),
+            "the calendar's comment was lost:\n{edited}"
+        );
+
+        // And it is still attached to the calendar rather than stranded above
+        // whatever now sits in that position.
+        let lines: Vec<&str> = edited.lines().collect();
+        let comment = lines
+            .iter()
+            .position(|l| l.contains("Wide enough for two months"))
+            .expect("comment present");
+        assert!(
+            lines[comment + 1].contains("calendar"),
+            "the comment came away from its panel:\n{edited}"
+        );
+    }
+
+    /// Heights belong to rows, not to positions. Swapping two rows must carry
+    /// each height along, or the reader's proportions silently change.
+    #[test]
+    fn a_swapped_row_keeps_its_own_height() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows.swap(0, 1);
+
+        let edited = apply(SAMPLE, &desired).expect("applies");
+        let after = layout_of(&edited);
+        assert_eq!(after.rows[0].height, 42, "the todo row kept its 42");
+        assert_eq!(after.rows[1].height, 34, "and the clocks row its 34");
+    }
+
+    /// A row written entirely on one line has no separate lines to reuse.
+    /// Slicing it as though it did read backwards and panicked — found by
+    /// driving a move in a real terminal, where it took the dashboard down at
+    /// the moment the arrangement was committed. A config in that shape loads
+    /// perfectly well, so nothing upstream refuses it.
+    #[test]
+    fn a_row_written_on_one_line_can_still_be_moved() {
+        const COMPACT: &str = r#"[layout]
+rows = [
+  { height = 25, panels = [ { widget = "clocks", width = 100 } ] },
+  { height = 25, panels = [ { widget = "watchlog", width = 100 } ] },
+  { height = 25, panels = [ { widget = "notes", width = 100 } ] },
+  { height = 25, panels = [ { widget = "cpu", width = 100 } ] },
+]
+"#;
+        let mut desired = layout_of(COMPACT);
+        desired.rows.swap(1, 2);
+
+        // The bug was a panic, so reaching an assertion at all is half the test.
+        let error =
+            apply(COMPACT, &desired).expect_err("a compacted row cannot be moved and must say so");
+        let message = format!("{error}");
+        assert!(
+            message.contains("several lines"),
+            "the refusal should name the shape it wants: {message}"
+        );
+    }
+
+    /// The refusal above must stay as narrow as the problem. A compacted config
+    /// still resizes — that path never touches a row's entries — and only the
+    /// row *move* is out of reach. Widening the check would take a working
+    /// feature away from anyone who tidied their config.
+    #[test]
+    fn a_compact_config_can_still_be_resized() {
+        const COMPACT: &str = r#"[layout]
+rows = [
+  { height = 25, panels = [ { widget = "clocks", width = 100 } ] },
+  { height = 25, panels = [ { widget = "notes", width = 100 } ] },
+]
+"#;
+        let mut desired = layout_of(COMPACT);
+        desired.rows[0].height = 40;
+        desired.rows[1].height = 10;
+
+        let edited = apply(COMPACT, &desired).expect("a resize must still work");
+        assert_eq!(shape(&layout_of(&edited)), shape(&desired));
+    }
+
+    /// The reorder path must not steal work from the cheap one. A plain resize
+    /// leaves the rows in order, so it still rewrites numbers in place rather
+    /// than rebuilding the block — which is what keeps a hand-aligned config
+    /// aligned through a held `Ctrl+arrow`.
+    #[test]
+    fn a_resize_does_not_go_through_the_reorder_path() {
+        let mut desired = layout_of(SAMPLE);
+        desired.rows[0].panels[0].width = 30;
+
+        let edited = apply(SAMPLE, &desired).expect("applies");
+        let before: Vec<&str> = SAMPLE.lines().collect();
+        let after: Vec<&str> = edited.lines().collect();
+        assert_eq!(before.len(), after.len(), "no lines added or removed");
+        let changed = before.iter().zip(&after).filter(|(a, b)| a != b).count();
+        assert_eq!(
+            changed, 1,
+            "a resize should touch exactly one line:\n{edited}"
         );
     }
 }


### PR DESCRIPTION
Closes #100.

`Shift+↑`/`↓` — or `J`/`K` — moves the whole row the focused panel sits in.

Before this, a new row was only ever created by `promote`, reachable only when
the panel is already in the top or bottom row. Everywhere else `Up`/`Down`
merged the panel into its neighbour and `close_if_empty` deleted the row it
left, so a panel alone in a **middle** row could not travel at all and the row
count fell when you tried. `[clocks] [watchlog] [notes] [cpu]` →
`[clocks] [notes] [watchlog] [cpu]` was not expressible with any sequence of
keys.

**Additive.** Moving a panel between rows still merges, which the issue calls
"the right reading of *move this panel into that row*".

## Not the key the issue proposed

#100 suggests `Ctrl+Up`/`Ctrl+Down` and says it "costs no new key". Those
already **resize** inside arrange mode — advertised in the legend and pinned by
`ctrl_arrows_still_resize_inside_arrange_mode`. `Shift+arrow` instead, matching
the clock panel from #109: the bare key moves the small thing, the shifted key
moves the thing it sits in.

## The larger half was `layout_edit`

`pair_rows` produces a crossed pairing when rows swap, and every per-row edit
writes its row where it already sits — so the round-trip check threw the whole
edit away. **The move worked on screen and could never be saved**, which is what
the first real-terminal run showed.

Rows are now emitted in the desired order from their captured text, so a row's
comments and hand-alignment travel with it. Verified on the shipped config: the
reading row's three-line comment moved with it, all 269 comments survived, and
everything outside `[layout]` was byte-identical.

A layout whose rows stay in order still takes the per-row path, so a held
`Ctrl+arrow` still rewrites one number on one line —
`a_resize_does_not_go_through_the_reorder_path` pins that.

## Two things found by driving it, not reading it

**A panic.** A row written entirely on one line has no separate lines to reuse,
and slicing it as though it did read backwards — taking the dashboard down at
the moment the arrangement was committed. A config in that shape loads
perfectly well, so nothing upstream refuses it. Such a row is now refused with a
message naming the shape it needs. Rebuilding it is not the escape it looks
like: a panel's captured entry would be the whole row, nesting the row inside
itself.

**The refusal is as narrow as the problem.** A compacted config still resizes,
because that path never touches a row's entries —
`a_compact_config_can_still_be_resized` holds that line.

## The legend

Both vertical hints were shortened to fit a sixth entry at an ordinary 110
columns. Dropping one was not an option: the help overlay carries only the
*global* keys, so the arrange legend is the only place any of the mode's keys
are written down, and a key that ships undiscoverable is a mistake this project
has already made once with the resize keys.

## Tests

Eleven added. Checked by breaking the code in each direction:

| Break | Test that fails |
| --- | --- |
| unwire `Shift+arrow` from the key handler | `shift_arrows_move_the_whole_row_in_arrange_mode` |
| swap panel lists instead of whole rows | `a_row_takes_its_height_with_it` |
| let `move_row` reach past the edge | `a_row_at_the_edge_has_nowhere_to_go` |

The shell test exists because #106 shipped a correct helper that was simply
never called, with two passing unit tests beside it.

## Verified in a real terminal

- The issue's exact four-row layout: the watch log travels down past the notes
  row, which no sequence of keys could do before.
- On the shipped config: down, back up, and the order is restored; commit, and
  it persists with no alert.
- The compact config that panicked now refuses cleanly and the dashboard stays
  up.

All four gates clean: 668 tests, clippy, fmt, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)