### PR TITLE
Add --factory-reset: start over, without destroying anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,23 @@ moves the panel itself, merging it into the neighbouring row.
 and leaves a backup beside the original.
 
 If a config has gone past fixing, `mirador --reset-config` writes the shipped
-defaults over it and copies the old one to `config.toml.bak` first. It says what
-it is about to do and waits for a `y`, and it will not run at all without a
-terminal to ask on unless you add `--yes`. An existing backup is never
-overwritten, so resetting twice still leaves your original recoverable.
+defaults over it and copies the old one to `config.toml.bak` first. It also puts
+aside the preferences you changed from the keyboard, because those outrank the
+config — leaving them would apply your old choices straight back over the file
+just restored, and the dashboard would come back looking untouched. Your tasks,
+notes and watchlist are left alone, and it says so.
+
+If you want the whole thing back to how it arrived, `mirador --factory-reset`
+sets aside everything mirador has written — config, preferences, tasks, notes,
+watchlist and world clocks — and the next launch seeds them all again. **Nothing
+is deleted.** Every file is renamed to a `.bak` beside itself, so a factory
+reset is something you can walk back from with `mv`. Your calendar is not
+touched: mirador only ever reads an `.ics`, so that file is yours even when it
+sits in mirador's own directory.
+
+Both say what they are about to do and wait for a `y`, and neither runs without
+a terminal to ask on unless you add `--yes`. An existing backup is never
+overwritten, so resetting twice still leaves the first one recoverable.
 
 ## The panels
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -192,7 +192,7 @@ impl Config {
     pub fn reset(path: &Path) -> Result<Option<PathBuf>> {
         let backup = match path.try_exists() {
             Ok(true) => {
-                let to = free_backup_path(path);
+                let to = crate::store::free_backup_path(path);
                 std::fs::copy(path, &to).with_context(|| {
                     format!("backing up {} to {}", path.display(), to.display())
                 })?;
@@ -354,6 +354,31 @@ impl Config {
         Ok(crate::update::default_path(&Self::default_data_dir()?))
     }
 
+    /// Every file mirador writes into its own data directory.
+    ///
+    /// The list a factory reset works from, and deliberately not the same as
+    /// "every file a panel reads". `calendar.ics` is absent because mirador
+    /// only ever *reads* a calendar — it is the reader's file, sitting in
+    /// mirador's directory by default, and a reset has no business moving it.
+    /// The rule is ownership by authorship: if mirador wrote it, mirador may
+    /// set it aside.
+    ///
+    /// Default locations only. A `[todo].file` pointing somewhere else is a
+    /// path the reader chose, and resetting the config already stops mirador
+    /// looking there — moving a file out of a directory the reader picked
+    /// would be a surprise a reset cannot justify.
+    pub fn owned_data_files() -> Result<Vec<PathBuf>> {
+        let dir = Self::default_data_dir()?;
+        Ok(vec![
+            crate::state::default_path(&dir),
+            dir.join("todos.toml"),
+            dir.join("notes.toml"),
+            dir.join("watchlist.toml"),
+            dir.join("zones.toml"),
+            crate::update::default_path(&dir),
+        ])
+    }
+
     pub fn state_path() -> Result<PathBuf> {
         Ok(crate::state::default_path(&Self::default_data_dir()?))
     }
@@ -440,31 +465,6 @@ impl Config {
         }
     }
 }
-
-/// A backup path beside `path` that nothing is using yet.
-///
-/// `config.toml.bak` first, matching `migrate`, then `.bak.2`, `.bak.3` and so
-/// on. The counter is not tidiness: without it a second reset would overwrite
-/// the first backup with the defaults the first reset had just written, and the
-/// user's real config would be gone with no way back.
-///
-/// Racy in principle — the name is checked and then written — but the loser of
-/// that race is a person running two resets at the same instant, and the bound
-/// stops a directory of stale backups from making this loop for ever.
-pub(crate) fn free_backup_path(path: &Path) -> PathBuf {
-    let first = path.with_extension("toml.bak");
-    if !first.exists() {
-        return first;
-    }
-    for n in 2..1000 {
-        let candidate = path.with_extension(format!("toml.bak.{n}"));
-        if !candidate.exists() {
-            return candidate;
-        }
-    }
-    first
-}
-
 /// Turn a parse failure into an error that says how to fix it.
 ///
 /// The common case by far is a config written by an older version: mirador
@@ -514,6 +514,43 @@ fn expand_tilde(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The list a factory reset works from. What is *absent* is the load-bearing
+    /// part: mirador reads a calendar and never writes one, so `calendar.ics`
+    /// belongs to the reader even when it sits in mirador's own directory.
+    /// Setting it aside would be destroying data mirador did not create.
+    #[test]
+    fn the_owned_files_are_the_ones_mirador_writes() {
+        let Ok(files) = Config::owned_data_files() else {
+            // No data directory on this platform; nothing to assert about.
+            return;
+        };
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap_or_default().to_string_lossy().into())
+            .collect();
+
+        for wanted in [
+            "state.toml",
+            "todos.toml",
+            "notes.toml",
+            "watchlist.toml",
+            "zones.toml",
+            "update-check.toml",
+        ] {
+            assert!(names.iter().any(|n| n == wanted), "{wanted} must be reset");
+        }
+        assert!(
+            !names.iter().any(|n| n == "calendar.ics"),
+            "a factory reset must not touch a calendar mirador only ever reads: {names:?}"
+        );
+        // All in one directory, so nothing here can reach outside it.
+        let dir = files[0].parent().expect("a parent");
+        assert!(
+            files.iter().all(|p| p.parent() == Some(dir)),
+            "every owned file must live in mirador's own data directory: {files:?}"
+        );
+    }
 
     /// A scratch directory named for the calling test, so the reset tests do
     /// not share files with each other or with a parallel run.

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ OPTIONS:
         --config-path      Print the resolved config path and exit
         --migrate-config   Update a config written by an older version
         --reset-config     Replace the config with the defaults, keeping a copy
+        --factory-reset    Start over: config, preferences, tasks, notes and
+                           watchlist all set aside, nothing deleted
     -y, --yes              Do not ask for confirmation
     -h, --help             Print this help and exit
     -V, --version          Print the version and exit
@@ -93,6 +95,7 @@ struct Args {
     show_config_path: bool,
     migrate_config: bool,
     reset_config: bool,
+    factory_reset: bool,
     /// Skip the confirmation `--reset-config` would otherwise ask for.
     assume_yes: bool,
     help: bool,
@@ -112,6 +115,7 @@ fn parse_args(raw: impl Iterator<Item = String>) -> Result<Args> {
             "--config-path" => args.show_config_path = true,
             "--migrate-config" => args.migrate_config = true,
             "--reset-config" => args.reset_config = true,
+            "--factory-reset" => args.factory_reset = true,
             "-y" | "--yes" => args.assume_yes = true,
             "-c" | "--config" => {
                 let value = iter.next().ok_or_else(|| {
@@ -216,6 +220,87 @@ fn reset_config(path: &Path, assume_yes: bool) -> Result<()> {
     Ok(())
 }
 
+/// Put mirador back where a fresh install would leave it.
+///
+/// The reset `--reset-config` deliberately is not. That one is about
+/// configuration; this one is about everything mirador has written, because
+/// the owner's expectation of a reset was "as if I just installed the app" and
+/// `--reset-config` cannot honestly promise that — the watchlist, tasks and
+/// notes all outlive it (#153).
+///
+/// **Nothing is deleted.** Every file is renamed to a numbered `.bak` beside
+/// itself, so the dashboard starts over and the reader can still get their task
+/// list back. That is what makes a single `y` an acceptable confirmation for a
+/// command with this name: the prompt names every file, and the worst outcome
+/// is an afternoon of renaming rather than lost work.
+fn factory_reset(config_path: &Path, assume_yes: bool) -> Result<()> {
+    let data_files = Config::owned_data_files().unwrap_or_default();
+    let present: Vec<&PathBuf> = data_files
+        .iter()
+        .filter(|p| p.try_exists().unwrap_or(false))
+        .collect();
+    let config_exists = config_path.try_exists().unwrap_or(false);
+
+    if !assume_yes {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!(
+                "refusing to reset everything without a confirmation.\n\nThere is \
+                 no terminal to ask on, so re-run with `--yes` if you mean it."
+            );
+        }
+        println!("This starts mirador over from scratch.");
+        println!();
+        if config_exists {
+            println!("  Replaced with the defaults:");
+            println!("    {}", config_path.display());
+            println!();
+        }
+        if present.is_empty() {
+            println!("  There is nothing else to set aside.");
+        } else {
+            println!("  Set aside, each kept as a `.bak` beside itself:");
+            for path in &present {
+                println!("    {}", path.display());
+            }
+        }
+        println!();
+        println!("Nothing is deleted. Your tasks and notes stay on disk under their");
+        println!("backup names, and mirador starts again with fresh ones.");
+        print!("Go ahead? [y/N] ");
+        std::io::stdout().flush().context("writing the prompt")?;
+
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("reading your answer")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("Left everything alone.");
+            return Ok(());
+        }
+    }
+
+    let backup = Config::reset(config_path)?;
+    println!("Wrote the default config to {}.", config_path.display());
+    if let Some(backup) = backup {
+        println!("Your previous config is at {}.", backup.display());
+    }
+
+    let mut moved = 0usize;
+    for path in data_files {
+        if let Some(to) = store::move_aside(&path)? {
+            println!("Set aside {} -> {}", path.display(), to.display());
+            moved += 1;
+        }
+    }
+    if moved == 0 {
+        println!("There was nothing else to set aside.");
+    }
+
+    println!("Next launch starts fresh: example tasks and notes, and the");
+    println!("watchlist seeded from `[stocks].symbols` in the new config.");
+    Ok(())
+}
+
 fn run() -> Result<()> {
     let args = parse_args(std::env::args().skip(1))?;
 
@@ -246,6 +331,14 @@ fn run() -> Result<()> {
             None => Config::default_path()?,
         };
         return reset_config(&path, args.assume_yes);
+    }
+
+    if args.factory_reset {
+        let path = match args.config.clone() {
+            Some(p) => p,
+            None => Config::default_path()?,
+        };
+        return factory_reset(&path, args.assume_yes);
     }
 
     if args.migrate_config {
@@ -370,6 +463,11 @@ mod tests {
         assert!(parse(&["--config-path"]).unwrap().show_config_path);
         assert!(parse(&["--migrate-config"]).unwrap().migrate_config);
         assert!(parse(&["--reset-config"]).unwrap().reset_config);
+        assert!(parse(&["--factory-reset"]).unwrap().factory_reset);
+        // The two are separate commands, not degrees of one: a config reset
+        // must never quietly take the tasks with it.
+        assert!(!parse(&["--reset-config"]).unwrap().factory_reset);
+        assert!(!parse(&["--factory-reset"]).unwrap().reset_config);
         assert!(parse(&["-y"]).unwrap().assume_yes);
         assert!(parse(&["--yes"]).unwrap().assume_yes);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -230,16 +230,7 @@ pub fn default_path(data_dir: &Path) -> PathBuf {
 /// not a licence for the program to throw away a setting somebody spent time
 /// choosing.
 pub fn clear(path: &Path) -> Result<Option<PathBuf>> {
-    match path.try_exists() {
-        Ok(true) => {}
-        Ok(false) => return Ok(None),
-        Err(e) => anyhow::bail!("could not check whether {} exists: {e}", path.display()),
-    }
-
-    let to = crate::config::free_backup_path(path);
-    std::fs::rename(path, &to)
-        .with_context(|| format!("moving {} to {}", path.display(), to.display()))?;
-    Ok(Some(to))
+    crate::store::move_aside(path)
 }
 
 #[cfg(test)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -122,6 +122,48 @@ fn temp_path(path: &Path) -> std::path::PathBuf {
 /// panel can render it. Swallowing the error is deliberate — a read-only disk
 /// must not take the dashboard down — but swallowing it *silently* is not: an
 /// edit that never reached the disk is exactly what the user needs told.
+/// A `.bak` name beside `path` that nothing is using yet.
+///
+/// Numbered rather than overwritten, so a second reset does not destroy what
+/// the first one preserved. Lived in `config` while the config was the only
+/// thing ever set aside; it belongs here now that state and the data files use
+/// it too, because "do not lose the old file" is this module's whole job.
+pub(crate) fn free_backup_path(path: &Path) -> std::path::PathBuf {
+    let first = path.with_extension("toml.bak");
+    if !first.exists() {
+        return first;
+    }
+    for n in 2..1000 {
+        let candidate = path.with_extension(format!("toml.bak.{n}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    first
+}
+
+/// Move `path` out of the way, keeping its contents under a `.bak` name.
+///
+/// Returns where it went, or `None` if there was nothing there.
+///
+/// Renamed rather than deleted, and that is the point. A factory reset has to
+/// leave the reader where a fresh install would — which means these files must
+/// be *gone* from where mirador looks — but "gone" and "destroyed" are not the
+/// same thing, and this program does not destroy a task list. The same reason
+/// `write_atomic` exists.
+pub fn move_aside(path: &Path) -> Result<Option<std::path::PathBuf>> {
+    match path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return Ok(None),
+        Err(e) => anyhow::bail!("could not check whether {} exists: {e}", path.display()),
+    }
+
+    let to = free_backup_path(path);
+    std::fs::rename(path, &to)
+        .with_context(|| format!("moving {} to {}", path.display(), to.display()))?;
+    Ok(Some(to))
+}
+
 pub fn report(result: Result<()>, last_error: &mut Option<String>) {
     *last_error = match result {
         Ok(()) => None,
@@ -151,6 +193,61 @@ pub fn line_ending(source: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A factory reset has to leave these files gone from where mirador looks,
+    /// without destroying them. Both halves matter and the second is the one
+    /// worth a test — deleting a task list would be the single most
+    /// unforgivable thing this program could do.
+    #[test]
+    fn moving_aside_leaves_nothing_behind_and_loses_nothing() {
+        let dir = std::env::temp_dir().join(format!("mirador-aside-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+
+        let path = dir.join("todos.toml");
+        std::fs::write(&path, "title = \"do not lose me\"").expect("writes");
+
+        let moved = move_aside(&path).expect("moves").expect("there was a file");
+        assert!(
+            !path.exists(),
+            "the original must be gone from where mirador looks"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&moved).expect("readable"),
+            "title = \"do not lose me\"",
+            "and every byte of it kept"
+        );
+
+        assert!(
+            move_aside(&path).expect("no error").is_none(),
+            "moving an absent file is a normal outcome, not a failure"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Reset twice and the first rescue must survive the second.
+    #[test]
+    fn a_second_move_does_not_overwrite_the_first_backup() {
+        let dir = std::env::temp_dir().join(format!("mirador-aside2-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+
+        let path = dir.join("notes.toml");
+        std::fs::write(&path, "first").expect("writes");
+        let first = move_aside(&path).expect("moves").expect("a file");
+        std::fs::write(&path, "second").expect("writes again");
+        let second = move_aside(&path).expect("moves").expect("a file");
+
+        assert_ne!(first, second, "the second needs a name of its own");
+        assert_eq!(
+            std::fs::read_to_string(&first).expect("readable"),
+            "first",
+            "the first backup must not have been clobbered"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     struct TempDir(std::path::PathBuf);
 


### PR DESCRIPTION
The other half of #153. `--reset-config` resets *configuration*; the expectation behind the report was **"as if I just installed the app"**, and that flag cannot honestly promise it — the watchlist, tasks and notes all outlive it.

## It actually reaches a fresh install

Measured against a genuinely new one, after customising everything reachable:

| | after `--factory-reset` | fresh install |
|---|---|---|
| widgets in layout | 12 | 12 |
| watchlist tickers | 7 (defaults restored) | 7 |
| seeded tasks | 7 | 7 |
| rendered colours | `#d7af87` | `#d7af87` |

Indistinguishable on every measure — including the default tickers, which is the part `--reset-config` structurally could not do.

## Nothing is deleted

Every file is renamed to a numbered `.bak` beside itself. After the run above, `TSLA` and `nord` were still readable in `watchlist.toml.bak` and `state.toml.bak`.

That is what makes a single `y` a fair confirmation for a command with this name. The prompt lists every affected file by full path, and the worst outcome is renaming things back rather than lost work:

```
This starts mirador over from scratch.

  Replaced with the defaults:
    …/config.toml

  Set aside, each kept as a `.bak` beside itself:
    …/state.toml
    …/todos.toml
    …/notes.toml
    …/watchlist.toml

Nothing is deleted. Your tasks and notes stay on disk under their
backup names, and mirador starts again with fresh ones.
Go ahead? [y/N]
```

I considered requiring a typed word rather than `y`. It is not warranted once the operation is recoverable, and it would have diverged from `--reset-config` for no gain — the file list is what actually informs the decision. Declining was checked too: it leaves every file untouched.

## What it will not touch, and why

**Your calendar.** mirador *reads* an `.ics` and never writes one, so it is the reader's file even when it sits in mirador's own directory. Ownership by authorship: if mirador wrote it, mirador may set it aside. `the_owned_files_are_the_ones_mirador_writes` asserts `calendar.ics` is absent and that every entry stays inside the data directory — add it to the list and the test fails.

**Files at custom paths.** A `[todo].file` pointing elsewhere is a location the reader chose. Resetting the config already stops mirador looking there, and moving a file out of somebody's own directory is a surprise a reset cannot justify.

## Refactor

`free_backup_path` moves from `config` to `store`, beside `write_atomic` — "do not lose the old file" is that module's whole job, and state and the data files now use it too. `state::clear` delegates to the new `store::move_aside` instead of duplicating the rename.

## Tests

Five, each verified by breaking the code:

- `moving_aside_leaves_nothing_behind_and_loses_nothing` — fails if `move_aside` deletes rather than moves
- `a_second_move_does_not_overwrite_the_first_backup`
- `the_owned_files_are_the_ones_mirador_writes` — fails if `calendar.ics` is added
- flag parsing, including that `--reset-config` never sets `factory_reset` and vice versa: they are separate commands, not degrees of one

All four gates clean: 696 tests, `clippy`, `fmt`, rustdoc. README updated for both flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)