### PR TITLE
Stop the watch log erasing its own rule line when you come back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The watch log erased its own "since you were here" line the moment you came
+  back.** It marked the log seen on gaining focus as well as losing it, so
+  returning to the dashboard set "last looked" to *now* — everything that
+  arrived while you were away landed on the old side of the line, and the line
+  disappeared in the instant you came back to read it. A terminal that reported
+  focus *correctly* made the feature less visible than one that did not. Only
+  losing focus marks it seen now.
+  [#132](https://github.com/jchultarsky/mirador/issues/132).
+
 - **The clock's reorder keys were invisible.** `Shift+↑`/`↓` shipped in 0.17.0 as
   an `extra` binding, which put it in the help overlay and nowhere else — so the
   panel border advertised `e edit` and said nothing about reordering, the thing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1094,8 +1094,8 @@ input is hostile", not "is this correct".
 
 ### Phase 3 — soak
 
-Nothing here had run for a day when this was written. Two of the four are done;
-the other two still need a person with a real terminal.
+Nothing here had run for a day when this was written. **Three of the four are
+done.** Only a real midnight is left, and it needs nothing but time.
 
 - **A full day idle — done.** 0.16.3 soaked for 9h42m over 583 samples on
   2026-07-30: RSS climbed 1.0MB in the first two hours and then moved *once* in
@@ -1108,14 +1108,25 @@ the other two still need a person with a real terminal.
   as unknown.
 - **A real midnight** — still open. The day-rollover entry has only met a test
   that winds the date back.
-- **Terminal focus reporting** — still open, and **blocked on
-  [#132](https://github.com/jchultarsky/mirador/issues/132)**. It cannot be
-  honestly confirmed while the current behaviour hides its own evidence: the
-  watch log marks itself seen on `FocusGained` as well as `FocusLost`, so
-  returning to the dashboard erases the "since you were here" line in the same
-  instant you look for it. A terminal that reports focus *correctly* makes the
-  feature less visible, not more, so "I saw no rule line" cannot distinguish
-  working from broken. Fix #132 first, then verify.
+- **Terminal focus reporting — done, and the method is the interesting part.**
+  This was recorded for a long time as unverifiable by an agent, because a
+  headless tmux has no attached client to have focus. That is true and beside
+  the point: **focus events are just bytes on stdin**, and `tmux send-keys -H`
+  can inject them.
+
+  ```sh
+  tmux send-keys -t <session> -H 1b 5b 49   # ESC [ I — focus gained
+  tmux send-keys -t <session> -H 1b 5b 4f   # ESC [ O — focus lost
+  ```
+
+  Verified on 2026-07-30 with a rule line on screen: focus-in left it alone,
+  focus-out erased it. **The control is what makes that mean anything** — if the
+  sequences were being swallowed, focus-out would have done nothing either. Use
+  the same pair for anything else that reacts to focus.
+
+  This also settles #132's fix end to end: `mark_seen` now runs on `FocusLost`
+  only, so returning to the dashboard no longer erases the line in the instant
+  it is wanted.
 
 **The midnight check wants two independent witnesses**, for exactly that reason:
 the clock's own date line flipping, *and* a watch log entry reading

--- a/src/app.rs
+++ b/src/app.rs
@@ -568,10 +568,23 @@ impl App {
                     // tmux forwards it only with `focus-events on`, so it is
                     // an improvement where available rather than the mechanism
                     // — the keypress below carries it everywhere else.
-                    // Both, not just one: gaining focus means they are here
-                    // now, and losing it means they were here until this
-                    // moment. Either way the line belongs at this point.
-                    Event::FocusGained | Event::FocusLost => self.watch.mark_seen(),
+                    //
+                    // **Losing focus only.** This used to mark on both, on the
+                    // reasoning that gaining focus means they are here now and
+                    // losing it means they were here until this moment — each
+                    // true in isolation, and together they made the rule line
+                    // impossible to see. Returning to the dashboard set "last
+                    // looked" to *now*, so everything that arrived while the
+                    // reader was away landed on the old side of the line and the
+                    // line vanished in the instant they came back to read it.
+                    // A terminal that reported focus *correctly* therefore made
+                    // the feature less visible than one that did not (#132).
+                    //
+                    // Leaving is the half that can be recorded without
+                    // destroying what it describes: they were present with those
+                    // entries on screen, so marking them seen is honest. Coming
+                    // back is precisely when the line has to still be there.
+                    Event::FocusLost => self.watch.mark_seen(),
                     _ => {}
                 }
             }
@@ -3331,6 +3344,22 @@ mod tests {
         assert!(
             GLOBAL.iter().any(|b| b.key == "?" && b.primary),
             "help must always be advertised"
+        );
+    }
+
+    /// And the event loop itself must offer only `FocusLost` to `mark_seen`.
+    /// The two tests above exercise `WatchLog`; this one is about the wiring,
+    /// which is where #132 actually lived — the log was always correct.
+    #[test]
+    fn only_losing_focus_marks_the_log_seen() {
+        let source = std::fs::read_to_string(file!()).expect("this file is readable");
+        let wiring = source
+            .lines()
+            .find(|line| line.contains("=> self.watch.mark_seen()"))
+            .expect("the focus arm still exists");
+        assert!(
+            wiring.contains("FocusLost") && !wiring.contains("FocusGained"),
+            "gaining focus must not mark the log seen: {wiring:?}"
         );
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -208,4 +208,54 @@ mod tests {
 
         assert_eq!(log.unseen(), Some(2), "the two that arrived after");
     }
+
+    /// #132, written as the sequence a reader actually performs.
+    ///
+    /// The bug was in `app.rs`, which marked the log seen on `FocusGained` as
+    /// well as `FocusLost` — so returning to the dashboard set "last looked" to
+    /// *now*, every entry that arrived while away landed on the old side of the
+    /// line, and the line vanished in the instant it was wanted. A terminal that
+    /// reported focus *correctly* made the feature less visible than one that
+    /// did not.
+    ///
+    /// The log itself was always right, which is why this asserts the property
+    /// the reader cares about — the line is still there when they come back —
+    /// rather than which events fire. `only_losing_focus_marks_the_log_seen` in
+    /// `app.rs` holds the wiring.
+    ///
+    /// Timestamps come from `at`, not `Zoned::now()`. The first version of this
+    /// test used real clock reads and failed about one run in three: `unseen`
+    /// compares with `>`, and two `now()` calls in a tight loop can land on the
+    /// same instant.
+    #[test]
+    fn coming_back_leaves_the_rule_line_where_it_was() {
+        let mut log = WatchLog::default();
+        log.push(at(&log, 1));
+
+        // Leaving is the half that can be recorded honestly: the reader was
+        // present with that entry on screen.
+        log.seen_at = Some(
+            log.since
+                .checked_add(Span::new().minutes(2))
+                .expect("in range"),
+        );
+
+        // Two things happen while nobody is looking.
+        log.push(at(&log, 3));
+        log.push(at(&log, 4));
+
+        assert_eq!(
+            log.unseen(),
+            Some(2),
+            "both entries that arrived while away are unseen"
+        );
+
+        // Coming back marks nothing now, so the line is still here. Before the
+        // fix this point was a fresh `mark_seen()` and the answer became `None`.
+        assert_eq!(
+            log.unseen(),
+            Some(2),
+            "returning must not erase the line it exists to show"
+        );
+    }
 }


### PR DESCRIPTION
Closes #132, using option 1 from the issue: mark on `FocusLost` only.

`mark_seen()` ran on `FocusGained` as well as `FocusLost`. Each half was true in
isolation, and together they made the rule line impossible to see — returning to
the dashboard set "last looked" to *now*, so everything that arrived while the
reader was away landed on the old side of the line and the line vanished in the
instant they came back to read it.

The perverse consequence: **a terminal that reported focus correctly made the
feature less visible than one that did not.** It survived only on a window that
never took focus.

Losing focus is the half that can be recorded without destroying what it
describes: the reader was present with those entries on screen. Coming back is
precisely when the line has to still be there. The keypress fallback is
untouched.

## Verified end to end — and the method unblocks Phase 3

The notes had recorded focus reporting as unverifiable by an agent, because a
headless tmux has no attached client to have focus. True, and beside the point:
**focus events are bytes on stdin.**

```sh
tmux send-keys -t <session> -H 1b 5b 49   # ESC [ I — focus gained
tmux send-keys -t <session> -H 1b 5b 4f   # ESC [ O — focus lost
```

With a real rule line on screen, built by letting two calendar entries arrive
either side of a mark:

| Injected | Rule line |
| --- | --- |
| focus gained | **survives** — the fix |
| focus lost | **erased** — the intended half still works |

**The second is the control.** Had the sequences been swallowed by tmux, neither
would have done anything and the first result would have meant nothing.

`CLAUDE.md` records the method. It takes Phase 3 from two open items to one —
only a real midnight is left, and that needs nothing but time.

## Where the tests live

The two behavioural tests are in `watch.rs`, not beside the wiring they describe.
The first versions used `Zoned::now()` and **failed about one run in three**:
`unseen` compares with `>`, and two clock reads in a tight loop can land on the
same instant. `watch.rs` already had a helper that builds entries at explicit
offsets. Confirmed stable over ten consecutive runs.

`only_losing_focus_marks_the_log_seen` in `app.rs` holds the wiring, and was
checked by restoring `FocusGained |` and watching it fail.

All four gates clean, 674 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)