### PR TITLE
Record that iTerm2 reports focus too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,9 +611,16 @@ in raw mode, write `\033[?1004h`, and log stdin to a file answers it outright �
 Terminal.app produced exactly `1b5b4f` on leaving and `1b5b49` on returning. Do
 that first, then test mirador; two clean signals beat one ambiguous one.
 
-Still untried: iTerm2, and any non-Apple terminal. Focus events do not survive
-zellij and tmux needs `focus-events on`; the keypress fallback carries the feature
-wherever delivery fails.
+**iTerm2 was checked the same way on 2026-07-31 and behaves identically** — the
+same six bytes, the rule line drawn while away and still there on return. Two
+independent terminals agreeing is what turns this from an observation into a
+reasonable expectation of the next one. Note that iTerm2 asks for confirmation
+before running a script handed to it by `open`, which is a dialog to click, not
+a failure.
+
+Still untried: any non-Apple terminal. Focus events do not survive zellij and
+tmux needs `focus-events on`; the keypress fallback carries the feature wherever
+delivery fails.
 
 **One run out of three showed no rule line, and it did not reproduce.** Recorded
 because the temptation was to file it. The failing run differed in that the entry
@@ -1311,9 +1318,9 @@ That is a fact about the *list*, not a claim the program is finished. The
 last untested condition — a **bare terminal with no multiplexer** — was closed on
 2026-07-30 against macOS Terminal.app, which reports focus and drew the rule line
 correctly. See the watch log section for the method and for the one anomalous run
-that did not reproduce. What remains is breadth rather than doubt: iTerm2 and the
-non-Apple terminals have not been tried, and focus events still do not survive
-zellij.
+that did not reproduce. iTerm2 was checked on 2026-07-31 and matches. What
+remains is breadth rather than doubt: no non-Apple terminal has been tried, and
+focus events still do not survive zellij.
 
 One thing is parked on its merits rather than forgotten. **OSC 8 hyperlinks**
 were the third mechanism in the news-link design; `y` and `[news].open_command`


### PR DESCRIPTION
Closes the remaining breadth item on focus reporting. Docs only.

## Result

iTerm2 behaves identically to Terminal.app. Same method as before — probe the terminal separately for the raw bytes, *then* test mirador, because reading mirador's screen alone cannot tell "the terminal sent nothing" from "mirador mishandled it".

**The probe:**

```
1b5b4f 1b5b49     →  ESC[O on leaving, ESC[I on returning
```

Exactly one of each, same as Terminal.app.

**mirador:**

```
15:10 ENTRY TWO WHILE AWAY appeared in your calendar, Sun 02 Aug at 12:00
──────────────────────── since you were here ────────────────────────
15:09 ENTRY ONE appeared in your calendar, Sun 02 Aug at 10:00
watching from 15:09
```

Drawn while unfocused, and still there after regaining focus — #132's fix holding on a second real terminal.

## Why this was worth doing

One terminal reporting focus is an observation. **Two independent ones agreeing is what makes it a reasonable expectation of the third**, which matters because the fallback (mark on keypress) is strictly worse — it cannot see the glances that touch nothing, and those are the ones the feature exists for.

## Small practical note, now recorded

iTerm2 asks for confirmation before running a script handed to it by `open`. That is a dialog to click, not a failure — worth knowing before someone repeats this and reads the silence as a broken probe.

## Still untried

Any non-Apple terminal. Focus events still do not survive zellij, and tmux still needs `focus-events on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)