### PR TITLE
Release 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-07-30
+
 ### Fixed
 
 - **The watch log erased its own "since you were here" line the moment you came
@@ -1237,7 +1239,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.18.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.18.2...HEAD
+[0.18.2]: https://github.com/jchultarsky/mirador/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/jchultarsky/mirador/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/jchultarsky/mirador/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/jchultarsky/mirador/compare/v0.17.0...v0.17.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
### Fixed
- Watch log erased its own "since you were here" line on return (#132) — #135
- Clock's reorder keys were invisible on the border (#134) — #134

Also refreshes the stale notes in `CLAUDE.md` (#133), including the method for
injecting focus events with `tmux send-keys -H` — which took Phase 3 of the road
to 1.0 from two open items down to one.

### Before this commit

The built binary was driven in a real terminal:

- the clock border reads `s seconds · a add · e edit · Shift+↑↓ move`
- with a rule line on screen, focus-gained (`1b 5b 49`) **left it alone** and
  focus-lost (`1b 5b 4f`) **erased it** — the second being the control that makes
  the first mean anything
- `q` exits cleanly

`lto = true` intact, `dist plan` announces v0.18.2, all four gates clean on exit
code (674 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)