### PR TITLE
Stop the test suite reaching Yahoo Finance

### DIFF
--- a/src/quote.rs
+++ b/src/quote.rs
@@ -26,17 +26,24 @@
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+#[cfg(not(test))]
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 /// How long any single request may take.
+///
+/// `cfg(not(test))` alongside the only function that uses it: under `cfg(test)`
+/// `http_get` refuses before building an agent, so keeping these would be dead
+/// code the lint would rightly complain about.
+#[cfg(not(test))]
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Yahoo rejects requests without a browser user agent with HTTP 429, whatever
 /// the request rate. This is not an attempt to hide what mirador is — the
 /// endpoint simply refuses anything that does not look like a browser.
+#[cfg(not(test))]
 const BROWSER_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
                           AppleWebKit/537.36 (KHTML, like Gecko) \
                           Chrome/126.0.0.0 Safari/537.36";
@@ -235,6 +242,25 @@ impl QuoteSource for YahooChart {
 }
 
 /// A blocking GET with a timeout, presenting a browser user agent.
+///
+/// **Refuses outright under `cfg(test)`, and that is load-bearing (#147).**
+/// This is the only function in the crate that opens a socket, and the stated
+/// rule is that no test does. The rule was believed to hold because
+/// `parse_chart` is tested against captured JSON — but a panel spawns a fetch
+/// thread when it is *constructed*, and `Layout::default()` places the stocks
+/// panel, so building a dashboard in a test was enough. A Windows runner got a
+/// real HTTP 404 back for a made-up symbol and rendered it.
+///
+/// Injecting a `QuoteSource` fixes the tests that build a panel directly, and
+/// is the better design; this covers the ones that reach it through
+/// `widgets::build`, where there is no seam to pass a source through. Nothing
+/// is lost: no test asserts on a live response, because none could.
+#[cfg(test)]
+fn http_get(_url: &str) -> Result<String> {
+    anyhow::bail!("network access is refused in tests")
+}
+
+#[cfg(not(test))]
 fn http_get(url: &str) -> Result<String> {
     let agent = ureq::Agent::config_builder()
         .timeout_global(Some(HTTP_TIMEOUT))
@@ -448,6 +474,24 @@ pub fn sparkline(series: &[f64], width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The rule that no test opens a socket, made checkable (#147).
+    ///
+    /// It used to rest on `parse_chart` being split from the request — true,
+    /// and not enough: constructing a stocks panel spawns a fetch thread, and
+    /// `Layout::default()` places that panel, so building a dashboard in a test
+    /// was sufficient to call Yahoo. `http_get` refuses under `cfg(test)` now.
+    /// Delete that branch and this goes red rather than going quiet.
+    #[test]
+    fn the_network_is_refused_while_testing() {
+        let err = YahooChart
+            .fetch("AAPL")
+            .expect_err("a live fetch must not be possible from a test");
+        assert!(
+            err.to_string().contains("refused in tests"),
+            "the refusal must come from the cfg(test) guard, not from the wire: {err}"
+        );
+    }
 
     /// A trimmed but structurally faithful v8 chart response.
     const SAMPLE: &str = r#"{

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -175,6 +175,28 @@ impl StocksPanel {
                 crate::quote::SOURCE_NAMES.join(", ")
             )
         })?;
+
+        Ok(Self::with_source(config, watchlist, source))
+    }
+
+    /// Build the panel against a source that is already chosen.
+    ///
+    /// This is the seam `QuoteSource` exists for, and it was missing: `new`
+    /// resolved the only real source itself and spawned a thread against it, so
+    /// *constructing a panel made an HTTP request*. Every test that built one
+    /// therefore reached Yahoo Finance — the rule that no test touches the
+    /// network held for `parse_chart` and had quietly stopped holding here.
+    /// It surfaced when a Windows runner got a real 404 back for a made-up
+    /// symbol and rendered it (#147).
+    ///
+    /// The watchlist is loaded by the caller so that a bad file is still
+    /// reported before an unknown source name, which is the order `new`
+    /// always had.
+    fn with_source(
+        config: StocksConfig,
+        watchlist: Watchlist,
+        source: Box<dyn QuoteSource>,
+    ) -> Self {
         let source_name = source.name();
 
         let board: Board = watchlist
@@ -234,7 +256,7 @@ impl StocksPanel {
         panel.reselect();
         // Persist the seed on first run so there is a file to hand-edit.
         panel.watchlist.save_reporting();
-        Ok(panel)
+        panel
     }
 
     fn snapshot(&self) -> Board {
@@ -820,20 +842,64 @@ mod tests {
         }
     }
 
+    /// A source that answers from memory.
+    ///
+    /// Counts its calls so a test can prove the panel used *this* and not the
+    /// network. Always succeeds: an error would be equally deterministic, but
+    /// a filled board is the state most tests want to look at.
+    struct Offline(Arc<std::sync::atomic::AtomicUsize>);
+
+    impl QuoteSource for Offline {
+        fn name(&self) -> &'static str {
+            "offline"
+        }
+
+        fn fetch(&self, symbol: &str) -> anyhow::Result<Quote> {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Ok(Quote {
+                symbol: symbol.to_string(),
+                price: 100.0,
+                previous_close: 99.0,
+                currency: Some("USD".into()),
+                series: vec![99.0, 100.0],
+                delayed: false,
+            })
+        }
+    }
+
     fn panel(name: &str, seed: &[&str]) -> (StocksPanel, TempDir) {
+        let (p, dir, _calls) = panel_counting(name, seed);
+        (p, dir)
+    }
+
+    /// The panel every test builds, wired to `Offline`.
+    ///
+    /// It used to call `StocksPanel::new`, which resolves the real Yahoo
+    /// source and spawns a thread against it — so building a panel issued an
+    /// HTTP request. The `refresh_secs` below was believed to prevent that and
+    /// does not: it governs the gap *between* cycles, and the first poll is
+    /// immediate. See #147.
+    fn panel_counting(
+        name: &str,
+        seed: &[&str],
+    ) -> (StocksPanel, TempDir, Arc<std::sync::atomic::AtomicUsize>) {
         let dir =
             std::env::temp_dir().join(format!("mirador-stocks-{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let config = StocksConfig {
             symbols: seed.iter().map(|s| (*s).to_string()).collect(),
-            // Long enough that the fetch thread never completes a cycle during
-            // a test, so nothing here touches the network.
+            // Still long, so the loop polls once and then sleeps rather than
+            // spinning through the whole watchlist for the length of the test.
             refresh_secs: 86_400,
             ..StocksConfig::default()
         };
-        let p = StocksPanel::new(config, dir.join("watchlist.toml")).unwrap();
-        (p, TempDir(dir))
+        let watchlist =
+            Watchlist::load(dir.join("watchlist.toml"), &config.symbols).expect("watchlist loads");
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let source = Box::new(Offline(Arc::clone(&calls)));
+        let p = StocksPanel::with_source(config, watchlist, source);
+        (p, TempDir(dir), calls)
     }
 
     fn press(p: &mut StocksPanel, code: KeyCode) {
@@ -860,6 +926,41 @@ mod tests {
         for c in text.chars() {
             press(p, KeyCode::Char(c));
         }
+    }
+
+    /// #147: building a panel spawned a thread against the real Yahoo source,
+    /// so every test in this module issued an HTTP request — a Windows runner
+    /// got a genuine 404 back for a made-up symbol and rendered it. The helper
+    /// wires an offline source now, and this is what stops that drifting back.
+    ///
+    /// Two halves, because either alone is weak. The panel a test receives must
+    /// be built against `Offline`, which `source_for` cannot produce — so its
+    /// presence proves the test constructed the source rather than resolving
+    /// one from config. And the module must not reach for the real constructor
+    /// except in the single test that expects it to fail before any thread
+    /// exists.
+    #[test]
+    fn no_test_builds_a_panel_against_the_network() {
+        let (p, _g, _calls) = panel_counting("offline-guard", &["AAPL"]);
+        assert_eq!(
+            p.source_name, "offline",
+            "the test helper must not resolve a real quote source"
+        );
+        assert!(
+            source_for("offline").is_none(),
+            "`offline` has to stay unreachable from config, or the check above proves nothing"
+        );
+
+        // Split so the needle is not itself a match in this file.
+        let needle = concat!("StocksPanel", "::new(");
+        let text = std::fs::read_to_string(file!()).expect("this file is readable");
+        let tests = text.split_once("mod tests").expect("the tests module").1;
+        let direct = tests.matches(needle).count();
+        assert_eq!(
+            direct, 1,
+            "only the unknown-source test may use the real constructor, and it \
+             fails before a thread is spawned; found {direct} uses"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #147.

## The proof, first

Removing the guard added here and running the suite fetches a real quote:

```
a live fetch must not be possible from a test: Quote { symbol: "AAPL",
price: 302.523, previous_close: 333.43, currency: Some("USD"),
series: [302.1099853515625, 301.32000732421875, ...], delayed: false }
```

That is Yahoo Finance, mid-test, from a machine running `cargo test`.

## Why it happened

The rule that no test touches the network rested on `parse_chart` being split from the request. That much is true, and it was not enough: **constructing a stocks panel spawns a fetch thread**, so *building* a panel issued an HTTP request before any assertion ran.

And it was never only the stocks tests. `Layout::default()` places the stocks panel, so any test that builds a default dashboard called Yahoo as well.

The helper's `refresh_secs: 86_400` carried a comment saying it prevented this. It does not — the interval governs the gap *between* cycles, and the first poll is immediate.

## Two changes, because neither covers the other

**`StocksPanel::with_source`** is the seam `QuoteSource` was always for, and it was simply missing — `new` resolved the only real source itself. Tests build panels against an `Offline` source that answers from memory and counts its calls. This is the better design and the one #147 sketched.

**`http_get` refuses under `cfg(test)`.** That covers panels reached through `widgets::build`, where there is no seam to thread a source through. It is the only function in the crate that opens a socket, so the refusal is total and needs no cooperation from callers.

## What the passing suite proves

All **690** tests pass with the network closed off. That is the evidence that nothing was asserting on a live response — had any test depended on real data, closing the socket would have shown it immediately.

## Guards, both verified by breaking them

- `no_test_builds_a_panel_against_the_network` — points the helper back at the real constructor and it fails. It checks two things: the panel's source is `offline`, a name `source_for` cannot produce, so its presence proves the test built it; and the module uses the real constructor exactly once, in the test that expects it to fail before a thread exists.
- `the_network_is_refused_while_testing` — delete the `cfg(test)` branch and it fails, with the live quote above as the message.

## The release binary is untouched

Checked in a real terminal rather than assumed:

```
  SYMBOL         LAST       CHG        % TODAY
▸ ^GSPC       7445.30     +7.67   +0.10% ▇▅▄▂▂▃▄▄▄▄▃▄
  AAPL         302.62    -30.81   -9.24% ▂█▆▃▄▃▃▄▄▅▃▃
```

`HTTP_TIMEOUT` and `BROWSER_UA` are now `cfg(not(test))` alongside their only consumer, so the lint stays quiet without an `allow`.

All four gates clean: 690 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)