### PR TITLE
Spell the resize key the way the screen spells it

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Some settings you change with a keystroke are remembered across restarts:
 | Agenda file | `f` | Agenda |
 | Which panels are shown | `w` | — |
 | Where the panels are | `m` | — |
-| Panel sizes | `Ctrl+arrow` | — |
+| Panel sizes | `Ctrl+arrows` | — |
 
 They go to two different places, and the split is deliberate.
 
@@ -290,8 +290,8 @@ widget mirador has and which of them your layout places:
 disappears the moment you toggle it, and the change is written to your config
 when you close the dialog — as a one-line edit, with your comments untouched.
 A new panel joins the row carrying the fewest panels; `m` moves it wherever you
-want it afterwards, and `Ctrl+arrow` moves the
-space around afterwards, and that is written too.
+want it afterwards, and `Ctrl+arrows` move the
+space around, and that is written too.
 
 The last panel cannot be switched off, because a layout with nothing in it is
 rejected at startup and would leave you with a config that will not open.
@@ -681,7 +681,7 @@ rather than a cap on what a wider panel can draw.
 | `w` | Choose which panels are shown |
 | `m` | Rearrange the panels — see below |
 | `t` | Choose a theme, previewing as you move — see below |
-| `Ctrl+arrow` | Resize the focused panel against its neighbour |
+| `Ctrl+arrows` | Resize the focused panel against its neighbour |
 | `q` / `Ctrl+C` | Quit |
 
 ### Rearranging the dashboard
@@ -705,8 +705,8 @@ at the edge stops rather than spawning a row per keypress.
 
 The panels themselves move as you press, so what you see is what you will get.
 `Enter` keeps the arrangement and `Esc` puts everything back exactly as it was.
-`Tab` picks a different panel to move without leaving the mode, and `Ctrl+arrow`
-still resizes while you are in there.
+`Tab` picks a different panel to move without leaving the mode, and `Ctrl+arrows`
+still resize while you are in there.
 
 A panel keeps the width you gave it when it moves, and the row weights always
 add up to what they added up to before — so rearranging one corner of the

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -4,7 +4,7 @@
 # default, so you can delete anything you do not want to override.
 #
 # mirador edits this file surgically and never reserialises it: switching a
-# panel on with `w`, or resizing one with Ctrl+arrow, rewrites the one line it
+# panel on with `w`, or resizing one with Ctrl+arrows, rewrites the one line it
 # has to and leaves your comments, spacing and ordering exactly as they were.
 # So it stays safe to hand-edit and to keep in version control.
 #


### PR DESCRIPTION
The status bar, the arrange legend and `--help` all say **`Ctrl+arrows`**. The README said `Ctrl+arrow` in four places — including both key-reference tables, so someone reading the table and then glancing at the status bar saw two different strings for one key.

## Changed

| where | was | now |
|---|---|---|
| [README.md:236](README.md#L236) — "what is stored where" table | `Ctrl+arrow` | `Ctrl+arrows` |
| [README.md:684](README.md#L684) — key bindings table | `Ctrl+arrow` | `Ctrl+arrows` |
| [README.md:293](README.md#L293) — prose | "`Ctrl+arrow` moves the space" | "`Ctrl+arrows` move the space" |
| [README.md:708](README.md#L708) — prose | "`Ctrl+arrow` still resizes" | "`Ctrl+arrows` still resize" |
| `assets/default_config.toml:7` | `Ctrl+arrow` | `Ctrl+arrows` |

The two prose uses needed verb agreement to go plural. One of them also said "afterwards" twice in a single sentence; fixed in passing, since it is the sentence being edited either way.

The shipped config is `include_str!`-baked, so the change does nothing until a rebuild — verified through `--print-config` rather than assumed, because that trap has bitten this repo twice.

## Deliberately not changed

The singular survives in source comments and `CLAUDE.md`, where it means **one keypress**:

> every `Ctrl+arrow` repeat … a plain `Ctrl+arrow` resize rewrites digits on the lines they are already on

That is grammar, not drift. The plural names the binding — the set of four arrows you can press. The singular counts presses. Flattening both to one spelling would make those sentences read worse, so the rule is: plural when naming the key, singular when counting.

Docs only, no code. All four gates clean: 690 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)