### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-31
+
+Working notes and test coverage. **Nothing you can see changes** — the binary
+behaves identically, and the README and shipped config are untouched. Published
+so the source on crates.io matches the repository.
+
+### Changed
+
+- The working notes now record what shaped the two reset flags: why they are
+  separate commands rather than degrees of one, why resetting the config has to
+  clear the remembered preferences with it, and why a factory reset decides what
+  it may touch by which program wrote the file rather than by where it sits.
+- A test now checks those notes for the kinds of staleness a machine can see — a
+  test cited by name that no longer exists, a released version disagreeing with
+  the manifest, a cited path that has moved. It found one on its first run. Most
+  of that file is prose about the world and stays unchecked, which the test says
+  out loud rather than implying otherwise.
+
 ## [1.1.0] - 2026-07-31
 
 ### Added
@@ -1375,7 +1393,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/jchultarsky/mirador/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/jchultarsky/mirador/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/jchultarsky/mirador/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/jchultarsky/mirador/compare/v1.0.2...v1.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1431,7 +1431,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.1.0` is released**, on crates.io and as a GitHub release with binaries
+- **`1.1.1` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Working notes and test coverage. **Nothing you can see changes** — `docs.rs` is `#[cfg(test)]` and the only `main.rs` change is a `#[cfg(test)] mod` declaration, so the binary behaves identically, and the README and shipped config are untouched. Published so the source on crates.io matches the repository.

## The new guard earned its keep before this PR existed

Bumping `Cargo.toml` to 1.1.1 immediately failed:

```
CLAUDE.md says 1.1.0 is released; Cargo.toml says 1.1.1.
The version bump and the note belong in the same commit.
```

That is `the_released_version_in_the_notes_matches_the_manifest`, added in #159 one commit earlier. **The same line had previously gone stale by six releases before a human noticed** — this time it took seconds, and the failure message said what to do about it. Fixed in this commit, which is where it belonged.

## What is in it

- The working notes record what shaped the two reset flags (#158): why they are separate commands rather than degrees of one, why resetting the config has to clear the remembered preferences with it, and why a factory reset decides what it may touch by *which program wrote the file* rather than by where it sits.
- A test checks those notes for machine-visible staleness (#159) — a cited test that no longer exists, a released version disagreeing with the manifest, a moved path. It found one on its first run. Most of that file is prose about the world and stays unchecked, which the module says out loud rather than implying otherwise.

All four gates clean: 700 tests, `clippy`, `fmt`, rustdoc. Smoke-tested in a real terminal — runs, draws, exits 0 — which is the proportionate check for a release that changes no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)