### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-07-31
+
+Documentation only. No behaviour changes at all; this exists so the corrected
+text reaches the README on crates.io and the config mirador prints.
+
+### Changed
+
+- **The resize key is spelled the same everywhere.** The status bar, arrange
+  mode and `--help` all say `Ctrl+arrows`; the README said `Ctrl+arrow` in four
+  places, including both key tables, so the page you read and the bar you look
+  at disagreed about one key. The comment at the head of the shipped config said
+  it too, and that text is compiled into the binary, so `mirador --print-config`
+  carried it. The singular survives where it means one keypress — that is
+  grammar, not inconsistency.
+
 ## [1.0.2] - 2026-07-31
 
 Housekeeping. Nothing you can see changes; both entries are things that were
@@ -1319,7 +1334,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/jchultarsky/mirador/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/jchultarsky/mirador/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/jchultarsky/mirador/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/jchultarsky/mirador/compare/v0.19.0...v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
**Documentation only. No behaviour changes at all.**

It exists because two of the corrected files only reach users through a release: `README.md` is what crates.io renders, and `assets/default_config.toml` is `include_str!`-baked, so `mirador --print-config` carries whatever the last published build compiled.

## What is in it

- **The resize key is spelled the same everywhere** (#150). The status bar, arrange mode and `--help` all say `Ctrl+arrows`; the README said `Ctrl+arrow` in four places, including both key tables — so the page you read and the bar you look at disagreed about one key. The singular survives where it means one keypress, which is grammar rather than inconsistency.

`CLAUDE.md` also gained the iTerm2 focus-reporting result (#151), which is working notes rather than user documentation.

## Checked, proportionately

A docs release does not earn the full key sweep, so this got a smoke test and I would rather say so than imply otherwise:

```
$ mirador --print-config | sed -n 7p
# panel on with `w`, or resizing one with Ctrl+arrows, rewrites the one line it
```

Plus: the dashboard runs at 130x36, the status bar reads `Ctrl+arrows resize`, `?` lists the binding, and `q` exits 0 with no panic.

All four gates clean: 690 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)