### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-08-01
+
+### Fixed
+
+- **The agenda panel's "no calendar yet" message was cutting off the path.** That
+  message exists to tell you where to put your `.ics`, and it stopped mid-path —
+  `Looked in /var/folders/zj/blsvny` — which is not an instruction. It wraps now,
+  as does the prose above it, which had been hand-wrapped for one panel width and
+  clipped at every narrower one, and as does the failure reason when a calendar
+  cannot be read.
+
+  Same shape as the markets fix in 1.1.2: the terminal clips whatever does not
+  fit, so anything built without asking how wide the panel is will eventually say
+  something untrue or unreadable.
+
 ## [1.1.2] - 2026-07-31
 
 ### Fixed
@@ -1415,7 +1430,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/jchultarsky/mirador/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/jchultarsky/mirador/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/jchultarsky/mirador/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/jchultarsky/mirador/compare/v1.0.4...v1.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1431,7 +1431,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.1.2` is released**, on crates.io and as a GitHub release with binaries
+- **`1.1.3` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
One user-visible fix, plus a guard that ships no behaviour.

**The agenda's "no calendar yet" message was cutting off the path** (#163). That message exists to tell you where to put your `.ics`, and it stopped mid-path — `Looked in /var/folders/zj/blsvny` — which is not an instruction. It wraps now, as does the prose above it (hand-wrapped for one panel width, clipped at every narrower one) and the failure reason when a calendar cannot be read.

Same shape as 1.1.2's markets fix: the terminal clips whatever does not fit, so anything built without asking how wide the panel is will eventually say something untrue or unreadable.

Also in, but invisible: **a structural guard that only two places may use ratatui's own wrapper** (#164) — the help overlay and the delete confirmation. A third fails the test with a message saying what to do instead.

## Driven in a real terminal before tagging

```
│ Looked in                        │
│ /var/folders/zj/blsvny1s0gb8b4lv │
│ 0x_90s3w0000gn/T/tmp.JpuRX9wRho/ │
```

The path wraps across rows and reads; clean exit 0.

All four gates clean: 704 tests, `clippy`, `fmt`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)