### PR TITLE
Markets: drop a column rather than clip a number

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 281 of them, including the ones mirador
+    trip through `toml` discards all 283 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -81,8 +81,10 @@ rows = [
     # The timer draws block numerals when it has the width for them and falls
     # back to plain text when it does not.
     { widget = "pomodoro", width = 24 },
-    { widget = "stocks",   width = 28 },
-    { widget = "cpu",      width = 22 },
+    # 30 keeps the change column at 120 columns; below a panel width of 33 the
+    # markets grid drops it rather than clipping a number.
+    { widget = "stocks",   width = 30 },
+    { widget = "cpu",      width = 20 },
     { widget = "network",  width = 26 },
   ] },
 ]

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -48,8 +48,18 @@ impl Default for Layout {
                     18,
                     &[
                         ("pomodoro", 24),
-                        ("stocks", 28),
-                        ("cpu", 22),
+                        // 30 rather than 28 so the change column survives at
+                        // 120 columns. Below a panel width of 33 the grid drops
+                        // it rather than clipping a number, which is right — but
+                        // "what is the portfolio doing" is one of the four
+                        // questions, and the answer is the change, not the last
+                        // price. The two cells come from `cpu`, which draws a
+                        // graph and scales to whatever it is given — taking them
+                        // from `network` instead clipped its own text to
+                        // `839 B` rather than `839 B/s`, which is the very
+                        // failure being fixed, one panel over.
+                        ("stocks", 30),
+                        ("cpu", 20),
                         ("network", 26),
                     ],
                 ),

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -299,7 +299,7 @@ pub struct Grid {
 }
 
 /// Space between adjacent columns.
-const GUTTER: u16 = 1;
+pub(crate) const GUTTER: u16 = 1;
 
 impl Grid {
     /// Resolve `columns` against a total width.

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 281;
+        const CITED: usize = 283;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -57,23 +57,37 @@ const SPARK_WIDTH: u16 = 12;
 /// Columns the `▸ ` selection marker occupies to the left of the grid.
 const SELECTION_MARKER: u16 = 2;
 
-/// Width the four fixed columns and the gutters between all five occupy.
-const FIXED_COLUMNS: u16 = 8 + 10 + 9 + 8 + 4;
-
-/// Grid width at which the sparkline column earns its place: everything else,
-/// plus a sparkline drawn at full size.
+/// Every column's threshold, each derived from the one before it.
 ///
-/// Derived rather than written down, because this figure appears in three
-/// places — the column's own drop threshold, the panel's maximum width, and the
-/// width the sparkline is drawn at — and the three drifting apart is exactly
-/// how the column ends up allocated but empty.
-const SPARK_MIN_GRID: u16 = FIXED_COLUMNS + SPARK_WIDTH;
+/// A row used to be built at its full width whatever the panel could show, and
+/// the renderer clipped whatever hung over the edge — so the shipped layout,
+/// which gives this panel about 32 columns at 120, drew `+52.0` for a change of
+/// `+52.07`. **A dropped column reads as a narrow terminal; a clipped number
+/// reads as a different number**, which is the same argument that made the
+/// status bar drop whole hints rather than half of one.
+///
+/// Derived rather than written down because these figures appear in the column
+/// thresholds, the panel's maximum width and the width the sparkline is drawn
+/// at, and drifting apart is how a column ends up allocated but empty.
+///
+/// The order of expendability is the order of derivation. Symbol and last price
+/// are what a watchlist *is*; the change is what you look at next; the
+/// percentage restates the change; the sparkline is texture.
+///
+/// Even the symbol has a floor. A ticker clipped to `BRK.` is as wrong as a
+/// price clipped to `+52.0`, and below eight cells there is no honest way to
+/// draw one — so the row comes out empty, which is a panel with no room rather
+/// than a panel telling you something untrue.
+const CORE_GRID: u16 = 8 + crate::grid::GUTTER + 10;
+const CHG_MIN_GRID: u16 = CORE_GRID + crate::grid::GUTTER + 9;
+const PCT_MIN_GRID: u16 = CHG_MIN_GRID + crate::grid::GUTTER + 8;
+const SPARK_MIN_GRID: u16 = PCT_MIN_GRID + crate::grid::GUTTER + SPARK_WIDTH;
 
 const COLUMNS: &[Column] = &[
-    Column::fixed("symbol", 8),
-    Column::fixed("last", 10).right(),
-    Column::fixed("chg", 9).right(),
-    Column::fixed("%", 8).right(),
+    Column::fixed("symbol", 8).drops_below(8),
+    Column::fixed("last", 10).right().drops_below(CORE_GRID),
+    Column::fixed("chg", 9).right().drops_below(CHG_MIN_GRID),
+    Column::fixed("%", 8).right().drops_below(PCT_MIN_GRID),
     Column::flex("today", 1).drops_below(SPARK_MIN_GRID),
 ];
 
@@ -1172,6 +1186,115 @@ mod tests {
             guard.refresh,
             "and is woken rather than waiting an interval"
         );
+    }
+
+    /// A row must never be wider than the grid it was built for.
+    ///
+    /// It used to be built at full width whatever the panel could show, and the
+    /// renderer clipped the overhang — so the shipped layout, which gives this
+    /// panel about 32 columns at 120, drew `+52.0` for a change of `+52.07`.
+    /// Wrong numbers, in the default configuration, in the one panel where a
+    /// wrong number costs something.
+    #[test]
+    fn a_row_is_never_wider_than_the_grid_it_was_built_for() {
+        let theme = Theme::default();
+        let quote = Quote {
+            symbol: "^GSPC".into(),
+            price: 7489.72,
+            previous_close: 7437.65,
+            currency: Some("USD".into()),
+            series: vec![7437.0, 7489.72],
+            delayed: false,
+        };
+
+        for width in 0..64u16 {
+            let grid = Grid::new(COLUMNS, width);
+            for cell in [
+                ready(quote.clone()),
+                Cell::default(),
+                failed("network request failed"),
+            ] {
+                let line = StocksPanel::row("^GSPC", &cell, false, &theme, &grid, 8);
+                let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                assert!(
+                    crate::grid::display_width(text.trim_end()) <= usize::from(width),
+                    "a {}-cell row was built for a {width}-cell grid: {text:?}",
+                    crate::grid::display_width(text.trim_end())
+                );
+            }
+        }
+    }
+
+    /// Whichever value columns survive a narrow panel carry their *whole*
+    /// value, **as drawn**.
+    ///
+    /// This renders rather than inspecting the row, and that is the whole
+    /// point. `StocksPanel::row` never clips anything — the *renderer* clips
+    /// what will not fit — so a test that reads the row back can assert
+    /// complete values all day and pass with the defect in place. Two such
+    /// tests were written here first and both passed against the bug they were
+    /// meant to catch. The buffer is the only place the truth shows.
+    #[test]
+    fn every_value_on_screen_is_a_whole_value() {
+        use crate::panel::RenderContext;
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let theme = Theme::default();
+        let gradients = theme.gradients();
+        let quote = Quote {
+            symbol: "^GSPC".into(),
+            price: 7489.72,
+            previous_close: 7437.65,
+            currency: Some("USD".into()),
+            series: vec![7437.0, 7489.72],
+            delayed: false,
+        };
+
+        // Each value with the prefix a clip would leave behind. Seeing the
+        // prefix without the whole is the defect.
+        let whole = ["7489.72", "+52.07", "+0.70%", "^GSPC"];
+
+        for width in 4..64u16 {
+            let (mut p, _g) = panel(&format!("draw{width}"), &["^GSPC"]);
+            update(&p.board, &p.generation, "^GSPC", Ok(quote.clone()));
+
+            let mut t = Terminal::new(TestBackend::new(width, 6)).expect("backend");
+            t.draw(|f| {
+                p.render(
+                    f,
+                    Rect::new(0, 0, width, 6),
+                    RenderContext {
+                        theme: &theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .expect("draws");
+
+            let buffer = t.backend().buffer();
+            let screen: String = (0..6)
+                .map(|y| {
+                    (0..width)
+                        .map(|x| buffer[(x, y)].symbol())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            for value in whole {
+                let clipped = &value[..value.len() - 1];
+                if screen.contains(clipped) {
+                    assert!(
+                        screen.contains(value),
+                        "at width {width} the screen shows `{clipped}` but not the \
+                         whole `{value}` — a clipped value is a wrong value:\n{screen}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Found by looking hard at the default dashboard. **The Markets panel was showing wrong numbers out of the box.**

## The defect

The row was built at full width whatever the panel could show, and the renderer clipped the overhang. The shipped layout gives that panel ~32 columns at 120, so:

```
before:  ^GSPC       7489.72    +52.0      ← the change is +52.07
after:   ^GSPC       7489.72    +52.09
```

A dropped column reads as a narrow terminal. **A clipped number reads as a different number** — the same argument that made the status bar drop whole hints rather than half of one, one release ago.

## The fix

Every column now has a width below which it is not drawn, each derived from the one before it, in order of expendability:

| shown | grid | panel |
|---|---|---|
| symbol + last | 19 | 23 |
| + change | 29 | 33 |
| + percent | 38 | 42 |
| + sparkline | 51 | 55 |

The mechanism (`Column::drops_below`) already existed — only the sparkline had ever used it. Even the symbol gets a floor: a ticker clipped to `BRK.` is as wrong as a price clipped to `+52.0`, so below eight cells the row comes out empty, which is a panel with no room rather than a panel saying something untrue.

## Two cells for the default layout

Dropping alone would have cost the default dashboard its **change** column, and *"what is the portfolio doing"* is one of the four questions this program exists to answer — the answer is the change, not the last price. So `stocks` goes 28 → 30.

The cells come from `cpu`, which draws a graph and scales to whatever it gets. **Taking them from `network` first clipped its own text to `839 B` instead of `839 B/s`** — the same defect, one panel over. Recorded in the code, because other panels can still do this and this PR does not fix them.

## The test that matters renders

`StocksPanel::row` never clips; the *renderer* does. **Two tests written here first inspected the row and both passed against the bug they were meant to catch.** They are gone. What replaced them draws into a buffer at every width from 4 to 63 and asserts that seeing a value's prefix implies seeing the whole value — which fails at width 6 with the fix reverted.

A second test pins the root cause directly: a row must never be wider than the grid it was built for.

## Verified in a real terminal

120 columns, default layout, all four panels of that row complete:

```
╭┤Markets├──────────────────────┤7├╮╭┤CPU├───────┤18 cores├╮╭┤Network├───────────────┤all├╮
│   SYMBOL         LAST       CHG  ││   7.5% LOAD   12s    ││ ↓   2.6 KB/s   ↑   2.5 KB/s │
│   ^GSPC       7489.72    +52.09  ││                      ││                             │
```

Also updates the shipped config to match `Layout::default()` (invariant 18) and the comment count both it and `CLAUDE.md` quote — a pre-existing guard caught that, correctly.

All four gates clean: 702 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)