### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-07-31
+
+### Fixed
+
+- **`--reset-config` now resets what you can see.** It restored the config
+  correctly all along, but left `state.toml` — the preferences you change from
+  the keyboard — in place. Those *outrank* the config, so they were applied
+  straight back over the file just restored, and the dashboard came back looking
+  exactly as before. Anyone who had only ever changed their theme saw the
+  command appear to do nothing. The remembered preferences are now put aside
+  too, into `state.toml.bak`, and a second reset does not overwrite the first
+  copy.
+
+  Both the prompt and the result say what is kept, because the boundary was
+  invisible from the flag's name: **your tasks, notes and watchlist are left
+  alone.** They are your content rather than configuration, so a command called
+  `--reset-config` does not delete them — which also means the default stock
+  tickers are not restored. `[stocks].symbols` seeds `watchlist.toml` only when
+  that file is absent, and that is what lets the panel edit the list at all.
+
 ## [1.0.3] - 2026-07-31
 
 Documentation only. No behaviour changes at all; this exists so the corrected
@@ -1334,7 +1354,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/jchultarsky/mirador/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/jchultarsky/mirador/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/jchultarsky/mirador/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/jchultarsky/mirador/compare/v1.0.0...v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
One user-facing bug fix, reported from real use.

## What is in it

**`--reset-config` now resets what you can see** (#153, #154). It restored the config correctly all along, but left `state.toml` — the preferences changed from the keyboard — in place. Those *outrank* the config, so they were applied straight back over the file just restored and the dashboard came back looking identical. Anyone who had only ever changed their theme saw the command appear to do nothing at all.

Remembered preferences are now put aside into `state.toml.bak`, and a second reset does not overwrite the first copy.

Both the prompt and the result now state what is kept, because the boundary was invisible from the flag's name: **tasks, notes and the watchlist are left alone.** They are user content rather than configuration. That also means the default stock tickers are *not* restored — `[stocks].symbols` seeds `watchlist.toml` only when that file is absent, which is what lets the panel edit the list at all.

## Driven in a real terminal before tagging

Rendered colours on the clock row, same build, one home:

```
with nord remembered   38;2;136;192;208     ← #88C0D0
after --reset-config   38;2;215;175;135     ← #d7af87, matching a fresh install
```

Both message branches exercised — "there were no remembered preferences to clear" and "put your remembered preferences aside" — and backups accumulated as `config.toml.bak`, `config.toml.bak.2`, `state.toml.bak` rather than clobbering.

All four gates clean: 693 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)