### PR TITLE
Drop whole values rather than letting the terminal cut one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,45 @@ map, that one is the procedure.
     no file now seeds it. Panel tests write an empty file first, which is the
     branch every run after the first one takes.
 
+19. **Nothing may be drawn wider than the space it was given.** A line built at
+    its natural width and handed to a `Paragraph` is not truncated by mirador —
+    it is truncated by the *terminal*, which keeps the cells that fit and
+    discards the rest in silence. The terminal cannot tell a value from a
+    fragment, so it cuts wherever the edge falls, and a fragment of a value is
+    not a smaller truth. `↑ 6.4 KB` is a total where a rate was meant, `+52.0`
+    is a price nobody quoted, `humidity` with no figure is a label over nothing,
+    and `13 1` under a calendar's THU is Thursday the 1st.
+
+    Two mechanisms, and which one applies is decided by what the text *is*:
+
+    - **Values drop whole.** `grid::assemble` takes a line as a list of parts
+      and drops from the end until it fits; `Grid` does the same for table
+      columns via `drops_below`. A part is anything that means nothing on its
+      own — a figure and its unit, an arrow and what it points at. Put the
+      separator at the *front* of the part it introduces, so a dropped part
+      takes its separator with it and no line ends in a dangling `·`.
+    - **Prose is ellipsised.** `grid::truncate` for one line, `grid::wrap` for
+      several. The `…` is the whole point: it is the difference between a
+      message the reader knows is abridged and one they do not.
+
+    Where a value would be dropped only because of its own *padding*, drop the
+    padding first — the network and cpu readouts pad to a fixed field so the
+    figures hold still, and give that up rather than the second reading.
+
+    This was found late, and by looking rather than by any test failing: nine
+    modules built composite lines by hand and four were cutting values at
+    ordinary terminal sizes, one of them in the shipped 120-column default.
+    `no_grid_in_the_program_ever_overflows_its_width` sweeps every declared
+    column set at every width, `every_grid_in_the_program_is_on_this_list`
+    keeps that sweep complete, and
+    `every_hand_built_composite_line_in_a_widget_is_accounted_for` counts what
+    is left and makes a new one justify itself.
+
+    **A render-level sweep cannot check this, and it was tried first.** A
+    buffer records what the terminal *kept*, so an overflowing line and a line
+    that happens to end there are the same bytes. Overflow has to be caught
+    where the line is built.
+
 ## Visual system
 
 Design thesis: *the watch station*. The vernacular is a lookout's instrument

--- a/src/app.rs
+++ b/src/app.rs
@@ -1531,7 +1531,7 @@ impl App {
         // waits until `Enter` or `Esc` has lost nothing, because the thing it
         // names has already happened either way.
         if self.arranging.is_some() {
-            let mut spans = vec![Span::styled(
+            let spans = vec![Span::styled(
                 " ARRANGE",
                 Style::default()
                     .fg(theme.accent)
@@ -1546,7 +1546,7 @@ impl App {
             // Ordered so that the two that matter most survive a narrow
             // terminal: knowing how to get out of a mode beats knowing every
             // trick inside it.
-            let mut used = crate::grid::display_width(" ARRANGE");
+            let mut parts = vec![spans];
             // Both vertical hints were shortened when `Shift+↑↓` was added in
             // #100: a sixth entry does not fit beside the old wording at an
             // ordinary 110 columns, and dropping one was not an option —
@@ -1563,21 +1563,22 @@ impl App {
             ] {
                 // Dropped whole rather than clipped: half a hint reads as a
                 // rendering fault, where a missing one just reads as a narrow
-                // terminal.
-                let width = 3 + crate::grid::display_width(key) + 1 + action.len();
-                if used + width > usize::from(area.width) {
-                    break;
-                }
-                used += width;
-                spans.push(Span::styled("   ", muted));
-                spans.push(Span::styled(key, key_style));
-                spans.push(Span::styled(format!(" {action}"), muted));
+                // terminal. The gap leads the hint it introduces, so a dropped
+                // hint takes its gap with it.
+                parts.push(vec![
+                    Span::styled("   ", muted),
+                    Span::styled(key, key_style),
+                    Span::styled(format!(" {action}"), muted),
+                ]);
             }
-            frame.render_widget(Paragraph::new(Line::from(spans)), area);
+            frame.render_widget(
+                Paragraph::new(crate::grid::assemble(parts, area.width)),
+                area,
+            );
             return;
         }
 
-        let mut spans = vec![Span::styled(
+        let spans = vec![Span::styled(
             " mirador",
             Style::default()
                 .fg(theme.accent)
@@ -1590,19 +1591,13 @@ impl App {
         // need one while every primary was a single character — `t theme` was
         // the widest thing in it. Promoting the resize keys made it need one:
         // at 80 columns the bar ended `Ctrl+←`.
-        let mut used = crate::grid::display_width(" mirador");
+        let mut parts = vec![spans];
         for binding in GLOBAL.iter().filter(|b| b.primary) {
-            let width = 3
-                + crate::grid::display_width(binding.key)
-                + 1
-                + crate::grid::display_width(binding.action);
-            if used + width > usize::from(area.width) {
-                break;
-            }
-            used += width;
-            spans.push(Span::styled("   ", muted));
-            spans.push(Span::styled(binding.key, key_style));
-            spans.push(Span::styled(format!(" {}", binding.action), muted));
+            parts.push(vec![
+                Span::styled("   ", muted),
+                Span::styled(binding.key, key_style),
+                Span::styled(format!(" {}", binding.action), muted),
+            ]);
         }
 
         // An alert takes the whole bar rather than sharing it. It outranks both
@@ -1636,8 +1631,10 @@ impl App {
         // The hint rides on the right of the bar it shares with the global
         // keys, and gives way to them when the terminal is too narrow: knowing
         // how to quit matters more than knowing what you are not using.
+        let mut line = crate::grid::assemble(parts, area.width);
         if let Some(hint) = self.update_hint() {
-            let used: usize = spans
+            let used: usize = line
+                .spans
                 .iter()
                 .map(|s| crate::grid::display_width(&s.content))
                 .sum();
@@ -1645,15 +1642,16 @@ impl App {
             let total = usize::from(area.width);
             // One space of breathing room on each side of the gap.
             if used + hint_width + 3 <= total {
-                spans.push(Span::styled(
+                line.spans.push(Span::styled(
                     " ".repeat(total - used - hint_width - 1),
                     muted,
                 ));
-                spans.push(Span::styled(hint, Style::default().fg(theme.label)));
+                line.spans
+                    .push(Span::styled(hint, Style::default().fg(theme.label)));
             }
         }
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        frame.render_widget(Paragraph::new(line), area);
     }
 
     /// The single most pressing thing, if anything is pressing.

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -368,6 +368,39 @@ impl Grid {
             resolved.push((column, width, declared));
         }
 
+        // No column may take space the grid has not got.
+        //
+        // `drops_below` is how a grid *chooses* what to lose, and it is the
+        // mechanism panels should reach for — a threshold names the width at
+        // which a column stops being worth its room. This is the floor
+        // underneath it, for the widths no threshold anticipated: a fixed
+        // width is declared without reference to the total, so three fixed
+        // columns in a pane narrower than their sum built a row wider than the
+        // pane it was resolved for. What the reader then saw was decided by
+        // the terminal, which cannot tell a value from a fragment and cuts
+        // wherever the edge falls.
+        //
+        // Clamping hands the short column whatever is left, and `fit`
+        // ellipsises it. That is the same bargain the rest of the module
+        // makes: degrade visibly rather than silently.
+        let mut left = total;
+        let mut emitted = false;
+        for (_, width, _) in &mut resolved {
+            if *width == 0 {
+                continue;
+            }
+            let gutter = if emitted { GUTTER } else { 0 };
+            if left <= gutter {
+                *width = 0;
+                continue;
+            }
+            *width = (*width).min(left - gutter);
+            if *width > 0 {
+                left -= gutter + *width;
+                emitted = true;
+            }
+        }
+
         Self { resolved }
     }
 
@@ -410,12 +443,12 @@ impl Grid {
             .add_modifier(Modifier::BOLD);
 
         let mut spans = Vec::new();
-        for (index, (column, width, _)) in self.resolved.iter().enumerate() {
-            if index > 0 {
-                spans.push(Span::raw(" ".repeat(GUTTER as usize)));
-            }
+        for (column, width, _) in &self.resolved {
             if *width == 0 {
                 continue;
+            }
+            if !spans.is_empty() {
+                spans.push(Span::raw(" ".repeat(GUTTER as usize)));
             }
             let text = crate::glyphs::utility(column.label);
             spans.push(Span::styled(fit(&text, *width, column.align), style));
@@ -426,12 +459,12 @@ impl Grid {
     /// A data row. Extra cells are ignored; missing cells render blank.
     pub fn row(&self, cells: &[Span<'_>]) -> Line<'static> {
         let mut spans = Vec::new();
-        for (index, (column, width, declared)) in self.resolved.iter().enumerate() {
-            if index > 0 {
-                spans.push(Span::raw(" ".repeat(GUTTER as usize)));
-            }
+        for (column, width, declared) in &self.resolved {
             if *width == 0 {
                 continue;
+            }
+            if !spans.is_empty() {
+                spans.push(Span::raw(" ".repeat(GUTTER as usize)));
             }
             // Indexed by the column's declared position, not its surviving
             // one, so a dropped column takes its own value with it rather than
@@ -444,6 +477,59 @@ impl Grid {
         }
         Line::from(spans)
     }
+}
+
+/// Assemble `parts` into a line that fits `width`, dropping whole parts from
+/// the end rather than letting the terminal cut one in half.
+///
+/// **A line assembled from parts must lose whole parts, never half a value.**
+/// This is the same rule [`Grid`] applies to columns, for the many lines in
+/// this program that are not tables: a readout, a summary, a settings line.
+/// Those were all built at their natural width and handed to a `Paragraph`,
+/// which draws what fits and drops the rest on the floor. The terminal has no
+/// idea what a value is, so it cuts wherever the edge falls — and a fragment
+/// of a value is not a smaller truth, it is a different one. `↑ 6.4 KB` is a
+/// total where a rate was meant, `+52.0` is a number nobody holds, and `13 1`
+/// under a calendar's THU is a date. All three were on screen at ordinary
+/// terminal widths.
+///
+/// A part is a group of spans that means nothing on its own — a value and its
+/// unit, an arrow and the figure it points at, a separator and what follows
+/// it. Put the separator at the *front* of the part it introduces, so dropping
+/// the part takes the separator with it and no line ends in a dangling `·`.
+///
+/// When not even the first part fits it is truncated rather than dropped. A
+/// blank where a number belongs reads as a broken panel — invariant 11, one
+/// scale up — and the ellipsis is what keeps that honest: something was cut,
+/// and the reader can see that it was.
+pub fn assemble(parts: Vec<Vec<Span<'static>>>, width: u16) -> Line<'static> {
+    let width = usize::from(width);
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut used = 0usize;
+
+    for part in parts {
+        let part_width: usize = part.iter().map(|s| display_width(&s.content)).sum();
+        if used + part_width > width {
+            // Nothing has been placed and this part is too wide for the line:
+            // show as much of it as fits, ellipsised, rather than nothing.
+            if spans.is_empty() {
+                let mut room = width;
+                for span in part {
+                    if room == 0 {
+                        break;
+                    }
+                    let text = truncate(&span.content, room);
+                    room -= display_width(&text);
+                    spans.push(Span::styled(text, span.style));
+                }
+            }
+            break;
+        }
+        used += part_width;
+        spans.extend(part);
+    }
+
+    Line::from(spans)
 }
 
 /// Pad or truncate `text` to exactly `width` terminal cells.
@@ -697,6 +783,110 @@ mod tests {
         );
     }
 
+    /// Every multi-span line a widget builds by hand is accounted for.
+    ///
+    /// The clipping pass found nine lines assembled from parts and handed to a
+    /// `Paragraph` at their natural width, in nine different modules, each
+    /// written as if the pane would be wide enough. Four of them were cutting
+    /// values at ordinary terminal sizes — the upload rate reduced to a bare
+    /// `↑`, `humidity` with no figure, `25m focus ·` trailing into nothing,
+    /// `+52.0`. The defect was not in any one of them; it was that nothing
+    /// asked the question.
+    ///
+    /// So this counts the remaining hand-built composite lines and names why
+    /// each is safe. It is a coarse instrument — `Line::from(vec![…])` is not
+    /// itself wrong — and that is the intent: a new one has to be justified out
+    /// loud, here, rather than discovered on somebody's narrow terminal.
+    ///
+    /// The alternative was a render-level sweep, and it was tried first. It
+    /// cannot work: a buffer records what the terminal *kept*, so an overflowing
+    /// line and a line that happens to end there are the same bytes. Overflow
+    /// has to be caught where the line is built, which makes the call site the
+    /// only thing there is to count.
+    #[test]
+    fn every_hand_built_composite_line_in_a_widget_is_accounted_for() {
+        // Each entry is a module and how many composite lines it may build.
+        // A line is exempt only when its width is *already* bounded — every
+        // span truncated to a computed room, or the whole thing measured before
+        // it is built.
+        const ALLOWED: &[(&str, usize, &str)] = &[
+            ("agenda.rs", 1, "the row's summary is truncated to `room`"),
+            (
+                "notes.rs",
+                2,
+                "search field and caret, both cut to the pane",
+            ),
+            ("stocks.rs", 1, "the add field, assembled by `status_line`"),
+            (
+                "todo.rs",
+                1,
+                "the priority marker: three short fixed strings",
+            ),
+            (
+                "watchlog.rs",
+                2,
+                "entry text truncated; the rule line is built to width",
+            ),
+        ];
+
+        fn walk(dir: &std::path::Path, needle: &str, found: &mut Vec<String>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, needle, found);
+                } else if path.extension().is_some_and(|e| e == "rs")
+                    && let Ok(text) = std::fs::read_to_string(&path)
+                {
+                    // Tests build lines to assert about them, which is not
+                    // drawing one.
+                    let body = text.split("mod tests").next().unwrap_or(&text);
+                    for line in body.lines() {
+                        if line.trim_start().starts_with("//") {
+                            continue;
+                        }
+                        if line.contains(needle) {
+                            found.push(
+                                path.file_name()
+                                    .unwrap_or_default()
+                                    .to_string_lossy()
+                                    .to_string(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // Split so this test's own source is not a match.
+        let needle = concat!("Line::fr", "om(vec![");
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/widgets");
+
+        let mut found = Vec::new();
+        walk(&root, needle, &mut found);
+
+        for name in &found {
+            let allowed = ALLOWED
+                .iter()
+                .find(|(module, _, _)| module == name)
+                .map_or(0, |(_, count, _)| *count);
+            let actual = found.iter().filter(|f| *f == name).count();
+            assert!(
+                actual <= allowed,
+                "{name} builds {actual} composite line(s) by hand; {allowed} are \
+                 accounted for.\n\n\
+                 A line assembled from parts and drawn at its natural width is \
+                 cut by the terminal, which cannot tell a value from a fragment \
+                 — `↑ 6.4 KB` where a rate was meant, `+52.0` where a price was. \
+                 Build it with `grid::assemble` so whole parts are dropped \
+                 instead, or bound every span yourself and add the module here \
+                 with the reason."
+            );
+        }
+    }
+
     #[test]
     fn ratatuis_own_wrapper_is_why_this_module_wraps_first() {
         let hook = std::panic::take_hook();
@@ -781,6 +971,170 @@ mod tests {
 
     fn width_of(line: &Line<'_>) -> usize {
         line.spans.iter().map(|s| display_width(&s.content)).sum()
+    }
+
+    /// Every column set in the program, so the check below is about mirador
+    /// rather than about a fixture written to pass it.
+    ///
+    /// Kept honest by `every_grid_in_the_program_is_on_this_list`, which counts
+    /// the declarations in the tree. A grid that is not here is not checked,
+    /// and an unchecked grid is what this whole module exists to prevent.
+    const EVERY_GRID: &[(&str, &[Column])] = &[
+        ("clocks", crate::widgets::clocks::COLUMNS),
+        ("notes", crate::widgets::notes::COLUMNS),
+        ("stocks", crate::widgets::stocks::COLUMNS),
+        ("todo", crate::widgets::todo::COLUMNS),
+        ("weather", crate::widgets::weather::COLUMNS),
+    ];
+
+    /// A grid must never build a row wider than the width it was resolved for.
+    ///
+    /// The one property that matters, and the one nothing checked. A row that
+    /// overflows is not drawn wrong — it is drawn *by the terminal*, which
+    /// keeps the cells that fit and discards the rest without saying so. The
+    /// reader gets a value with its tail missing and no way to tell.
+    ///
+    /// Swept over every width rather than the handful a panel is usually given,
+    /// because the widths that broke this were the ones nobody pictures: a
+    /// tiling window manager quartering a screen, a pane dragged narrow. Both
+    /// the header and a row are measured — they are built by separate loops,
+    /// and only one of them was wrong the first time.
+    #[test]
+    fn no_grid_in_the_program_ever_overflows_its_width() {
+        let cells = [
+            Span::raw("wwwwwwwwwwwwwwwwwwww"),
+            Span::raw("12:34:56"),
+            Span::raw("日本語日本語"),
+            Span::raw("🌞🌞🌞"),
+            Span::raw("+52.07"),
+            Span::raw("x"),
+        ];
+        for (name, columns) in EVERY_GRID {
+            for total in 0u16..=200 {
+                let grid = Grid::new(columns, total);
+                let header = width_of(&grid.header(&Theme::default()));
+                let row = width_of(&grid.row(&cells));
+                assert!(
+                    header <= usize::from(total),
+                    "{name}'s header is {header} cells wide in a {total}-cell grid; \
+                     the terminal will cut the overhang off a label without saying so"
+                );
+                assert!(
+                    row <= usize::from(total),
+                    "{name} builds a {row}-cell row for a {total}-cell grid. \
+                     The overhang is not dropped by mirador, it is dropped by the \
+                     terminal — so the last value on the row loses its tail and \
+                     still reads as a whole number. Give the column a \
+                     `drops_below` threshold that suits it."
+                );
+            }
+        }
+    }
+
+    /// The rule [`assemble`] exists for, stated as the property.
+    #[test]
+    fn an_assembled_line_never_exceeds_the_width_it_was_given() {
+        let parts = vec![
+            vec![Span::raw("12.3"), Span::raw("% "), Span::raw("LOAD")],
+            vec![Span::raw("   40s")],
+            vec![Span::raw("   \u{2191} 6.4 KB/s")],
+            vec![Span::raw("   \u{65E5}\u{672C}\u{8A9E}")],
+            vec![Span::raw("   \u{1F31E}\u{1F31E}")],
+        ];
+        for width in 0u16..=60 {
+            let line = assemble(parts.clone(), width);
+            assert!(
+                width_of(&line) <= usize::from(width),
+                "assemble produced {} cells for a width of {width}",
+                width_of(&line)
+            );
+        }
+    }
+
+    /// A part is all-or-nothing, which is the whole point of the function.
+    ///
+    /// Checked on the exact boundary rather than at a comfortable width: one
+    /// cell short of fitting is where a hand-rolled version drops a character
+    /// instead of a value, and every site this replaced was hand-rolled.
+    #[test]
+    fn a_part_that_does_not_fit_is_dropped_whole_rather_than_cut() {
+        let parts = vec![
+            vec![Span::raw("\u{2193} 6.4 KB/s")],
+            vec![Span::raw("   \u{2191} 1.2 MB/s")],
+        ];
+        let whole = width_of(&assemble(parts.clone(), 60));
+        assert_eq!(whole, 23, "the fixture should need 23 cells");
+
+        // One cell short of the pair: the second reading goes, and its arrow
+        // and separator go with it. An arrow left standing over nothing reads
+        // as a value of zero.
+        let line = assemble(parts.clone(), 22);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert_eq!(text, "\u{2193} 6.4 KB/s");
+
+        // And exactly at the pair's width, nothing is given up at all.
+        assert_eq!(width_of(&assemble(parts, 23)), 23);
+    }
+
+    /// A first part too wide to fit is ellipsised, not dropped.
+    ///
+    /// The alternative is a blank row where a reading belongs, which reads as a
+    /// broken panel rather than a narrow one — invariant 11 one scale up. The
+    /// `…` is what keeps it honest: the reader can see something was cut.
+    #[test]
+    fn a_lone_part_too_wide_to_fit_is_ellipsised_rather_than_dropped() {
+        let parts = vec![vec![Span::raw("^GSPC: network access is refused")]];
+        let line = assemble(parts, 12);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            text.ends_with('\u{2026}'),
+            "an abridged message must say so, got {text:?}"
+        );
+        assert!(display_width(&text) <= 12);
+        assert!(!text.is_empty(), "a blank line reads as a broken panel");
+    }
+
+    /// The list above has to name every grid, or the sweep passes by not
+    /// looking.
+    ///
+    /// Counting declarations rather than checking each one by hand: the same
+    /// shape as the guard on ratatui's wrapper, and for the same reason. A
+    /// registry nothing reconciles with the tree is a registry that quietly
+    /// stops being complete, and the failure mode is silence.
+    #[test]
+    fn every_grid_in_the_program_is_on_this_list() {
+        fn walk(dir: &std::path::Path, found: &mut Vec<String>) {
+            for entry in std::fs::read_dir(dir).unwrap().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, found);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let text = std::fs::read_to_string(&path).unwrap();
+                    if text.contains(concat!("const COLUMNS: &[", "Column]")) {
+                        found.push(path.file_stem().unwrap().to_string_lossy().into_owned());
+                    }
+                }
+            }
+        }
+
+        let mut found = Vec::new();
+        walk(
+            &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+            &mut found,
+        );
+        found.sort();
+
+        let mut listed: Vec<String> = EVERY_GRID.iter().map(|(n, _)| (*n).to_string()).collect();
+        listed.sort();
+
+        assert_eq!(
+            found, listed,
+            "the source declares grids {found:?} but EVERY_GRID names {listed:?}.\n\n\
+             Add the new one to EVERY_GRID. Until it is there, \
+             no_grid_in_the_program_ever_overflows_its_width does not cover it, \
+             and it will pass anyway — which is the failure this check exists \
+             to make impossible."
+        );
     }
 
     #[test]

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -785,19 +785,22 @@ impl AgendaPanel {
             } else {
                 format!("the next {} days", self.days)
             };
-            frame.render_widget(
-                Paragraph::new(vec![
-                    Line::from(TextSpan::styled(
-                        "Nothing scheduled",
-                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
-                    )),
-                    Line::from(TextSpan::styled(
-                        format!("in {horizon}."),
-                        Style::default().fg(theme.muted),
-                    )),
-                ]),
-                area,
+            // Wrapped, not hand-broken. Two lines written to fit a panel of the
+            // author's imagination lose a word each in a narrower one, and the
+            // pair still reads as a whole sentence — `Nothing schedule` above
+            // `in the next 7 da` looks like a rendering glitch, where the same
+            // words wrapped honestly just take four rows.
+            let mut lines = wrapped_lines(
+                "Nothing scheduled",
+                area.width,
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
             );
+            lines.extend(wrapped_lines(
+                &format!("in {horizon}."),
+                area.width,
+                Style::default().fg(theme.muted),
+            ));
+            frame.render_widget(Paragraph::new(lines), area);
             return;
         }
 

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -146,7 +146,7 @@ fn month_name(month: i8) -> &'static str {
         .unwrap_or("")
 }
 
-/// Centre `text` in a field of exactly `MONTH_WIDTH` cells.
+/// Centre `text` in a field of exactly `width` cells.
 ///
 /// The trailing padding matters as much as the leading: a month block is
 /// composed left to right, so a title line that stops short of the full width
@@ -154,36 +154,68 @@ fn month_name(month: i8) -> &'static str {
 /// to the right, which is where `cal` puts them.
 ///
 /// Month names are ASCII, so counting chars is counting cells here.
-fn centred(text: &str) -> String {
-    let width = usize::from(MONTH_WIDTH);
+fn centred(text: &str, width: usize) -> String {
     let len = text.chars().count();
     if len >= width {
-        return text.to_string();
+        // Ellipsised rather than left to hang over the edge. A title is prose,
+        // so `Aug…` is a plainly abridged month where a title the terminal cut
+        // would read as a shorter name.
+        return crate::grid::truncate(text, width);
     }
     let left = (width - len) / 2;
     let right = width - len - left;
     format!("{:left$}{text}{:right$}", "", "")
 }
 
-/// One month as exactly `MONTH_HEIGHT` lines of exactly `MONTH_WIDTH` cells.
+/// Cells a month occupies when only `day_columns` of its seven weekdays fit.
+///
+/// Each day is two cells with one between them, so the whole-column widths are
+/// 2, 5, 8 … 20 and nothing else. Any other width cuts a date down the middle,
+/// and a date cut down the middle is still a date: `14` clipped to `1` under
+/// THU is not a fragment the reader can spot, it is Thursday the 1st.
+const fn month_width(day_columns: usize) -> usize {
+    day_columns * 3 - 1
+}
+
+/// The most whole weekday columns that fit in `width`.
+///
+/// Zero when not even one day fits, which is the only honest answer at a
+/// couple of cells — the panel then draws nothing rather than half a number.
+const fn day_columns_for(width: u16) -> usize {
+    let fits = (width as usize + 1) / 3;
+    if fits > 7 { 7 } else { fits }
+}
+
+/// One month as exactly `MONTH_HEIGHT` lines of exactly
+/// `month_width(day_columns)` cells.
+///
+/// Narrowing drops whole weekday columns from the end, the way the shared grid
+/// drops whole table columns. What is left is true — the dates under SU MO TU
+/// are the right dates — and it is visibly a cut-off calendar, which the
+/// alternative was not.
 fn month_block(
     first: Date,
     today: Date,
     week_start: Weekday,
     theme: &Theme,
     focused: bool,
+    day_columns: usize,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::with_capacity(usize::from(MONTH_HEIGHT));
+    let width = month_width(day_columns);
 
     lines.push(Line::from(Span::styled(
-        centred(&format!("{} {}", month_name(first.month()), first.year())),
+        centred(
+            &format!("{} {}", month_name(first.month()), first.year()),
+            width,
+        ),
         Style::default()
             .fg(theme.title)
             .add_modifier(Modifier::BOLD),
     )));
 
     lines.push(Line::from(Span::styled(
-        weekday_headings(week_start).join(" "),
+        weekday_headings(week_start)[..day_columns].join(" "),
         Style::default().fg(theme.label),
     )));
 
@@ -195,11 +227,21 @@ fn month_block(
     for week in 0..WEEK_ROWS {
         let mut spans: Vec<Span<'static>> = Vec::with_capacity(13);
         for column in 0..7 {
+            let leading = week == 0 && column < blanks;
+            let drawn = !(leading || day > days);
+            // A dropped column still consumes its date: the month must go on
+            // advancing behind the edge of the panel, or the second week would
+            // start on the wrong day.
+            if column >= day_columns {
+                if drawn {
+                    day += 1;
+                }
+                continue;
+            }
             if column > 0 {
                 spans.push(Span::raw(" "));
             }
-            let leading = week == 0 && column < blanks;
-            if leading || day > days {
+            if !drawn {
                 spans.push(Span::raw("  "));
                 continue;
             }
@@ -349,6 +391,19 @@ impl Panel for CalendarPanel {
 
         let across = usize::from(self.config.months.clamp(1, 12));
         let (columns, rows) = grid_shape(area, across);
+
+        // A month is twenty cells and there is no honest way to squeeze one
+        // into fewer, so a panel narrower than that shows fewer weekdays rather
+        // than a narrower week. Below three cells not even one day fits and
+        // there is nothing to draw; the frame still says which panel this is.
+        let day_columns = if columns > 1 {
+            7
+        } else {
+            day_columns_for(area.width)
+        };
+        if day_columns == 0 {
+            return;
+        }
         let week_start = self.week_start();
         let anchor = first_of_month(self.today);
 
@@ -372,7 +427,14 @@ impl Panel for CalendarPanel {
                 };
                 drew_any = true;
 
-                let block = month_block(first, self.today, week_start, ctx.theme, ctx.focused);
+                let block = month_block(
+                    first,
+                    self.today,
+                    week_start,
+                    ctx.theme,
+                    ctx.focused,
+                    day_columns,
+                );
                 for (line_index, line) in block.into_iter().enumerate() {
                     let Some(target) = strip.get_mut(line_index) else {
                         continue;
@@ -415,7 +477,7 @@ mod tests {
     fn a_month_matches_what_cal_prints() {
         let july = Date::new(2026, 7, 1).unwrap();
         let theme = Theme::default();
-        let block = month_block(july, july, Weekday::Sunday, &theme, true);
+        let block = month_block(july, july, Weekday::Sunday, &theme, true, 7);
 
         let text: Vec<String> = block
             .iter()
@@ -446,7 +508,7 @@ mod tests {
         // it scrolls.
         for (year, month) in [(2026, 2), (2026, 8), (2026, 3)] {
             let first = Date::new(year, month, 1).unwrap();
-            let block = month_block(first, first, Weekday::Sunday, &theme, true);
+            let block = month_block(first, first, Weekday::Sunday, &theme, true, 7);
             assert_eq!(
                 block.len(),
                 usize::from(MONTH_HEIGHT),
@@ -460,7 +522,14 @@ mod tests {
     fn today_is_the_only_reversed_day() {
         let theme = Theme::default();
         let today = Date::new(2026, 7, 25).unwrap();
-        let block = month_block(today.first_of_month(), today, Weekday::Sunday, &theme, true);
+        let block = month_block(
+            today.first_of_month(),
+            today,
+            Weekday::Sunday,
+            &theme,
+            true,
+            7,
+        );
 
         let reversed: Vec<String> = block
             .iter()
@@ -477,7 +546,7 @@ mod tests {
         let theme = Theme::default();
         let today = Date::new(2026, 7, 25).unwrap();
         let august = Date::new(2026, 8, 1).unwrap();
-        let block = month_block(august, today, Weekday::Sunday, &theme, true);
+        let block = month_block(august, today, Weekday::Sunday, &theme, true, 7);
 
         assert!(
             !block
@@ -492,7 +561,7 @@ mod tests {
     fn a_monday_week_shifts_the_headings_and_the_blanks() {
         let theme = Theme::default();
         let july = Date::new(2026, 7, 1).unwrap();
-        let block = month_block(july, july, Weekday::Monday, &theme, true);
+        let block = month_block(july, july, Weekday::Monday, &theme, true, 7);
         let header: String = block[1].spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(header, "Mo Tu We Th Fr Sa Su");
 
@@ -592,7 +661,7 @@ mod tests {
 
         for (year, month) in [(2026, 7), (2026, 8), (2026, 9), (2026, 12)] {
             let first = Date::new(year, month, 1).unwrap();
-            let block = month_block(first, july, Weekday::Sunday, &theme, true);
+            let block = month_block(first, july, Weekday::Sunday, &theme, true, 7);
             for (index, line) in block.iter().enumerate() {
                 let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
                 assert_eq!(
@@ -612,7 +681,7 @@ mod tests {
         };
 
         for name in ["July 2026", "August 2026", "September 2026", "May 2026"] {
-            let line = centred(name);
+            let line = centred(name, usize::from(MONTH_WIDTH));
             let leading = line.len() - line.trim_start().len();
             let trailing = line.len() - line.trim_end().len();
             assert_eq!(line.chars().count(), usize::from(MONTH_WIDTH));
@@ -630,6 +699,7 @@ mod tests {
             Weekday::Sunday,
             &theme,
             true,
+            7,
         );
         assert_eq!(text_of(&block[1]), "Su Mo Tu We Th Fr Sa");
     }

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -67,7 +67,7 @@ const BIG_CLOCK_ROWS: u16 = 5 * MAX_CLOCK_SCALE;
 /// time and truncates the marker away — and the marker is the half that carries
 /// the warning, so the column silently dropped the only part of the row a reader
 /// could get wrong. See the note on `day_marker` below.
-const COLUMNS: &[Column] = &[
+pub(crate) const COLUMNS: &[Column] = &[
     Column::flex("zone", 1),
     Column::fixed("time", 12),
     Column::fixed("vs local", 9).right().drops_below(30),

--- a/src/widgets/cpu.rs
+++ b/src/widgets/cpu.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui::text::Span;
 use ratatui::widgets::Paragraph;
 use sysinfo::{CpuRefreshKind, RefreshKind, System};
 
@@ -160,27 +160,46 @@ impl Panel for CpuPanel {
         // The number takes its colour from the same ramp as the graph, so the
         // whole panel changes temperature together.
         let colour = gradient.at(self.current.round() as i64);
+        // Three parts, and the split is where the meaning is. The figure and
+        // its `%` are inseparable — a percentage with the sign cut off is a
+        // different quantity, and the terminal cuts wherever the edge falls.
+        // The word LOAD and the age of the history are both droppable, in that
+        // order: a bare `7.3%` in a panel titled CPU says everything the label
+        // does, where `7.3% LO…` says it worse.
         frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled(
-                    format!("{:>5.1}", self.current),
-                    Style::default().fg(colour).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("% ", Style::default().fg(theme.muted)),
-                Span::styled(
-                    crate::glyphs::utility("load"),
-                    Style::default()
-                        .fg(theme.label)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!(
-                        "   {}s",
-                        self.history.len() as u64 * self.config.sample_secs.max(1)
-                    ),
-                    Style::default().fg(theme.muted),
-                ),
-            ])),
+            Paragraph::new(crate::grid::assemble(
+                vec![
+                    vec![
+                        Span::styled(
+                            // Padded to a fixed field so the figure holds still
+                            // as it changes, and unpadded when the padding is
+                            // the difference between a reading and an
+                            // ellipsis. Same trade as the network readout.
+                            if rows[0].width >= 6 {
+                                format!("{:>5.1}", self.current)
+                            } else {
+                                format!("{:.1}", self.current)
+                            },
+                            Style::default().fg(colour).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled("%", Style::default().fg(theme.muted)),
+                    ],
+                    vec![Span::styled(
+                        format!(" {}", crate::glyphs::utility("load")),
+                        Style::default()
+                            .fg(theme.label)
+                            .add_modifier(Modifier::BOLD),
+                    )],
+                    vec![Span::styled(
+                        format!(
+                            "   {}s",
+                            self.history.len() as u64 * self.config.sample_secs.max(1)
+                        ),
+                        Style::default().fg(theme.muted),
+                    )],
+                ],
+                rows[0].width,
+            )),
             rows[0],
         );
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -169,6 +169,65 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Not a test: renders every panel across a width sweep so clipping can be
+    /// seen rather than reasoned about.
+    /// Run with `cargo test dump_width_sweep -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "renders every panel at many widths for eyeballing, not an assertion"]
+    fn dump_width_sweep() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let dir = std::env::temp_dir().join(format!("mirador-sweep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut config = Config::default();
+        config.todo.file = Some(dir.join("todos.toml"));
+        config.notes.file = Some(dir.join("notes.toml"));
+        config.stocks.file = Some(dir.join("watchlist.toml"));
+        config.weather.latitude = Some(42.36);
+        config.weather.longitude = Some(-71.06);
+
+        for name in WIDGET_NAMES {
+            let mut panel = build(name, &config).unwrap().unwrap();
+            panel.tick();
+            let gradients = config.theme.gradients();
+
+            for width in [12u16, 16, 20, 24, 26, 30, 40] {
+                let mut terminal = Terminal::new(TestBackend::new(width, 12)).unwrap();
+                terminal
+                    .draw(|frame| {
+                        let area = frame.area();
+                        panel.render(
+                            frame,
+                            area,
+                            crate::panel::RenderContext {
+                                theme: &config.theme,
+                                gradients: &gradients,
+                                focused: true,
+                                watch: &crate::watch::WatchLog::default(),
+                            },
+                        );
+                    })
+                    .unwrap();
+                let buf = terminal.backend().buffer().clone();
+                println!("\n=== {name} @ {width} ===");
+                for y in 0..buf.area.height {
+                    let mut line = String::new();
+                    for x in 0..buf.area.width {
+                        line.push_str(buf[(x, y)].symbol());
+                    }
+                    if !line.trim().is_empty() {
+                        println!("|{line}|");
+                    }
+                }
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// Not a test: renders what a brand-new user sees, with nothing on disk,
     /// so the seeded examples can be eyeballed the way they will be met.
     /// Run with `cargo test dump_first_run -- --ignored --nocapture`.

--- a/src/widgets/network.rs
+++ b/src/widgets/network.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui::text::Span;
 use ratatui::widgets::Paragraph;
 use sysinfo::Networks;
 
@@ -232,19 +232,48 @@ impl Panel for NetworkPanel {
         ])
         .split(area);
 
+        // An arrow and the rate it points at are one part, so a pane too narrow
+        // for both readouts loses the upload arrow along with its figure. It
+        // used to keep the arrow and lose the number, which drew `↑` followed
+        // by nothing — a heading over an empty space, which reads as zero
+        // rather than as absent. At a middling width it was worse still: `6.4
+        // KB` survived where `6.4 KB/s` was meant, and a total is not a rate.
+        let rx = format_rate(self.rx_rate);
+        let tx = format_rate(self.tx_rate);
+
+        // The figures are padded to a fixed field so they hold still as they
+        // change — a rate that shifts sideways every second is the restlessness
+        // this dashboard exists not to have. The padding is the first thing
+        // given up, though, because losing the upload reading entirely to keep
+        // the download's right margin is the wrong trade at the widths where
+        // that choice comes up.
+        let padded = 2 + 10 + 5 + 10;
+        let (rx_text, arrow, tx_text) = if usize::from(rows[0].width) >= padded {
+            (format!("{rx:>10}"), "   \u{2191} ", format!("{tx:>10}"))
+        } else {
+            (rx, " \u{2191} ", tx)
+        };
+
         frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled("\u{2193} ", Style::default().fg(rx_color)),
-                Span::styled(
-                    format!("{:>10}", format_rate(self.rx_rate)),
-                    Style::default().fg(rx_color).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("   \u{2191} ", Style::default().fg(tx_color)),
-                Span::styled(
-                    format!("{:>10}", format_rate(self.tx_rate)),
-                    Style::default().fg(tx_color).add_modifier(Modifier::BOLD),
-                ),
-            ])),
+            Paragraph::new(crate::grid::assemble(
+                vec![
+                    vec![
+                        Span::styled("\u{2193} ", Style::default().fg(rx_color)),
+                        Span::styled(
+                            rx_text,
+                            Style::default().fg(rx_color).add_modifier(Modifier::BOLD),
+                        ),
+                    ],
+                    vec![
+                        Span::styled(arrow, Style::default().fg(tx_color)),
+                        Span::styled(
+                            tx_text,
+                            Style::default().fg(tx_color).add_modifier(Modifier::BOLD),
+                        ),
+                    ],
+                ],
+                rows[0].width,
+            )),
             rows[0],
         );
 
@@ -272,24 +301,31 @@ impl Panel for NetworkPanel {
         }
 
         if rows[3].height > 0 {
+            let muted = Style::default().fg(theme.muted);
             frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled(
-                        crate::glyphs::utility("session"),
-                        Style::default()
-                            .fg(theme.label)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        format!(
-                            "  \u{2193} {}  \u{2191} {}   peak {}",
-                            format_bytes(self.rx_total),
-                            format_bytes(self.tx_total),
-                            format_rate(scale)
-                        ),
-                        Style::default().fg(theme.muted),
-                    ),
-                ])),
+                Paragraph::new(crate::grid::assemble(
+                    vec![
+                        vec![Span::styled(
+                            crate::glyphs::utility("session"),
+                            Style::default()
+                                .fg(theme.label)
+                                .add_modifier(Modifier::BOLD),
+                        )],
+                        vec![Span::styled(
+                            format!("  \u{2193} {}", format_bytes(self.rx_total)),
+                            muted,
+                        )],
+                        vec![Span::styled(
+                            format!("  \u{2191} {}", format_bytes(self.tx_total)),
+                            muted,
+                        )],
+                        vec![Span::styled(
+                            format!("   peak {}", format_rate(scale)),
+                            muted,
+                        )],
+                    ],
+                    rows[3].width,
+                )),
                 rows[3],
             );
         }

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -49,7 +49,7 @@ const BINDINGS: &[Binding] = &[
 ];
 
 /// Columns of the note list. The date is right-aligned so the dates line up.
-const COLUMNS: &[Column] = &[
+pub(crate) const COLUMNS: &[Column] = &[
     Column::flex("title", 1),
     Column::fixed("date", 6).right().drops_below(24),
 ];
@@ -525,7 +525,14 @@ impl NotesPanel {
     /// The bottom line: a delete confirmation, the search prompt, or the last
     /// status message. A save failure outranks nothing — it stays until the
     /// next keypress, because a note that failed to save must not look saved.
-    fn status_line(&self, theme: &Theme) -> Line<'static> {
+    /// The status line, cut to `width` with an ellipsis rather than by the
+    /// terminal. See `StocksPanel::status_line`: a note title in a delete
+    /// prompt and a typed search term are both as long as the user made them.
+    fn status_line(&self, theme: &Theme, width: u16) -> Line<'static> {
+        crate::grid::assemble(vec![self.status_text(theme).spans], width)
+    }
+
+    fn status_text(&self, theme: &Theme) -> Line<'static> {
         match (&self.mode, &self.status) {
             (Mode::ConfirmDelete { title, .. }, _) => Line::from(Span::styled(
                 format!("delete \"{title}\"?  y / n"),
@@ -843,7 +850,10 @@ impl Panel for NotesPanel {
         self.detail_area = Some(detail_area);
         self.render_detail(frame, detail_area, theme);
 
-        frame.render_widget(Paragraph::new(self.status_line(theme)), rows[2]);
+        frame.render_widget(
+            Paragraph::new(self.status_line(theme, rows[2].width)),
+            rows[2],
+        );
     }
 
     fn shutdown(&mut self) {

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -471,42 +471,59 @@ impl Panel for PomodoroPanel {
 
         // Pips for the set, and what the two dials are currently set to.
         if cursor < bottom {
-            let mut spans = Vec::new();
+            let mut pips = Vec::new();
             for index in 0..self.config.rounds_before_long_break {
                 let done = index < self.completed;
-                spans.push(Span::styled(
+                pips.push(Span::styled(
                     "■",
                     Style::default().fg(if done { theme.accent } else { theme.track }),
                 ));
-                spans.push(Span::raw(" "));
+                pips.push(Span::raw(" "));
             }
+            let pips_width =
+                usize::try_from(self.config.rounds_before_long_break).unwrap_or(usize::MAX) * 2;
+            let mut parts = vec![pips];
+
             // A broken chime displaces the dial readout rather than sitting
             // beside it: the durations are visible on the timer anyway, and a
             // notification you think is working but is not is the failure worth
             // the space.
             if let Some(error) = &self.chime_error {
-                spans.push(Span::styled(
-                    format!(" chime: {error}"),
+                // Truncated to what is left rather than dropped whole, unlike
+                // everything else on this line. The dials are readable off the
+                // timer, so losing them costs nothing — but this is the only
+                // place a broken chime is reported anywhere in the program, and
+                // a panel narrow enough to drop it is exactly the one where
+                // silence would be permanent.
+                parts.push(vec![Span::styled(
+                    crate::grid::truncate(
+                        &format!(" chime: {error}"),
+                        usize::from(area.width).saturating_sub(pips_width),
+                    ),
                     Style::default().fg(theme.error),
-                ));
+                )]);
             } else {
+                let muted = Style::default().fg(theme.muted);
+                parts.push(vec![Span::styled(
+                    format!(" {}m focus", self.config.focus_minutes),
+                    muted,
+                )]);
+                parts.push(vec![Span::styled(
+                    format!(" · {}m break", self.config.short_break_minutes),
+                    muted,
+                )]);
                 // The pips reset with every long break, so they cannot answer
                 // "how much have I actually done today". This can.
-                let done = if self.total_completed > 0 {
-                    format!(" · {} done", self.total_completed)
-                } else {
-                    String::new()
-                };
-                spans.push(Span::styled(
-                    format!(
-                        " {}m focus · {}m break{done}",
-                        self.config.focus_minutes, self.config.short_break_minutes
-                    ),
-                    Style::default().fg(theme.muted),
-                ));
+                if self.total_completed > 0 {
+                    parts.push(vec![Span::styled(
+                        format!(" · {} done", self.total_completed),
+                        muted,
+                    )]);
+                }
             }
+
             frame.render_widget(
-                Paragraph::new(Line::from(spans)),
+                Paragraph::new(crate::grid::assemble(parts, area.width)),
                 Rect::new(area.x, cursor, area.width, 1),
             );
         }

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -83,7 +83,7 @@ const CHG_MIN_GRID: u16 = CORE_GRID + crate::grid::GUTTER + 9;
 const PCT_MIN_GRID: u16 = CHG_MIN_GRID + crate::grid::GUTTER + 8;
 const SPARK_MIN_GRID: u16 = PCT_MIN_GRID + crate::grid::GUTTER + SPARK_WIDTH;
 
-const COLUMNS: &[Column] = &[
+pub(crate) const COLUMNS: &[Column] = &[
     Column::fixed("symbol", 8).drops_below(8),
     Column::fixed("last", 10).right().drops_below(CORE_GRID),
     Column::fixed("chg", 9).right().drops_below(CHG_MIN_GRID),
@@ -513,7 +513,22 @@ impl StocksPanel {
         ])
     }
 
-    fn status_line(&self, theme: &Theme, board: &Board) -> Line<'static> {
+    /// The status line, cut to `width` with an ellipsis rather than by the
+    /// terminal.
+    ///
+    /// This used to be left at full length on the reasoning that "the
+    /// paragraph clips it to the panel, and the first words carry the useful
+    /// part". The first half of that is true and is the problem: a clip by the
+    /// terminal leaves no mark, so `network access is refused` and `network
+    /// access is refused in tests` look like the same complete sentence. One
+    /// cell of `…` is the whole difference between a message the reader knows
+    /// is abridged and one they do not.
+    fn status_line(&self, theme: &Theme, board: &Board, width: u16) -> Line<'static> {
+        let line = self.status_text(theme, board);
+        crate::grid::assemble(vec![line.spans], width)
+    }
+
+    fn status_text(&self, theme: &Theme, board: &Board) -> Line<'static> {
         match (&self.mode, &self.status) {
             (Mode::ConfirmRemove { symbol }, _) => Line::from(Span::styled(
                 format!("remove {symbol}?  y / n"),
@@ -548,8 +563,6 @@ impl StocksPanel {
                     })
                 });
                 match failure {
-                    // Left full length: the paragraph clips it to the panel,
-                    // and the first words carry the useful part.
                     Some(text) => Line::from(Span::styled(text, Style::default().fg(theme.error))),
                     None => Line::from(Span::styled(
                         format!("via {}", self.source_name),
@@ -783,7 +796,10 @@ impl Panel for StocksPanel {
                 )),
                 rows[1],
             );
-            frame.render_widget(Paragraph::new(self.status_line(theme, &board)), rows[2]);
+            frame.render_widget(
+                Paragraph::new(self.status_line(theme, &board, rows[2].width)),
+                rows[2],
+            );
             return;
         }
 
@@ -824,7 +840,10 @@ impl Panel for StocksPanel {
             });
         frame.render_stateful_widget(list, rows[1], &mut self.list_state);
 
-        frame.render_widget(Paragraph::new(self.status_line(theme, &board)), rows[2]);
+        frame.render_widget(
+            Paragraph::new(self.status_line(theme, &board, rows[2].width)),
+            rows[2],
+        );
     }
 
     fn shutdown(&mut self) {
@@ -1386,7 +1405,7 @@ mod tests {
         let board: Board = vec![("AAPL".into(), failed("HTTP 429"))];
 
         let text: String = p
-            .status_line(&theme, &board)
+            .status_line(&theme, &board, 80)
             .spans
             .iter()
             .map(|s| s.content.as_ref())
@@ -1510,7 +1529,7 @@ mod tests {
         // And it is not passed off as current: the status line says how old it
         // is, and the row is muted rather than coloured by direction.
         let status: String = p
-            .status_line(&theme, &snapshot)
+            .status_line(&theme, &snapshot, 80)
             .spans
             .iter()
             .map(|s| s.content.as_ref())

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -93,7 +93,7 @@ const BINDINGS: &[Binding] = &[
 ///
 /// `done` and `pri` are glyph columns, but they still carry names: without a
 /// header the three-cell gauge is a guess.
-const COLUMNS: &[Column] = &[
+pub(crate) const COLUMNS: &[Column] = &[
     Column::fixed("done", 4),
     Column::fixed("pri", 3),
     Column::flex("task", 1),
@@ -681,52 +681,67 @@ impl TodoPanel {
     }
 
     /// The summary line: how much is open, and how it is sorted.
-    fn header(&self, theme: &Theme) -> Line<'static> {
+    ///
+    /// Assembled in priority order and cut at whole items, so a narrow panel
+    /// loses the sort mode before the overdue count and never shows `4 op`.
+    fn header(&self, theme: &Theme, width: u16) -> Line<'static> {
         let Counts {
             open,
             overdue,
             today,
         } = self.counts;
 
-        let mut spans = Vec::new();
-
         // Lead with whatever is actually wrong. On a calm day this line is
         // short and grey, which is the point: you should be able to tell at a
-        // glance that there is nothing to deal with.
+        // glance that there is nothing to deal with. That ordering is also the
+        // order things are given up in when the panel is narrow, which is the
+        // same judgement read from the other end.
+        let mut items: Vec<(String, Style)> = Vec::new();
         if overdue > 0 {
-            spans.push(Span::styled(
+            items.push((
                 format!("{overdue} overdue"),
                 Style::default()
                     .fg(theme.error)
                     .add_modifier(Modifier::BOLD),
             ));
-            spans.push(Span::styled("   ", Style::default().fg(theme.muted)));
         }
         if today > 0 {
-            spans.push(Span::styled(
+            items.push((
                 format!("{today} due today"),
                 Style::default().fg(theme.warning),
             ));
-            spans.push(Span::styled("   ", Style::default().fg(theme.muted)));
         }
-        spans.push(Span::styled(
-            format!("{open} open"),
-            Style::default().fg(theme.muted),
-        ));
-        spans.push(Span::styled(
-            format!("   by {}", self.sort.label()),
+        items.push((format!("{open} open"), Style::default().fg(theme.muted)));
+        items.push((
+            format!("by {}", self.sort.label()),
             Style::default().fg(theme.muted),
         ));
         if self.show_completed {
-            spans.push(Span::styled("   +done", Style::default().fg(theme.muted)));
+            items.push(("+done".to_string(), Style::default().fg(theme.muted)));
         }
         if !self.filter.is_empty() {
-            spans.push(Span::styled(
-                format!("   /{}", self.filter),
+            items.push((
+                format!("/{}", self.filter),
                 Style::default().fg(theme.accent),
             ));
         }
-        Line::from(spans)
+
+        // The gap belongs to the item it introduces, so dropping the item
+        // takes its gap with it and the line never ends in trailing space.
+        let parts = items
+            .into_iter()
+            .enumerate()
+            .map(|(index, (text, style))| {
+                let text = if index == 0 {
+                    text
+                } else {
+                    format!("   {text}")
+                };
+                vec![Span::styled(text, style)]
+            })
+            .collect();
+
+        crate::grid::assemble(parts, width)
     }
 
     /// Draw the add/edit form as a centred modal.
@@ -1041,7 +1056,7 @@ impl Panel for TodoPanel {
         ])
         .split(area);
 
-        frame.render_widget(Paragraph::new(self.header(theme)), rows[0]);
+        frame.render_widget(Paragraph::new(self.header(theme, rows[0].width)), rows[0]);
 
         // Recorded every pass so a click maps to the rows actually on screen,
         // and cleared when there are none rather than left pointing at a stale

--- a/src/widgets/watchlog.rs
+++ b/src/widgets/watchlog.rs
@@ -147,7 +147,15 @@ impl Panel for WatchLogPanel {
                     format!("{} ", entry.at.strftime("%H:%M")),
                     Style::default().fg(theme.muted),
                 ),
-                Span::styled(entry.text.clone(), Style::default().fg(theme.text)),
+                // Truncated here rather than by the list. An entry is written
+                // by whichever panel reported it — a task title, a calendar
+                // summary — so its length is the user's, not this panel's, and
+                // `Renew the domain went over` reads as a sentence that
+                // happens to end there.
+                Span::styled(
+                    crate::grid::truncate(&entry.text, usize::from(area.width).saturating_sub(6)),
+                    Style::default().fg(theme.text),
+                ),
             ])));
         }
 
@@ -159,17 +167,26 @@ impl Panel for WatchLogPanel {
             // Somebody switched this on, waited, and reasonably concluded it
             // was the latter.
             let width = usize::from(area.width);
-            let mut lines = vec![
-                Line::from(Span::styled(
-                    "Nothing has happened",
-                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
-                )),
-                Line::from(Span::styled(
-                    format!("since {}.", started(log.since())),
-                    Style::default().fg(theme.muted),
-                )),
-                Line::from(""),
-            ];
+            // Wrapped like the explanation below it, rather than trusted to
+            // fit. Hand-broken, the first row lost `happened` in a narrow panel
+            // and the two rows still read as a sentence — `Nothing has` above
+            // `since 00:30.` is a claim with a word missing from the middle,
+            // which is worse than one that takes an extra row.
+            let mut lines: Vec<Line<'static>> = crate::grid::wrap("Nothing has happened", width)
+                .into_iter()
+                .map(|row| {
+                    Line::from(Span::styled(
+                        row,
+                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                    ))
+                })
+                .collect();
+            lines.extend(
+                crate::grid::wrap(&format!("since {}.", started(log.since())), width)
+                    .into_iter()
+                    .map(|row| Line::from(Span::styled(row, Style::default().fg(theme.muted)))),
+            );
+            lines.push(Line::from(""));
 
             // Wrapped rather than hand-broken. The first version assumed a
             // width the panel does not have and lost its last line off the

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -62,7 +62,7 @@ const WIND_MIN: u16 = HOUR_W + SKY_W + TEMP_W + FEELS_W + RAIN_W + WIND_W + 5;
 /// Columns of the hourly forecast.
 ///
 /// Ordered by how often they are wanted, because the narrow ones drop first.
-const COLUMNS: &[Column] = &[
+pub(crate) const COLUMNS: &[Column] = &[
     Column::fixed("hour", HOUR_W),
     Column::flex("sky", 1),
     Column::fixed("temp", TEMP_W).right(),
@@ -910,7 +910,7 @@ impl Panel for WeatherPanel {
                     lines
                 }
                 None => vec![Line::from(Span::styled(
-                    "Fetching weather\u{2026}",
+                    crate::grid::truncate("Fetching weather\u{2026}", usize::from(area.width)),
                     Style::default().fg(theme.muted),
                 ))],
             };
@@ -993,31 +993,47 @@ impl WeatherPanel {
             area
         };
 
+        // Each reading is a part, so a narrow panel loses one whole and keeps
+        // the rest. Joined into one string, the last one was cut by the
+        // terminal instead: `humidity` with its figure gone still reads as a
+        // labelled value, and the label is the half that carries no
+        // information.
+        let width = readings_area.width;
         let mut lines = vec![
-            Line::from(vec![
-                Span::styled(
-                    format!("{:.0}{}", data.temperature, data.temperature_unit),
-                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!("  {}", glyphs::describe(sky)),
-                    Style::default().fg(theme.text),
-                ),
-            ]),
+            crate::grid::assemble(
+                vec![
+                    vec![Span::styled(
+                        format!("{:.0}{}", data.temperature, data.temperature_unit),
+                        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                    )],
+                    vec![Span::styled(
+                        format!("  {}", glyphs::describe(sky)),
+                        Style::default().fg(theme.text),
+                    )],
+                ],
+                width,
+            ),
             Line::from(Span::styled(
-                format!("feels {:.0}{}", data.feels_like, data.temperature_unit),
+                crate::grid::truncate(
+                    &format!("feels {:.0}{}", data.feels_like, data.temperature_unit),
+                    usize::from(width),
+                ),
                 Style::default().fg(theme.muted),
             )),
         ];
 
-        let mut extras = vec![format!("wind {:.0} {}", data.wind, data.wind_unit)];
+        let muted = Style::default().fg(theme.muted);
+        let mut extras = vec![vec![Span::styled(
+            format!("wind {:.0} {}", data.wind, data.wind_unit),
+            muted,
+        )]];
         if let Some(humidity) = data.humidity {
-            extras.push(format!("humidity {humidity}%"));
+            extras.push(vec![Span::styled(
+                format!("   humidity {humidity}%"),
+                muted,
+            )]);
         }
-        lines.push(Line::from(Span::styled(
-            extras.join("   "),
-            Style::default().fg(theme.muted),
-        )));
+        lines.push(crate::grid::assemble(extras, width));
 
         // Amber rather than red: the reading is still the best available, it is
         // simply not fresh. Red is for a panel with nothing to show.


### PR DESCRIPTION
A systematic pass on the clipping class, following the two instances found during the last run (#161, #163).

## What it is

A line built at its natural width and handed to a `Paragraph` is not truncated by mirador — it is truncated by the **terminal**, which keeps the cells that fit and discards the rest in silence. The terminal cannot tell a value from a fragment, so it cuts wherever the edge falls.

Found by rendering every panel across a width sweep rather than by reasoning about it. Nine modules built composite lines by hand; four were cutting values at ordinary terminal sizes:

| what was drawn | what was meant | at |
|---|---|---|
| `↑` | `↑ 6.4 KB/s` | 100 columns |
| `humidity` | `humidity 44%` | 100 columns |
| `25m focus ·` | `25m focus · 5m break` | **the shipped 120** |
| `13 1` | `13 14` | any calendar under 20 cells |

The last is the worst: a date cut in half is still a date. `14` under THU becomes Thursday the 1st, and nothing on screen says otherwise.

## The fix

`grid::assemble` — a line as a list of parts, dropped whole from the end until it fits. A part is anything that means nothing alone: a figure and its unit, an arrow and what it points at. Separators lead the part they introduce, so a dropped part takes its separator with it. A lone over-wide part is ellipsised rather than dropped, so nothing goes blank.

Both status bars were already doing this by hand — one of them measuring bytes instead of cells — and route through it now.

Prose is ellipsised instead: stocks' status line, weather's fetch message, watch-log entries, notes' status line. The agenda and watch-log empty states were hand-broken into two lines and lost a word each in a narrow panel; they wrap now.

`Grid` gains a floor under `drops_below`. Fixed widths are declared without reference to the total, so a pane narrower than their sum built a row wider than the pane it was resolved for. A zero-width column no longer emits its gutter either.

Where a value would be dropped only for its own **padding**, the padding goes first — network and cpu pad so their figures hold still, and give that up rather than the second reading.

## Guards

Three, each verified by breaking it on purpose:

- `no_grid_in_the_program_ever_overflows_its_width` — every declared column set, every width 0–200, header and row.
- `every_grid_in_the_program_is_on_this_list` — counts `const COLUMNS` in the tree so the sweep cannot quietly stop being complete.
- `every_hand_built_composite_line_in_a_widget_is_accounted_for` — counts what is left and makes a new one justify itself.

**A render-level sweep was tried first and cannot work.** A buffer records what the terminal *kept*, so an overflowing line and a line that happens to end there are the same bytes. Overflow has to be caught where the line is built, which makes the call site the only thing there is to count.

## Verification

All four gates silent. 710 tests. Driven in a real terminal under tmux at 100, 72, 56 and 40 columns; `dump_width_sweep` is left in the tree as the probe that found this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)