### PR TITLE
Release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-30
+
 ### Added
 
 - **A story's link can now be copied or opened, not just looked at.** `y` asks
@@ -1251,7 +1253,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.18.2...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/jchultarsky/mirador/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/jchultarsky/mirador/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/jchultarsky/mirador/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/jchultarsky/mirador/compare/v0.17.1...v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.18.2"
+version = "0.19.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
### Added
- A story's link can be copied or opened, not just looked at (#137) — #138

`y` asks the terminal for the clipboard via OSC 52 — no configuration, no
dependency, best-effort. `↵` opens it with `[news].open_command`, empty by
default so mirador launches nothing you did not name.

Minor rather than patch: two new keys and a new config value.

### Before this commit

The built binary was driven in a real terminal:

- the news border reads `o show link · y copy · ↵ open · r refresh`
- under tmux with `set-clipboard on`, `y` **really does set the buffer** —
  seeded a sentinel and watched the URL replace it
- `↵` with nothing configured says `set [news].open_command to open links`
  rather than failing silently
- `q` exits cleanly

`lto = true` intact, `dist plan` announces v0.19.0, all four gates clean on exit
code (683 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)