### PR TITLE
--reset-config now resets what you can see

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -451,7 +451,7 @@ impl Config {
 /// Racy in principle — the name is checked and then written — but the loser of
 /// that race is a person running two resets at the same instant, and the bound
 /// stops a directory of stale backups from making this loop for ever.
-fn free_backup_path(path: &Path) -> PathBuf {
+pub(crate) fn free_backup_path(path: &Path) -> PathBuf {
     let first = path.with_extension("toml.bak");
     if !first.exists() {
         return first;

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,11 @@ fn reset_config(path: &Path, assume_yes: bool) -> Result<()> {
             println!("There is no config at {}.", path.display());
             println!("This writes the defaults there.");
         }
+        // Say the second half out loud. Resetting the config without this
+        // leaves the dashboard looking untouched (#153), so a reader who is
+        // told only about the config is being told half of what will happen.
+        println!("Preferences you changed from the keyboard are put aside too.");
+        println!("Your tasks, notes and watchlist are left alone.");
         print!("Go ahead? [y/N] ");
         std::io::stdout().flush().context("writing the prompt")?;
 
@@ -189,6 +194,25 @@ fn reset_config(path: &Path, assume_yes: bool) -> Result<()> {
     if let Some(backup) = backup {
         println!("Your previous config is at {}.", backup.display());
     }
+
+    // The config is only half of what decides the dashboard. `state.toml`
+    // records what was changed from the keyboard and *outranks* the config, so
+    // leaving it would apply the old preferences straight back over the file
+    // just restored — the reason #153 looked like the command doing nothing.
+    match Config::state_path() {
+        Ok(state) => match state::clear(&state)? {
+            Some(moved) => println!(
+                "Put your remembered preferences aside; they are at {}.",
+                moved.display()
+            ),
+            None => println!("There were no remembered preferences to clear."),
+        },
+        // Worth a word rather than a silent skip: the config really was reset,
+        // and the reader should know which half did not happen.
+        Err(e) => println!("Could not find the preferences file to clear it: {e}"),
+    }
+
+    println!("Left your tasks, notes and watchlist alone.");
     Ok(())
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -213,9 +213,129 @@ pub fn default_path(data_dir: &Path) -> PathBuf {
     data_dir.join("state.toml")
 }
 
+/// Put the remembered preferences aside, so the config gets its say back.
+///
+/// Returns where the old file went, or `None` if there was nothing to move.
+///
+/// This exists because resetting the config alone does not reset the
+/// dashboard (#153). Remembered preferences are *deltas against the config*
+/// and they outrank it, so restoring the file and leaving them in place means
+/// the deltas are still measured against a config that is no longer there —
+/// the baseline moves and the overrides do not. Someone who had only ever
+/// changed their theme reset their config and saw an identical dashboard,
+/// which reads as the command having done nothing.
+///
+/// Moved rather than deleted, even though this file's own header says it is
+/// safe to delete. That is advice to a person who knows what they are doing,
+/// not a licence for the program to throw away a setting somebody spent time
+/// choosing.
+pub fn clear(path: &Path) -> Result<Option<PathBuf>> {
+    match path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return Ok(None),
+        Err(e) => anyhow::bail!("could not check whether {} exists: {e}", path.display()),
+    }
+
+    let to = crate::config::free_backup_path(path);
+    std::fs::rename(path, &to)
+        .with_context(|| format!("moving {} to {}", path.display(), to.display()))?;
+    Ok(Some(to))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #153: resetting the config alone left this file in place, and it
+    /// outranks the config — so the preferences were applied straight back
+    /// over the freshly restored file and the dashboard looked untouched.
+    #[test]
+    fn clearing_moves_the_file_aside_rather_than_destroying_it() {
+        let dir = std::env::temp_dir().join(format!("mirador-clear-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let _guard = TempDir(dir.clone());
+
+        let path = default_path(&dir);
+        let state = UiState {
+            theme: Some("nord".into()),
+            ..UiState::default()
+        };
+        state.save(&path).expect("saves");
+
+        let moved = clear(&path).expect("clears").expect("there was a file");
+        assert!(!path.exists(), "the state file must be gone after a clear");
+        assert!(
+            moved.exists(),
+            "and its contents kept at {}",
+            moved.display()
+        );
+        assert!(
+            std::fs::read_to_string(&moved)
+                .expect("readable")
+                .contains("nord"),
+            "the preference itself has to survive in the copy"
+        );
+
+        // And what mirador would load next time is the config's say, nothing
+        // else — which is the whole point of the reset.
+        assert_eq!(
+            UiState::load(&path),
+            UiState::default(),
+            "a cleared state must express no opinion at all"
+        );
+    }
+
+    /// Clearing when there is nothing to clear is a normal outcome, not an
+    /// error: plenty of people reset a config having never pressed a key that
+    /// records anything.
+    #[test]
+    fn clearing_nothing_is_not_a_failure() {
+        let dir = std::env::temp_dir().join(format!("mirador-clear-none-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let _guard = TempDir(dir.clone());
+
+        assert!(
+            clear(&default_path(&dir)).expect("no error").is_none(),
+            "an absent state file reports nothing moved"
+        );
+    }
+
+    /// Two resets must not lose the first set of preferences, the same way two
+    /// config resets do not clobber the first backup.
+    #[test]
+    fn a_second_clear_does_not_overwrite_the_first_copy() {
+        let dir = std::env::temp_dir().join(format!("mirador-clear-two-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let _guard = TempDir(dir.clone());
+
+        let path = default_path(&dir);
+        UiState {
+            theme: Some("nord".into()),
+            ..UiState::default()
+        }
+        .save(&path)
+        .expect("saves");
+        let first = clear(&path).expect("clears").expect("a file");
+
+        UiState {
+            theme: Some("dracula".into()),
+            ..UiState::default()
+        }
+        .save(&path)
+        .expect("saves again");
+        let second = clear(&path).expect("clears").expect("a file");
+
+        assert_ne!(first, second, "the second copy needs its own name");
+        assert!(
+            std::fs::read_to_string(&first)
+                .expect("readable")
+                .contains("nord"),
+            "the first copy must still hold the first preferences"
+        );
+    }
 
     struct TempDir(PathBuf);
 


### PR DESCRIPTION
Closes #153.

## What was wrong

The config half always worked — reset restored all twelve widgets correctly. **`state.toml` was the problem.** It records preferences changed from the keyboard and *outranks* the config, so resetting the config and leaving it in place meant the deltas were still measured against a config that no longer existed. The baseline moved; the overrides did not.

Reported as *"it displayed my previous screen"*, which is precisely what it did. Someone who had only ever changed their theme would reset and see nothing happen at all.

## Proven with the same measurement that showed the bug

Rendered colours on the clock row, same build:

| | before this PR | after |
|---|---|---|
| after `--reset-config` | `#88C0D0` `#434C5E` — Nord | `#d7af87` `#3a3a3a` |
| genuinely fresh install | `#d7af87` `#3a3a3a` | `#d7af87` `#3a3a3a` |

Identical to a fresh install now, byte for byte in the escape sequences.

## Moved, not deleted

`state::clear` renames the file aside. Its own header says *"Safe to delete: everything falls back to your config"* — but that is advice to a person who knows what they are doing, not a licence for the program to throw away a theme somebody spent time choosing. It reuses the config's `free_backup_path`, so a second reset does not clobber the first copy.

## Data files stay

Tasks, notes and the watchlist are **user content, not configuration**, and a flag called `--reset-config` has no business deleting them. What changed is that the boundary is now stated instead of implied — it was invisible from the name:

```
This replaces …/config.toml with the defaults.
Your current config will be copied alongside it first.
Preferences you changed from the keyboard are put aside too.
Your tasks, notes and watchlist are left alone.
Go ahead? [y/N]
```

and afterwards:

```
Wrote the default config to …/config.toml.
Your previous config is at …/config.toml.bak.
Put your remembered preferences aside; they are at …/state.toml.bak.
Left your tasks, notes and watchlist alone.
```

This does **not** restore the default stock tickers, which was the other half of the report. `[stocks].symbols` seeds `watchlist.toml` only when that file is absent — deliberate, and the only reason the panel can edit the watchlist at all. Whether a true factory reset is wanted is a separate decision and deserves its own flag and confirmation, since it deletes user data.

## Tests

Three, each verified by breaking the code:

- `clearing_moves_the_file_aside_rather_than_destroying_it` — fails if `clear` deletes instead of moving, **and** fails if it leaves the file in place, which is the original defect.
- `clearing_nothing_is_not_a_failure` — resetting having never pressed a recorded key is a normal outcome.
- `a_second_clear_does_not_overwrite_the_first_copy`

All four gates clean: 693 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)