### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-31
+
+### Fixed
+
+- **The resize keys are advertised where you would look for them.** `Ctrl+arrow`
+  has resized the focused
+  panel since long before 1.0, but it was declared as a secondary binding, so it
+  appeared only in the `?` overlay — someone looking for it on the status bar
+  concluded the feature did not exist. It now sits beside the other primary
+  hints, spelled `Ctrl+arrows resize`, the way arrange mode and `--help` already
+  spelled it. A panel that cannot use the extra space still declines it, so
+  growing a row may move the space to a neighbour rather than to the panel you
+  are pointing at; that is deliberate.
+- **The status bar no longer cuts a hint in half.** It drew every hint and let
+  the terminal clip the last one, which on a narrow window left fragments like
+  `Ctrl+←` — a rendering fault to look at, where a missing hint just reads as a
+  narrow terminal. It now drops whole hints, which is what arrange mode's legend
+  has always done. Reachable before this release for any terminal narrow enough
+  to cut `t theme`.
+
 ## [1.0.0] - 2026-07-30
 
 **1.0 is a promise, not a feature.** Nothing is added here that was not in
@@ -1273,7 +1293,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/jchultarsky/mirador/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/jchultarsky/mirador/compare/v0.19.0...v1.0.0
 [0.19.0]: https://github.com/jchultarsky/mirador/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/jchultarsky/mirador/compare/v0.18.1...v0.18.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
First patch release after 1.0. Two fixes, both about the status bar, both user-visible, neither touching a config key or a data file — so the compatibility promise is untouched and this is a patch rather than a minor.

## What changed

- **The resize keys are advertised where you would look for them.** `Ctrl+arrow` has resized the focused panel since long before 1.0, declared as a secondary binding — so it appeared only in the `?` overlay. The owner went looking for it on the status bar, did not find it, and concluded the feature did not exist. Now spelled `Ctrl+arrows resize` beside the other primary hints, matching arrange mode and `--help` rather than inventing a third wording (#144).
- **The status bar no longer cuts a hint in half.** It drew every hint and let the terminal clip the last one. Promoting an eleven-character key made that visible at 80 columns as `Ctrl+←`, but it was reachable before — any terminal narrow enough to cut `t theme` would do it. It drops whole hints now, as arrange mode's legend always has.

## Driven in a real terminal before tagging

Per the release rule that a release must not be the first time its code meets a terminal:

| width | status bar |
|---|---|
| 150 | full, plus arrange legend with all six hints |
| 120 | full |
| 80 | through `t theme`, resize dropped whole |
| 40 | through `q quit`, nothing clipped |

Also exercised: focus ring, `?` overlay (lists `Ctrl+arrows resize`), `w` picker, `t` theme picker, `m` arrange mode with `Ctrl+arrow` resize inside it, and `q` — clean exit 0, no panic.

All four gates clean: 686 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)