### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-30
+
 ### Added
 
 - **Arrange mode can move a row, not just a panel.** `Shift+↑`/`↓` (or `J`/`K`)
@@ -1199,7 +1201,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/jchultarsky/mirador/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/jchultarsky/mirador/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/jchultarsky/mirador/compare/v0.16.3...v0.17.0
 [0.16.3]: https://github.com/jchultarsky/mirador/compare/v0.16.2...v0.16.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
### Added
- Arrange mode can move a row, not just a panel (#100) — #128

`Shift+↑`/`↓`, or `J`/`K`, moves the whole row the focused panel sits in. A
panel alone in a middle row could not travel at all before this. Moving a panel
between rows still merges, exactly as it always has.

The larger half was `layout_edit`, which could not express a row swap: the move
worked on screen and the round-trip check threw the edit away. Rows are now
emitted in the desired order from their captured text, so a row's comments and
alignment travel with it.

### Before this commit

The built binary was driven in a real terminal, per the rule that a release must
not be the first time its code meets one: the row move persists on the shipped
config with no alert, the clock-zone and news-panel changes from 0.17.x still
behave, and `q` exits cleanly.

`lto = true` intact, `dist plan` announces v0.18.0, all four gates clean on exit
code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)