### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-31
+
+### Added
+
+- **`mirador --factory-reset` puts everything back to how it arrived.** The
+  reset `--reset-config` could never honestly be: it resets configuration, while
+  your watchlist, tasks and notes outlive it. This sets aside every file mirador
+  has written — config, remembered preferences, tasks, notes, watchlist and
+  world clocks — and the next launch seeds them all again, default stock tickers
+  included. A reset install is now indistinguishable from a new one.
+
+  **Nothing is deleted.** Every file is renamed to a `.bak` beside itself, so it
+  is something you can walk back from with `mv`, and an existing backup is never
+  overwritten. That is also why a plain `y` is enough to confirm it: the prompt
+  lists every affected file by full path, and the worst outcome is renaming
+  things back rather than lost work.
+
+  Your calendar is not touched. mirador only ever *reads* an `.ics`, so that
+  file is yours even when it sits in mirador's own directory — and neither are
+  files at paths you chose yourself with `[todo].file` and its siblings.
+
 ## [1.0.4] - 2026-07-31
 
 ### Fixed
@@ -1354,7 +1375,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.0.4...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/jchultarsky/mirador/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/jchultarsky/mirador/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/jchultarsky/mirador/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/jchultarsky/mirador/compare/v1.0.1...v1.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.0.4"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Minor rather than patch: this adds a flag.

## What is in it

**`mirador --factory-reset`** (#156) — the reset `--reset-config` could never honestly be. It sets aside every file mirador has written and the next launch seeds them all again, default stock tickers included.

Nothing is deleted; every file is renamed to a `.bak` beside itself. Your calendar is untouched, because mirador only ever *reads* an `.ics`, and so are files at paths you chose yourself.

## Driven in a real terminal before tagging

The confirmation is the safety mechanism here, so it got the attention rather than the happy path:

| input | outcome |
|---|---|
| `n` | left everything alone |
| `yes please` | **not** treated as a yes — left everything alone |
| no terminal, no `--yes` | refused, **exit 1** (checked without a pipe) |
| `-y` | 12 widgets, 7 tickers, 7 tasks, `#d7af87` |

The `-y` result is byte-identical to a genuinely fresh install on every measure, and `TSLA` and `nord` were still readable in `watchlist.toml.bak` and `state.toml.bak` afterwards.

`--reset-config` was re-checked alongside it and still refuses without a terminal, exit 1.

All four gates clean: 696 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)