### PR TITLE
Release 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-07-30
+
 ### Changed
 
 - **A story's link no longer hides in plain sight.** `o` drew it in the same
@@ -1216,7 +1218,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/jchultarsky/mirador/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/jchultarsky/mirador/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/jchultarsky/mirador/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/jchultarsky/mirador/compare/v0.16.3...v0.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Closes out the tracker — every mirador issue is now closed.

### Changed
- A story's link no longer hides in plain sight (#117) — #130

### Fixed
- `o` did nothing until you moved the cursor — #130

### Before this commit

The built binary was driven in a real terminal against live feeds, per the rule
that a release must not be the first time its code meets one: the first press of
`o` works with the cursor never moved, the link renders brass `215;175;135`
against the masthead's verdigris `95;135;135`, no story is displaced, and `q`
exits cleanly.

`lto = true` intact, `dist plan` announces v0.18.1, all four gates clean on exit
code (670 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)