### PR TITLE
Release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-31
+
+### Fixed
+
+- **The markets panel was showing wrong numbers in the default layout.** Its row
+  was built at full width whatever the panel could show, and the terminal
+  clipped whatever hung over the edge — so a change of `+52.07` was drawn as
+  `+52.0`. Every column now has a width below which it is dropped instead, in
+  order of expendability: the sparkline first, then the percentage, then the
+  change, then the last price. A missing column reads as a narrow terminal; half
+  a number reads as a different number.
+
+  Even the symbol has a floor, because a ticker clipped to `BRK.` is as wrong as
+  a price clipped to `+52.0`.
+
+- **The markets panel gains two columns in the shipped layout**, taken from the
+  cpu graph, which scales to whatever it is given. Without them the fix above
+  would have cost the default dashboard its change column — and the change is
+  the answer to "what is the portfolio doing", which is one of the four
+  questions this dashboard exists to answer. Existing configs are untouched; a
+  config is seeded once and never rewritten.
+
 ## [1.1.1] - 2026-07-31
 
 Working notes and test coverage. **Nothing you can see changes** — the binary
@@ -1393,7 +1415,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/jchultarsky/mirador/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/jchultarsky/mirador/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/jchultarsky/mirador/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/jchultarsky/mirador/compare/v1.0.3...v1.0.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1431,7 +1431,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.1.1` is released**, on crates.io and as a GitHub release with binaries
+- **`1.1.2` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
One user-visible correctness fix, found by looking hard at the default dashboard.

**The markets panel was showing wrong numbers out of the box** (#161). Its row was built at full width whatever the panel could show and the terminal clipped the overhang, so a change of `+52.07` was drawn as `+52.0`. Columns now drop whole instead — sparkline, then percentage, then change, then last price — and even the symbol has a floor, because a ticker clipped to `BRK.` is as wrong as a clipped price.

The panel also gains two cells in the shipped layout, taken from the cpu graph, which scales. Without them the fix would have cost the default dashboard its change column, and the change is the answer to *"what is the portfolio doing"* — one of the four questions this dashboard exists to answer. **Existing configs are untouched**: a config is seeded once and never rewritten, so this reaches new installs only.

## Driven in a real terminal before tagging

```
╭┤Markets├──────────────────────┤7├╮╭┤CPU├───────┤18 cores├╮╭┤Network├───────────────┤all├╮
│   SYMBOL         LAST       CHG  ││   6.8% LOAD   12s    ││ ↓   1.6 KB/s   ↑    439 B/s │
│   ^GSPC       7489.72    +52.09  ││                      ││                             │
```

Complete values in all four panels of that row at 120 columns; clean exit 0.

All four gates clean: 702 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)