### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-07-31
+
+Housekeeping. Nothing you can see changes; both entries are things that were
+wrong underneath.
+
+### Fixed
+
+- **A very long watchlist collapsed the stocks panel instead of filling it.**
+  The panel reports the height it can use, and that sum was not saturating while
+  already reaching for `u16::MAX` — so a watchlist of around 65,000 symbols
+  wrapped it to three rows. Absurd in practice; the watchlist is a file you
+  edit, so nothing bounded it. The cap itself was checked at the same time and
+  is exactly right: the panel is complete at header, every symbol and the status
+  line, and any extra height would be a blank gap, so the space goes to a
+  neighbouring row instead.
+
+### Changed
+
+- **The test suite no longer reaches the network.** It was documented as never
+  doing so, and that had quietly stopped being true: constructing the stocks
+  panel spawns a fetch thread, so *building* one called Yahoo Finance — and
+  since the default layout places that panel, any test building a dashboard did
+  too. Quote sources are injectable now, and the one function that opens a
+  socket refuses outright under `cfg(test)`. No effect on the shipped binary,
+  which fetches exactly as before.
+
 ## [1.0.1] - 2026-07-31
 
 ### Fixed
@@ -1293,7 +1319,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/jchultarsky/mirador/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/jchultarsky/mirador/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/jchultarsky/mirador/compare/v0.19.0...v1.0.0
 [0.19.0]: https://github.com/jchultarsky/mirador/compare/v0.18.2...v0.19.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Housekeeping release. **Nothing user-visible changes** — both entries are things that were wrong underneath, and neither touches a config key or a data file, so the 1.0 compatibility promise is untouched.

## What is in it

- **A very long watchlist collapsed the stocks panel** instead of filling it (#146). The height it reports was not a saturating sum while already reaching for `u16::MAX`, so ~65,000 symbols wrapped it to three rows. The cap itself was measured at the same time and is exact — the panel is complete at header + every symbol + status line, and extra height would be a blank gap, so it goes to a neighbouring row.
- **The test suite no longer reaches the network** (#147, #148). It was documented as never doing so and had quietly stopped being true: constructing the stocks panel spawns a fetch thread, so *building* one called Yahoo Finance — and the default layout places that panel, so any test building a dashboard did too. Quote sources are injectable now, and `http_get` refuses under `cfg(test)`. Proven by breaking the guard, which fetched a live AAPL quote mid-test.

## Driven in a real terminal before tagging

Per the rule that a release must not be the first time its code meets a terminal — and this release changes how the stocks panel is constructed, so that is what got the attention:

```
╭┤Markets├────────────────────────────┤7├╮
│   SYMBOL         LAST       CHG        │
│   ^GSPC       7484.83    +47.20   +0.6 │
│   ^DJI       52525.09   +317.03   +0.6 │
│ via yahoo                              │
```

Live quotes through the refactored constructor; panels rebuilt via the `w` picker with prices carried across; `t` preview and `Esc`; status bar correct at 150 columns; `q` exits 0 with no panic.

All four gates clean: 690 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)