### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-30
+
+**1.0 is a promise, not a feature.** Nothing is added here that was not in
+0.19.0. What changes is what the version number commits to:
+
+- **Your config keeps working.** No option that has ever shipped has been
+  removed. Re-verified before tagging against all thirty-one release tags —
+  1860 key comparisons, nothing lost. The four keys predating `0.1.0` are still
+  handled by `mirador --migrate-config`.
+- **Your data files keep working.** `todos.toml`, your notes, `watchlist.toml`,
+  `zones.toml` and `state.toml` have not changed shape since `0.1.0`, and all
+  ignore keys they do not recognise — so a file written by a newer mirador still
+  opens in an older one.
+- **No known crashes or hangs.** Every module has been read adversarially, the
+  untrusted-input boundary is bounded on every side, and the dashboard has been
+  soaked across real midnights on macOS, Linux and Windows.
+
+Breaking changes from here get a major version. Options may be added; they will
+not be renamed out from under you.
+
 ## [0.19.0] - 2026-07-30
 
 ### Added
@@ -1253,7 +1273,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/jchultarsky/mirador/compare/v0.19.0...v1.0.0
 [0.19.0]: https://github.com/jchultarsky/mirador/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/jchultarsky/mirador/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/jchultarsky/mirador/compare/v0.18.0...v0.18.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1153,7 +1153,7 @@ real defect, and the useful part is which of the three sub-questions had a
 mechanical answer.
 
 **No option that ever shipped has been removed.** Checked by extracting every
-key from `assets/default_config.toml` at all twenty-two release tags and
+key from `assets/default_config.toml` at all thirty-one release tags and
 diffing: 78 keys, none lost. So `migrate.rs` covering "every rename ever
 shipped" was already true — its four rules are all pre-`0.1.0`, and there has
 been nothing to migrate since.
@@ -1200,7 +1200,17 @@ cannot fail.
 
 ### Phase 5 — cut 1.0.0
 
-When phases 1–4 are done, and not because a date arrived.
+**Done, 2026-07-30.** Phases 1–4 were complete and the owner called it; the
+version number was not waiting on a date.
+
+The compatibility audit was re-run against **all thirty-one release tags** before
+tagging — 1860 key-comparisons, nothing removed — rather than trusting the
+twenty-two-tag figure from the Phase 4 audit. **The first three attempts at that
+re-run all reported a clean pass while comparing nothing**, which is worth more
+than the result: `"$t:assets/…"` in zsh applies the `:a` *absolute path*
+modifier to `$t`, so every `git show` failed and every tag yielded an empty key
+set that trivially contained no losses. Write `"${t}:path"`, and have the check
+count what it actually compared so a vacuous pass cannot look like a real one.
 
 ## Feature freeze — lifted 2026-07-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "0.19.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "0.19.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,7 @@ covers.
 
 **Your config.** No option that has ever shipped in a released version has been
 removed — every key in every `mirador.toml` written since `0.1.0` is still
-accepted, checked against all twenty-two releases. Options are added, never
+accepted, checked against all thirty-one releases. Options are added, never
 renamed out from under you. The four keys that predate `0.1.0` are handled by
 `mirador --migrate-config`, which edits the file in place and tells you what it
 changed.


### PR DESCRIPTION
**1.0 is a promise, not a feature.** Nothing is added that was not in 0.19.0.
What changes is what the version number commits to:

- **Your config keeps working.** No option that has ever shipped has been removed.
- **Your data files keep working.** Written by a newer mirador, still opened by an
  older one.
- **No known crashes or hangs.**

Breaking changes from here get a major version.

## The audit was re-run, not trusted

The Compatibility section claimed "all twenty-two releases". There are now
thirty-one tags, so the claim was re-verified rather than renumbered:
**31 tags, 1860 key comparisons, nothing lost.**

**The first three attempts reported a clean pass while comparing nothing.** In
zsh, `"$t:assets/…"` applies the `:a` *absolute-path* modifier to `$t` — every
`git show` failed against a path like
`/Users/julian/projects/mirador/v0.1.0ssets/default_config.toml`, every tag
yielded an empty key set, and an empty set trivially contains no losses. Written
`"${t}:path"` now, and the check counts what it compared so a vacuous pass cannot
look like a real one. That is recorded in `CLAUDE.md` beside Phase 5.

## Phase 3

Closed on the owner's own machines — a real midnight on 29 July, Windows on
28 July, a 15-hour RSS log ending *lower* than it started — plus a 6h11m soak
here: 371 samples, no alert, flat tail. And the owner has had it running all day
on another computer.

## Before this commit

The 1.0.0 binary was driven in a real terminal: first run, the help overlay
reading `v1.0.0`, the clipboard genuinely receiving a link under tmux, zone
reordering, row moving, `w` and `t`, and a clean quit.

`lto = true` intact, `dist plan` announces v1.0.0, all four gates clean
(683 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)