### PR TITLE
Let a news link be copied or opened, not only looked at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A story's link can now be copied or opened, not just looked at.** `y` asks
+  the terminal to put it on the clipboard (OSC 52) — no configuration and no
+  dependency, though some terminals refuse it and tmux needs `set-clipboard on`;
+  mirador cannot tell either way, so it says it *sent* the link rather than
+  claiming it copied one. `↵` opens it with `[news].open_command`, which is empty
+  by default — mirador launches nothing you did not name, runs it directly rather
+  than through a shell, and passes the link as its own argument so nothing in a
+  URL can be read as shell syntax.
+  [#137](https://github.com/jchultarsky/mirador/issues/137).
+
 ## [0.18.2] - 2026-07-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 269 of them, including the ones mirador
+    trip through `toml` discards all 281 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -545,6 +545,23 @@ value is trimmed once, at the end. There is a test.
 
 **Headlines only.** Every feed sampled carries 80–384 characters of article
 prose in `<description>`. A headline is a fact; a summary is somebody's work.
+
+**A link is now actionable, and the "no browser" rule was narrowed to get
+there** (#137). It used to read that no browser is launched at all, "the same
+answer this project gave to playing a sound file". That analogy was carrying
+more than it could: the sound decision was about a *dependency chain* — `rodio`
+reaching `cpal` reaching `alsa-sys`, C headers on every Linux builder — and
+spawning a process costs none of that. What actually settled the sound question
+was `chime_command`: **mirador does not pick the program, you name it.**
+`[news].open_command` is the same answer, empty by default, run directly rather
+than through a shell with the link as its own argument.
+
+`y` copies instead, via OSC 52 — a bare escape sequence, the same shape as the
+chime being a raw `\x07`. Base64 is hand-rolled in `clipboard.rs` rather than
+adding a dependency for twenty lines, which is the `quick-xml` over `rss` trade
+again. **It is write-only, so mirador cannot know whether it worked**, and the
+footer says it sent the link rather than claiming it copied one. Verified end to
+end under tmux with `set-clipboard on`, which does receive it.
 
 **The shipped feeds are science, space and technology.** Choosing outlets for
 general or political news is an editorial act this project should not make on

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Headlines from RSS feeds you choose.
 │ ARS TECHNICA · 45m old                               │
 │ 5th Circuit blocks Texas law requiring websites to   │
 │ filter "harmful" speech                              │
-╰───────── r refresh · o show link ────────────────────╯
+╰──── o show link · y copy · ↵ open · r refresh ────────╯
 ```
 
 **A window, not a feed.** It shows however many stories fit and no more. There
@@ -525,9 +525,31 @@ panel holds the newest from *each* feed. Sorting by date alone hands the whole
 window to whichever outlet publishes most often, which is fresh but is not a
 window on the world.
 
-`o` shows the selected story's link so you can copy it. It does not open a
-browser — that means talking to the platform, which is the same decision as
-playing a sound file and gets the same answer.
+`o` shows the selected story's link, in brass beneath a `↳`, wrapped whole so
+you can read all of it.
+
+`y` copies it, by asking your terminal to set the clipboard (OSC 52). No
+configuration and no dependency — but it is best-effort: some terminals refuse
+the sequence, and tmux needs `set-clipboard on`. mirador cannot tell whether it
+worked, which is why it says it sent the link rather than claiming it copied one.
+
+`↵` opens it, and **only if you name a program**:
+
+```toml
+[news]
+open_command = ["open"]                  # macOS
+# open_command = ["xdg-open"]            # Linux
+# open_command = ["cmd", "/c", "start"]  # Windows
+```
+
+Empty by default, so mirador launches nothing you did not ask for. It is run
+directly rather than through a shell, and the link goes on as its own argument,
+so nothing in a URL can be read as shell syntax. Same shape as
+`[pomodoro].chime_command`: mirador does not pick the program, you name it.
+
+If you would rather select the text with the mouse, note that mirador holds the
+mouse — use your terminal's override modifier (Shift in most, Option in macOS
+Terminal and iTerm2), or set `[general].mouse = false`.
 
 The shipped feeds are science, space and technology only. Choosing outlets for
 general or political news is an editorial act this project has no business

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -337,6 +337,19 @@ per_feed        = 4      # kept from each feed, so a chatty one cannot crowd
                          # out a quiet one. Stories are then interleaved, so
                          # the top of the panel holds one from each.
 
+# What Enter runs on the selected story, with the link added as the last
+# argument. Empty means Enter opens nothing — mirador launches no program you
+# did not name. Run directly rather than through a shell, so nothing in a URL
+# can be read as shell syntax.
+#
+#   open_command = ["open"]                  # macOS
+#   open_command = ["xdg-open"]              # Linux
+#   open_command = ["cmd", "/c", "start"]    # Windows
+#
+# `y` copies the link instead, by asking the terminal (OSC 52). That needs no
+# configuration, but some terminals refuse it and tmux wants `set-clipboard on`.
+# open_command = []
+
 [[news.feeds]]
 name = "NASA"
 url  = "https://www.nasa.gov/news-release/feed/"

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,141 @@
+//! Putting text on the clipboard, by asking the terminal to do it.
+//!
+//! OSC 52 is an escape sequence: the program writes the text, base64-encoded,
+//! and the terminal decides whether to honour it. That is the whole mechanism.
+//! No dependency, no platform call, no window-system connection — the same
+//! answer this project gave to playing a sound, where the chime is a raw `\x07`
+//! rather than an audio library.
+//!
+//! **It is best-effort, and the honesty about that matters more than the code.**
+//! The sequence is write-only: nothing comes back, so mirador cannot know
+//! whether the clipboard was actually set. Many terminals disable OSC 52 by
+//! default because a program that can write the clipboard can also overwrite
+//! whatever was on it, and tmux needs `set-clipboard on` to pass it through.
+//!
+//! So a caller must not report "copied". It can report that it asked, which is
+//! true either way, and let the reader discover the rest by pasting.
+
+use std::io::Write;
+
+/// Ask the terminal to put `text` on the system clipboard.
+///
+/// Errors only when the write itself fails. A terminal that ignores the
+/// sequence is indistinguishable from one that honoured it.
+pub fn copy(text: &str) -> std::io::Result<()> {
+    // `c` is the system clipboard. The alternative, `p`, is the X primary
+    // selection, which is a different thing on one platform and nothing at all
+    // on the others.
+    let payload = format!("\x1b]52;c;{}\x07", base64(text.as_bytes()));
+    let mut out = std::io::stdout();
+    out.write_all(payload.as_bytes())?;
+    out.flush()
+}
+
+/// Standard base64 with padding, which is what OSC 52 wants.
+///
+/// Hand-rolled rather than pulled in: this is the only base64 in the program,
+/// and a dependency for twenty lines is the trade `quick-xml` was chosen over
+/// `rss` to avoid.
+fn base64(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        // Pad the group to three bytes, remembering how many were real: the
+        // padding decides how many `=` go on the end.
+        let b = [
+            chunk[0],
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+        ];
+        let triple = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        let indices = [
+            (triple >> 18) & 0x3f,
+            (triple >> 12) & 0x3f,
+            (triple >> 6) & 0x3f,
+            triple & 0x3f,
+        ];
+        // `chunk.len()` real bytes produce `len + 1` meaningful characters.
+        for (position, index) in indices.iter().enumerate() {
+            if position <= chunk.len() {
+                out.push(ALPHABET[*index as usize] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The RFC 4648 vectors, which exist precisely because the padding cases
+    /// are where a hand-rolled encoder goes wrong.
+    #[test]
+    fn base64_matches_the_published_test_vectors() {
+        for (input, want) in [
+            ("", ""),
+            ("f", "Zg=="),
+            ("fo", "Zm8="),
+            ("foo", "Zm9v"),
+            ("foob", "Zm9vYg=="),
+            ("fooba", "Zm9vYmE="),
+            ("foobar", "Zm9vYmFy"),
+        ] {
+            assert_eq!(base64(input.as_bytes()), want, "encoding {input:?}");
+        }
+    }
+
+    /// A URL is what this exists for, and it has to survive byte for byte.
+    #[test]
+    fn a_real_link_round_trips_through_the_encoder() {
+        let link = "https://arstechnica.com/science/2026/07/if-a-quantum-computer/";
+        let encoded = base64(link.as_bytes());
+        assert_eq!(
+            decode(&encoded),
+            link.as_bytes(),
+            "the link did not survive encoding"
+        );
+    }
+
+    /// Non-ASCII goes through as UTF-8 bytes rather than characters. A link can
+    /// carry them, and a title certainly can if this is ever reused.
+    #[test]
+    fn multi_byte_text_encodes_as_bytes() {
+        for text in ["日本語", "café", "🌞", "a🌞b"] {
+            assert_eq!(decode(&base64(text.as_bytes())), text.as_bytes(), "{text}");
+        }
+    }
+
+    /// The sequence is what the terminal actually parses, so its shape is part
+    /// of the contract: introducer, selection, payload, terminator.
+    #[test]
+    fn the_escape_sequence_is_shaped_the_way_terminals_expect() {
+        let payload = format!("\x1b]52;c;{}\x07", base64(b"hi"));
+        assert!(payload.starts_with("\x1b]52;c;"), "OSC 52 introducer");
+        assert!(payload.ends_with('\x07'), "BEL terminator");
+        assert_eq!(&payload[7..payload.len() - 1], "aGk=");
+    }
+
+    /// Decode, for the tests only. Not `pub`: nothing in mirador reads a
+    /// clipboard, and an unused decoder is a thing to keep working for nobody.
+    fn decode(text: &str) -> Vec<u8> {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut bits = Vec::new();
+        for c in text.bytes().filter(|c| *c != b'=') {
+            let index = ALPHABET
+                .iter()
+                .position(|a| *a == c)
+                .expect("valid base64 alphabet");
+            for shift in (0..6).rev() {
+                bits.push((index >> shift) & 1);
+            }
+        }
+        bits.chunks_exact(8)
+            .map(|byte| byte.iter().fold(0u8, |acc, bit| (acc << 1) | *bit as u8))
+            .collect()
+    }
+}

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -403,6 +403,18 @@ pub struct NewsConfig {
     /// Most stories to keep from any one feed, so a chatty outlet cannot crowd
     /// out a quiet one.
     pub per_feed: usize,
+    /// What `Enter` runs on the selected story, with the link appended.
+    ///
+    /// **Empty by default, so mirador launches nothing it was not asked to.**
+    /// The panel's own note is that no browser is opened for you — and the way
+    /// that was settled for sound is the way it is settled here: mirador does
+    /// not pick the program, you name it. Same shape as
+    /// `[pomodoro].chime_command`, run directly rather than through a shell, so
+    /// nothing in a URL can be taken as shell syntax.
+    ///
+    /// `["open"]` on macOS, `["xdg-open"]` on Linux, `["cmd", "/c", "start"]`
+    /// on Windows — or name a specific browser.
+    pub open_command: Vec<String>,
 }
 
 impl Default for NewsConfig {
@@ -426,6 +438,7 @@ impl Default for NewsConfig {
             ],
             refresh_minutes: 60,
             per_feed: 4,
+            open_command: Vec::new(),
         }
     }
 }

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 269;
+        const CITED: usize = 281;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod app;
 mod arrange;
 mod chart;
+mod clipboard;
 mod config;
 mod dateinput;
 mod feed;

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -24,9 +24,18 @@
 //! You glance at it the way you glance at the weather glass. Break any of those
 //! and this becomes the feature that was turned down.
 //!
-//! Headlines only, never the summary — see [`crate::feed`] for why. And no
-//! browser is launched: `o` shows the link and you copy it yourself, the same
-//! answer this project gave to playing a sound file.
+//! Headlines only, never the summary — see [`crate::feed`] for why.
+//!
+//! **No browser is launched that the reader did not name.** That is a narrowing
+//! of what this note used to say, which was that no browser is launched at all,
+//! "the same answer this project gave to playing a sound file". The analogy was
+//! doing more work than it could carry: the sound decision was about a
+//! *dependency chain* — `rodio` reaching `cpal` reaching `alsa-sys`, C headers
+//! on every Linux builder — and spawning a process costs none of that. What
+//! actually settled the sound question was `[pomodoro].chime_command`: mirador
+//! does not pick the program, you name it. `[news].open_command` is that same
+//! answer, and empty by default, so the shipped dashboard still launches
+//! nothing.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -46,8 +55,10 @@ use crate::frame::{Binding, FRAME_WIDTH};
 use crate::panel::{KeyOutcome, Panel, RenderContext, describe_age};
 
 const BINDINGS: &[Binding] = &[
-    Binding::primary("r", "refresh"),
     Binding::primary("o", "show link"),
+    Binding::primary("y", "copy"),
+    Binding::primary("↵", "open"),
+    Binding::primary("r", "refresh"),
     Binding::extra("↑ / ↓", "select"),
     Binding::extra("j / k", "select"),
 ];
@@ -81,6 +92,13 @@ pub struct NewsPanel {
     selected: ListState,
     /// Set by `o`; the link of whatever is selected.
     showing_link: Option<String>,
+    /// What `Enter` runs, with the link appended. Empty means nothing runs.
+    open_command: Vec<String>,
+    /// What `y` or `Enter` just did, shown in the footer until the next key.
+    ///
+    /// Separate from `failing`, which belongs to the fetch: a clipboard that
+    /// went nowhere says nothing about whether the feeds are readable.
+    action: Option<String>,
     /// Stories drawn last frame, for clamping the selection.
     drawn: usize,
     /// The stories as of the last time the fetch thread published.
@@ -118,6 +136,7 @@ impl NewsPanel {
             .map(|feed| (feed.name.clone(), feed.url.clone()))
             .collect();
         let per_feed = config.per_feed.clamp(1, 20);
+        let open_command = config.open_command.clone();
 
         let shared = (
             Arc::clone(&state),
@@ -149,10 +168,81 @@ impl NewsPanel {
             seen: 0,
             selected: ListState::default(),
             showing_link: None,
+            open_command,
+            action: None,
             drawn: 0,
             shown: Vec::new(),
             fetched: None,
             failing: None,
+        }
+    }
+
+    /// The link of the story the cursor is on, or the top one when it has not
+    /// been placed — the same rule `o` follows, so all three keys act on the
+    /// same story.
+    fn link_under_cursor(&mut self) -> Option<String> {
+        let index = self.selected.selected().unwrap_or(0);
+        let link = self
+            .shown
+            .get(index)
+            .map(|story| story.link.clone())
+            .filter(|link| !link.is_empty())?;
+        self.selected.select(Some(index));
+        Some(link)
+    }
+
+    /// Ask the terminal to put the link on the clipboard.
+    fn copy_link(&mut self) {
+        let Some(link) = self.link_under_cursor() else {
+            return;
+        };
+        self.action = Some(match crate::clipboard::copy(&link) {
+            // Deliberately not "copied". OSC 52 is write-only — the terminal
+            // may ignore it, and many do by default — so mirador cannot know
+            // whether the clipboard changed. What it can say is what it did.
+            Ok(()) => "sent to the clipboard — paste to check".to_string(),
+            Err(e) => format!("could not reach the terminal: {e}"),
+        });
+    }
+
+    /// Run `[news].open_command` with the link appended.
+    fn open_link(&mut self) {
+        let Some(link) = self.link_under_cursor() else {
+            return;
+        };
+        let Some((program, rest)) = self.open_command.split_first() else {
+            // Not an error. Nothing is configured, which is the default and a
+            // perfectly good state to be in; the reader just asked for
+            // something that has not been switched on.
+            self.action = Some("set [news].open_command to open links".to_string());
+            return;
+        };
+
+        // Run directly, never through a shell, so nothing in a URL can be taken
+        // as shell syntax — the same reasoning as `[pomodoro].chime_command`,
+        // and the link goes on as one argument rather than being interpolated.
+        match std::process::Command::new(program)
+            .args(rest)
+            .arg(&link)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                // Just "opened". The program is in the reader's own config, so
+                // naming it here spends the footer on something they already
+                // know — and a configured path can be long enough to wrap.
+                // The failure case below does name it, which is when it matters.
+                self.action = Some("opened".to_string());
+                // Reaped on a thread that can take as long as it likes. A
+                // browser outlives the keypress by a long way, and without this
+                // the zombies pile up one per link.
+                std::thread::spawn(move || {
+                    let _ = child.wait();
+                });
+            }
+            Err(e) => self.action = Some(format!("{program}: {e}")),
         }
     }
 
@@ -224,6 +314,7 @@ impl Panel for NewsPanel {
         // Nothing here dismisses, hides or marks a story. There is no state to
         // keep up with, which is the point.
         self.showing_link = None;
+        self.action = None;
         match key.code {
             KeyCode::Char('r') => {
                 if let Ok(mut flag) = self.refresh.lock() {
@@ -239,9 +330,9 @@ impl Panel for NewsPanel {
                 // complaint that issue was filed about: the link was both
                 // unreachable at first press and camouflaged once reached.
                 let index = self.selected.selected().unwrap_or(0);
-                // Shown, not opened. Launching a browser means talking to the
-                // platform — `open`, `xdg-open`, `start` — which is the same
-                // decision as playing a sound file and gets the same answer.
+                // Shown. Opening is `Enter`, and only when the reader has
+                // named a program in `[news].open_command` — mirador still
+                // launches nothing of its own choosing.
                 self.showing_link = self
                     .shown
                     .get(index)
@@ -254,6 +345,8 @@ impl Panel for NewsPanel {
                     self.selected.select(Some(index));
                 }
             }
+            KeyCode::Char('y') => self.copy_link(),
+            KeyCode::Enter => self.open_link(),
             KeyCode::Down | KeyCode::Char('j') => {
                 crate::selection::down(&mut self.selected, 1, self.drawn);
             }
@@ -293,12 +386,12 @@ impl Panel for NewsPanel {
         // URL unreadable, uncopyable, and (worse) linkified by the terminal as
         // far as the ellipsis, so clicking it went somewhere that did not exist.
         // Bounded at half the panel so a long link cannot swallow the stories.
-        let foot_rows = match &self.showing_link {
-            Some(link) => u16::try_from(link_lines(link, area.width).len())
-                .unwrap_or(u16::MAX)
-                .clamp(1, (area.height / 2).max(1)),
-            None => 1.min(area.height),
-        };
+        let foot_rows = footer_rows(
+            self.action.as_deref(),
+            self.showing_link.as_deref(),
+            area.width,
+            area.height,
+        );
         let footer = Rect {
             y: area.y + area.height.saturating_sub(foot_rows),
             height: foot_rows,
@@ -310,28 +403,12 @@ impl Panel for NewsPanel {
         };
 
         if self.shown.is_empty() {
-            let message = match &self.failing {
-                Some(why) => vec![
-                    Line::from(Span::styled(
-                        "Cannot read the feeds",
-                        Style::default()
-                            .fg(theme.error)
-                            .add_modifier(Modifier::BOLD),
-                    )),
-                    Line::from(Span::styled(
-                        crate::grid::truncate(why, width),
-                        Style::default().fg(theme.muted),
-                    )),
-                ],
-                None if self.fetched.is_some() => vec![Line::from(Span::styled(
-                    "No stories.",
-                    Style::default().fg(theme.muted),
-                ))],
-                None => vec![Line::from(Span::styled(
-                    "Reading…",
-                    Style::default().fg(theme.muted),
-                ))],
-            };
+            let message = empty_message(
+                self.failing.as_deref(),
+                self.fetched.is_some(),
+                width,
+                theme,
+            );
             frame.render_widget(Paragraph::new(message), body);
             self.drawn = 0;
             return;
@@ -393,6 +470,21 @@ impl Panel for NewsPanel {
         // A `(text, style)` pair rather than a `Span`, because the link case is
         // multi-line and a `Span` holding newlines renders as one line with the
         // breaks swallowed. `Paragraph::new(String)` splits on them properly.
+        // What a key just did outranks everything: it is the answer to a
+        // question the reader asked a moment ago, and it is gone on the next
+        // keypress. The link, the fetch failure and the age are all standing
+        // state that will still be there afterwards.
+        if let Some(action) = &self.action
+            && footer.height > 0
+        {
+            frame.render_widget(
+                Paragraph::new(crate::grid::wrapped(action, area.width))
+                    .style(Style::default().fg(theme.accent)),
+                footer,
+            );
+            return;
+        }
+
         let (foot, foot_style) = match (&self.showing_link, &self.failing) {
             // Wrapped by `grid`, never handed to ratatui's wrapper, and never
             // truncated: the whole point is that the reader can read and copy
@@ -424,6 +516,62 @@ impl Panel for NewsPanel {
         if footer.height > 0 {
             frame.render_widget(Paragraph::new(foot).style(foot_style), footer);
         }
+    }
+}
+
+/// What the panel says when it has no stories.
+///
+/// Three different states, and telling them apart is the point: a failing fetch
+/// is a problem, "no stories" is a quiet day, and "reading" is neither. One
+/// message for all three would leave a reader unable to tell a broken feed from
+/// an empty one.
+fn empty_message(
+    failing: Option<&str>,
+    has_read: bool,
+    width: usize,
+    theme: &crate::theme::Theme,
+) -> Vec<Line<'static>> {
+    match failing {
+        Some(why) => vec![
+            Line::from(Span::styled(
+                "Cannot read the feeds",
+                Style::default()
+                    .fg(theme.error)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                crate::grid::truncate(why, width),
+                Style::default().fg(theme.muted),
+            )),
+        ],
+        None if has_read => vec![Line::from(Span::styled(
+            "No stories.",
+            Style::default().fg(theme.muted),
+        ))],
+        None => vec![Line::from(Span::styled(
+            "Reading…",
+            Style::default().fg(theme.muted),
+        ))],
+    }
+}
+
+/// How many rows the footer needs.
+///
+/// Each case is measured by the same rule that draws it. A wrapped message sized
+/// as a single row loses its tail, which is the bug #108 fixed for the link and
+/// which was waiting to be reintroduced beside it the moment a second kind of
+/// footer text existed.
+///
+/// Bounded at half the panel either way, so nothing in the footer can swallow
+/// the stories.
+fn footer_rows(action: Option<&str>, link: Option<&str>, width: u16, height: u16) -> u16 {
+    let cap = (height / 2).max(1);
+    match (action, link) {
+        (Some(action), _) => crate::grid::wrapped_height(action, width).clamp(1, cap),
+        (None, Some(link)) => u16::try_from(link_lines(link, width).len())
+            .unwrap_or(u16::MAX)
+            .clamp(1, cap),
+        (None, None) => 1.min(height),
     }
 }
 
@@ -994,6 +1142,105 @@ mod tests {
             panel.selected.selected(),
             Some(0),
             "and mark the story it belongs to"
+        );
+    }
+
+    /// `Enter` must not launch anything when nothing is configured. That is the
+    /// default state, and mirador shipping a browser launch nobody asked for is
+    /// the decision this feature was careful not to reverse.
+    #[test]
+    fn enter_launches_nothing_until_a_command_is_named() {
+        let mut panel = loaded_panel();
+        assert!(panel.open_command.is_empty(), "the default is empty");
+
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+
+        assert_eq!(
+            panel.action.as_deref(),
+            Some("set [news].open_command to open links"),
+            "it should say how to switch it on, not fail silently"
+        );
+    }
+
+    /// And when one *is* named, the link goes on as a separate argument. Never
+    /// interpolated into a string and never through a shell — a URL is full of
+    /// characters a shell would take an interest in.
+    #[test]
+    fn a_named_command_runs_with_the_link_as_its_own_argument() {
+        let mut panel = loaded_panel();
+        // `true` exists everywhere and ignores its arguments, so this checks the
+        // spawn path without depending on a browser.
+        panel.open_command = vec!["true".into()];
+
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+
+        assert_eq!(
+            panel.action.as_deref(),
+            Some("opened"),
+            "the spawn should have succeeded; got {:?}",
+            panel.action
+        );
+    }
+
+    /// A command that is not there has to say so rather than looking like it
+    /// worked. The reader named it; only they can fix it.
+    #[test]
+    fn a_command_that_does_not_exist_reports_itself() {
+        let mut panel = loaded_panel();
+        panel.open_command = vec!["mirador-no-such-program".into()];
+
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+
+        let said = panel.action.clone().unwrap_or_default();
+        assert!(
+            said.starts_with("mirador-no-such-program:"),
+            "the failure should name the program: {said:?}"
+        );
+    }
+
+    /// `y` reports what mirador did, not what the terminal did. OSC 52 is
+    /// write-only, so "copied" would be a claim nothing can stand behind — many
+    /// terminals refuse the sequence and tmux needs `set-clipboard on`.
+    #[test]
+    fn copying_does_not_claim_more_than_it_knows() {
+        let mut panel = loaded_panel();
+        panel.handle_key(KeyEvent::from(KeyCode::Char('y')));
+
+        let said = panel.action.clone().unwrap_or_default();
+        assert!(
+            !said.starts_with("copied"),
+            "the terminal may have ignored it; do not assert success: {said:?}"
+        );
+        assert!(
+            said.contains("clipboard"),
+            "but it should say what was attempted: {said:?}"
+        );
+    }
+
+    /// All three keys act on the same story, so the link that is copied or
+    /// opened is the one the cursor marks — #114's complaint, one layer up.
+    #[test]
+    fn copy_and_open_act_on_the_story_the_cursor_marks() {
+        let mut panel = loaded_panel();
+        // The cursor is bounded by what was drawn, so the panel has to have been
+        // drawn before it can move at all.
+        draw(&mut panel, 46, 20);
+        panel.handle_key(KeyEvent::from(KeyCode::Char('j')));
+        let marked = panel.selected.selected().expect("cursor placed");
+
+        panel.handle_key(KeyEvent::from(KeyCode::Char('o')));
+        assert_eq!(
+            panel.showing_link.as_deref(),
+            Some(panel.shown[marked].link.as_str()),
+            "`o` shows the marked story"
+        );
+
+        panel.open_command = vec!["true".into()];
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(
+            panel.selected.selected(),
+            Some(marked),
+            "`Enter` must not move the cursor to a different story"
         );
     }
 


### PR DESCRIPTION
Closes #137, shipping mechanisms 1 and 2 from the design note.

```
╰──── o show link · y copy · ↵ open · r refresh ────────╯
```

## `y` — copy, via OSC 52

A bare escape sequence: mirador writes the link base64-encoded and the terminal
decides. No dependency, no platform call — the same shape as the pomodoro chime
being a raw `\x07` rather than an audio library.

Base64 is hand-rolled in a new `clipboard.rs`. It is the only base64 in the
program, and a dependency for twenty lines is the trade `quick-xml` over `rss`
already refused. Held to the **RFC 4648 vectors**, which exist precisely because
the padding cases are where a hand-rolled encoder goes wrong.

**It is write-only, so mirador cannot know whether it worked.** Terminals refuse
OSC 52 fairly often and tmux needs `set-clipboard on`. So the footer says it
*sent* the link rather than claiming it copied one, and
`copying_does_not_claim_more_than_it_knows` fails if that ever changes to
"copied".

## `↵` — open, only with a named program

```toml
[news]
open_command = ["open"]                  # macOS
# open_command = ["xdg-open"]            # Linux
# open_command = ["cmd", "/c", "start"]  # Windows
```

**Empty by default, so mirador still launches nothing.**

### This narrows a recorded decision rather than reversing one

The panel's note said no browser is launched at all, *"the same answer this
project gave to playing a sound file"*. The analogy was carrying more than it
could: the sound decision was about a **dependency chain** — `rodio` → `cpal` →
`alsa-sys`, C headers on every Linux builder, which would have undone the musl
and Windows work. Spawning a process costs none of that.

What actually settled the sound question was `[pomodoro].chime_command`:
**mirador does not pick the program, you name it.** This is that same answer,
applied to the same shape of question. Run directly rather than through a shell,
with the link as its own argument, so nothing in a URL can be read as shell
syntax.

## Verified in a real terminal, at both ends

- Under tmux with `set-clipboard on`, `y` **really does set the buffer** —
  checked by seeding a sentinel value and watching the URL replace it.
- `Enter` with a two-element command ran it with exactly `--flag` and the URL as
  **separate arguments**, proving the link is passed rather than interpolated.
- `Enter` with nothing configured says how to switch it on rather than failing
  silently.

## Tests

Nine added, and the two that carry the design were checked by breaking the code:

| Break | Test that fails |
| --- | --- |
| open unconditionally when unconfigured | `enter_launches_nothing_until_a_command_is_named` |
| claim "copied" | `copying_does_not_claim_more_than_it_knows` |

## Also

The README now points out something that already worked and nobody knew: mirador
holds the mouse, so selecting text needs the terminal's override modifier —
Shift in most, Option in macOS Terminal and iTerm2. That was the reporter's
actual complaint, and it had an answer buried on line 845.

The comment-count guard caught the shipped config gaining lines and asked for
both quoted numbers to be updated; done, 269 → 281.

All four gates clean, 683 tests.

Not in scope, per the design note: OSC 8 clickable hyperlinks, which fight
ratatui's cell renderer and want a prototype first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)