### PR TITLE
Close the last unverified behaviour: focus on a bare terminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,9 +598,31 @@ line on screen the first left it alone while the second erased it. **Always send
 the second as a control:** if the sequences were being swallowed, neither would
 do anything, and only one of them proves that.
 
-What is left is a terminal question rather than mirador's. Focus events do not
-survive zellij, tmux needs `focus-events on`, and nobody has yet run this on a
-bare terminal with neither. The keypress fallback carries the feature there.
+**Delivery on a bare terminal — verified 2026-07-30, on macOS Terminal.app with
+no multiplexer.** This was the last unverified behaviour in the program, and it
+passes: an entry that arrived while away drew the rule line, and the line
+*survived* coming back, which is #132's fix meeting a real terminal for the first
+time.
+
+The method is the part worth keeping, because inferring delivery from mirador's
+own screen cannot distinguish "the terminal sent nothing" from "mirador mishandled
+it". **Measure the terminal separately.** A dozen lines of Python that put the tty
+in raw mode, write `\033[?1004h`, and log stdin to a file answers it outright —
+Terminal.app produced exactly `1b5b4f` on leaving and `1b5b49` on returning. Do
+that first, then test mirador; two clean signals beat one ambiguous one.
+
+Still untried: iTerm2, and any non-Apple terminal. Focus events do not survive
+zellij and tmux needs `focus-events on`; the keypress fallback carries the feature
+wherever delivery fails.
+
+**One run out of three showed no rule line, and it did not reproduce.** Recorded
+because the temptation was to file it. The failing run differed in that the entry
+arrived only after the window came forward, so that was made the variable and
+tested directly — and the line appeared anyway. The most likely cause is the test
+harness rather than mirador: the screenshot tool hides non-allowlisted
+applications, which can shuffle focus and deliver transitions nobody asked for.
+**An anomaly seen once, in a rig you built that morning, is more likely to be the
+rig.** Reproduce before reporting.
 
 **The log does not persist, on purpose.** A file would come back after a restart
 with a hole in it — the hours mirador was not running and observed nothing —
@@ -1286,11 +1308,12 @@ picker over them, arrange mode with row movement, and in-panel editing for
 everything the UI can change.
 
 That is a fact about the *list*, not a claim the program is finished. The
-nearest thing to an untested condition left is a **bare terminal with no
-multiplexer**: focus events demonstrably do not survive zellij, and tmux needs
-`focus-events on`, so nobody has yet watched the watch log's rule line behave
-where the terminal reports focus directly. mirador's own handling of those
-events is verified — see Phase 3.
+last untested condition — a **bare terminal with no multiplexer** — was closed on
+2026-07-30 against macOS Terminal.app, which reports focus and drew the rule line
+correctly. See the watch log section for the method and for the one anomalous run
+that did not reproduce. What remains is breadth rather than doubt: iTerm2 and the
+non-Apple terminals have not been tried, and focus events still do not survive
+zellij.
 
 One thing is parked on its merits rather than forgotten. **OSC 8 hyperlinks**
 were the third mechanism in the news-link design; `y` and `[news].open_command`


### PR DESCRIPTION
Ran mirador 1.0.0 in **macOS Terminal.app with no multiplexer** — the one condition the road map had never covered. It passes, and the road map's list of unverified behaviour is now genuinely empty.

## What was tested

An entry arrived while the window was unfocused. Coming back showed:

```
23:58 ENTRY TWO AFTER RETURN appeared in your calendar, Sat 01 Aug at 12:00
──────────────────────── since you were here ────────────────────────
23:58 ENTRY ONE appeared in your calendar, Sat 01 Aug at 10:00
watching from 23:57
```

The rule was drawn, and it **survived regaining focus** — which is #132's fix meeting a real terminal for the first time rather than an injected byte sequence.

The rig drives the agenda panel off an `.ics` at `refresh_secs = 5`, so watch-log entries can be generated on demand without touching the keyboard — which matters, because a keypress also marks the log seen and would have destroyed the thing being measured.

## The method is the part worth keeping

Reading mirador's own screen cannot distinguish *"the terminal sent nothing"* from *"mirador mishandled what it sent"*. So the terminal was measured separately — raw mode, `\033[?1004h`, log stdin to a file:

```
1b5b4f 1b5b49     →  ESC[O on leaving, ESC[I on returning
```

Exactly one of each. Two clean signals beat one ambiguous one, and this is cheap.

## An anomaly that did not reproduce, recorded anyway

One run of three showed no rule line, and the instinct was to file it as a bug. Instead the distinguishing variable was made explicit — in the failing run the entry was only detected *after* the window came forward — and tested directly. The line appeared anyway.

The likely cause is the test harness rather than mirador: the screenshot tool hides non-allowlisted applications, which can shuffle focus and deliver transitions nobody asked for. So no issue was filed. **An anomaly seen once, in a rig built that morning, is more likely to be the rig.**

## Scope

Still untried: iTerm2 and any non-Apple terminal. Focus events still do not survive zellij, and tmux still needs `focus-events on`. That is breadth, not doubt — the keypress fallback carries the feature wherever delivery fails.

Docs only, no code touched. 683 tests pass; `fmt` and `clippy` silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)