### PR TITLE
Add a calculator panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,8 +137,9 @@ textfield.rs single-line text editor used by task entry
 textarea.rs  multi-line text editor used by note bodies
 dateinput.rs due-date entry
 ical.rs      enough RFC 5545 to answer "what is next"; no new dependencies
+calc.rs      the calculator's parser: precedence, brackets, bounded depth
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
-             pomodoro, watchlog, news, cpu, network
+             pomodoro, watchlog, news, cpu, network, calculator
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -207,7 +208,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 283 of them, including the ones mirador
+    trip through `toml` discards all 286 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -342,7 +343,15 @@ bottom border; jump key in the title.
 **The four things the dashboard exists to answer:** what time/day is it, what
 tasks are next, what is the portfolio doing, what compute is available.
 
-**The pomodoro panel answers none of them, and is here anyway** — the owner
+**Two panels answer none of them and are here anyway.** The pomodoro was asked
+for directly by the owner; the calculator was suggested by a reader and
+endorsed. Both are recorded rather than left for the next reader to wonder
+whether the filter was forgotten, and the calculator has an argument of its own:
+it is about *reaching* rather than reading. A tab left open all day is a tab you
+reach into for a quick sum, and the alternative is `bc` in a shell you have to
+go and find. It is the first panel with no data source behind it at all.
+
+The pomodoro's own case follows. The owner
 asked for it directly. Worth recording rather than leaving the next reader to
 wonder whether the filter was forgotten. It is arguably a fifth question, "how
 is this stretch of work going", and it is the only panel that is *about* the
@@ -751,9 +760,25 @@ persistence story rests on. The known cost is that panels of unlike natural
 height in one row waste space; the mitigation is that arrange mode makes it
 easy to group like with like.
 
-**The default is four rows of twelve panels**, and the measurement behind it
-still holds: re-checked at 120x40 on 2026-07-30, nothing truncates, every panel
-is legible and no frame title is clipped. The blank space in the clock is
+**The default is four rows of thirteen panels**, re-measured at 120x40 on
+2026-08-01 when the calculator joined it: nothing truncates, every panel is
+legible and no frame title is clipped.
+
+Where the thirteenth went was decided by arithmetic rather than taste, and the
+arithmetic is worth keeping. The instrument row was the obvious home — a
+calculator belongs beside the pomodoro and the graphs — and it is the one row
+that could not take it. A fifth panel there drops `stocks` from 36 cells to 30
+at 120 columns, and it needs 35 to keep the change column that 1.1.2 went to
+some trouble to save; `network` loses its upload rate a little further down the
+same slope. So it sits on the reading row instead, where the two neighbours are
+prose that wraps. **Prose gives way more gracefully than a table does**: a
+narrower paragraph is still the whole paragraph, where a dropped column is a
+fact the reader no longer has.
+
+The knock-on is worth knowing rather than fixing: jump keys only go up to `9`,
+so a thirteenth panel means `pomodoro` joins `cpu` and `network` in having none.
+The dashboard already had more panels than digits; this changes which three are
+past the end. The blank space in the clock is
 inherent to a row sharing its height with weather rather than being waste to
 reclaim. Arrange mode can open, close and now reorder rows, so the row count is a
 gesture rather than a number shipped for everyone.

--- a/README.md
+++ b/README.md
@@ -661,6 +661,38 @@ If that program cannot be started, the panel says so where the durations
 usually sit. A notification you believe is working but is not is worse than
 none at all.
 
+
+### Calculator
+
+Type an expression and press Enter. `2 + 3 * 4` is 14, not 20 — precedence is
+the arithmetic kind, and brackets work — because what this replaces is `bc` or
+`python3 -c`, not a pocket calculator. What you worked out lands on a tape below
+the answer.
+
+| Key | Action |
+| --- | --- |
+| `0`–`9` `.` | Type a number |
+| `+` `-` `*` `/` | Operators; `x` also multiplies |
+| `(` `)` | Group |
+| `Enter` or `=` | Work it out |
+| `Backspace` | Rub out the last character |
+| `Esc` | Clear what is typed, then the answer |
+| `y` | Send the answer to the clipboard |
+| `↑` / `↓` | Scroll the tape |
+
+**While this panel has focus, `1`–`9` type digits instead of jumping to a
+panel.** It is the only panel that changes what a global key does, and it is
+unavoidable — a calculator needs the digits. `Tab` still moves focus, and `q`,
+`?`, `w`, `m` and `t` all still work.
+
+An answer too wide for the panel is shown in scientific notation rather than
+cut. Everywhere else in mirador a value that does not fit reads as a narrow
+terminal; here a number with its tail missing is a different number, and there
+would be nothing on screen to say so.
+
+Nothing is kept when you quit. There is no memory key, no percent key and no
+functions — the tape and chaining an answer into the next sum cover what those
+were for.
 ### CPU and network
 
 CPU shows average load, a moving history graph and a per-core meter row.
@@ -831,6 +863,7 @@ rather than failing quietly.
 | `calendar` | Month grids in the shape `cal` prints, with today marked |
 | `agenda` | What is next, from a local `.ics` file |
 | `pomodoro` | A focus timer: phase, time left, progress, and the set so far |
+| `calculator` | Type a sum, press Enter; a tape of what you worked out |
 | `cpu` | Average utilisation, a moving chart, and per-core meters |
 | `network` | Receive and transmit rates as moving charts |
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -49,8 +49,8 @@ check_for_updates = false
 # The dashboard is a grid of rows. `height` and `width` are relative weights,
 # not cell counts, so the proportions hold at any terminal size.
 #
-# Available widgets: clocks, weather, todo, notes, stocks, calendar, pomodoro,
-# cpu, network
+# Available widgets: clocks, weather, todo, notes, stocks, calendar, agenda,
+# pomodoro, watchlog, news, cpu, network, calculator
 # ---------------------------------------------------------------------------
 [layout]
 rows = [
@@ -72,10 +72,14 @@ rows = [
   # numbers, so they get a row to themselves rather than being squeezed in
   # beside the lists.
   { height = 24, panels = [
-    { widget = "news",     width = 55 },
+    { widget = "news",     width = 48 },
     # What happened while you were not looking. Empty most of the time, which
     # is the point.
-    { widget = "watchlog", width = 45 },
+    { widget = "watchlog", width = 38 },
+    # Type a sum, press Enter. It sits on this row rather than beside the
+    # markets panel because a fifth panel down there would narrow `stocks`
+    # below the width its change column needs.
+    { widget = "calculator", width = 24 },
   ] },
   { height = 18, panels = [
     # The timer draws block numerals when it has the width for them and falls

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -1,0 +1,532 @@
+//! Arithmetic for the calculator panel: parse a typed expression, evaluate it.
+//!
+//! Split from the panel for the same reason `quote::parse_chart` is split from
+//! the HTTP call — the interesting behaviour is in the parsing, and it is worth
+//! testing without building a terminal.
+//!
+//! # Why a parser and not two registers
+//!
+//! A pocket calculator needs no parser: pressing an operator evaluates whatever
+//! came before it, so `2 + 3 * 4` is 20. That is genuinely what a *basic*
+//! calculator does, and it was the other candidate. It lost because of who is
+//! typing: somebody at a terminal who reaches for this instead of `bc` or
+//! `python3 -c` expects `2 + 3 * 4` to be 14, and would read 20 as a bug rather
+//! than as a design. Precedence is not the scientific end of the wedge — memory
+//! keys, percent and functions are, and none of those are here.
+//!
+//! Parentheses come along nearly free once there is a `factor` rule, and their
+//! absence would be the surprising thing in an expression that already honours
+//! precedence.
+//!
+//! # Bounds
+//!
+//! Everything here reads text somebody typed, so the sizes are capped rather
+//! than trusted. That is the lesson from the untrusted-input pass: the interior
+//! arithmetic is usually right, and what is missing is a bound.
+//!
+//! Nesting is bounded **explicitly** rather than by the stack. `(((((…` is one
+//! key held down, and a stack overflow aborts the process — there is no
+//! catching it and no error to show. A depth limit turns that into a message.
+
+/// Longest expression that can be typed.
+///
+/// Far past anything a person writes by hand; it exists so that no later
+/// bound has to reason about unbounded length.
+pub const MAX_LEN: usize = 256;
+
+/// Deepest nesting of parentheses.
+///
+/// Not a stack-depth estimate — a flat refusal well below anything that could
+/// threaten one. Sixteen is more nesting than arithmetic anybody can read.
+const MAX_DEPTH: usize = 16;
+
+/// Significant digits kept when a result is turned into text.
+///
+/// Twelve, because that is what makes binary floating point behave the way a
+/// calculator's user expects: `0.1 + 0.2` is 0.30000000000000004 in an `f64`,
+/// and every person who opens a calculator tries it. Rounding the *display*
+/// rather than the arithmetic is what desk calculators have always done.
+const SIGNIFICANT_DIGITS: usize = 12;
+
+/// Why an expression could not be evaluated.
+///
+/// One short phrase each, written to be shown where the answer would go. They
+/// name what is wrong with the expression rather than where the parser was,
+/// because "unexpected token at 7" is a compiler's kind of honesty and no use
+/// to somebody who just wants the sum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CalcError {
+    Empty,
+    TooLong,
+    TooDeep,
+    UnbalancedParens,
+    /// An operator with nothing after it — the state every half-typed
+    /// expression is in, so it must read as unfinished rather than as broken.
+    Incomplete,
+    DivideByZero,
+    /// A character that means nothing here.
+    Unexpected(char),
+    /// The arithmetic left the range an `f64` can describe.
+    OutOfRange,
+}
+
+impl CalcError {
+    /// The phrase shown in place of the answer.
+    pub fn message(&self) -> String {
+        match self {
+            Self::Empty => "nothing to work out".to_string(),
+            Self::TooLong => format!("too long — {MAX_LEN} characters at most"),
+            Self::TooDeep => "too many brackets".to_string(),
+            Self::UnbalancedParens => "a bracket is unclosed".to_string(),
+            Self::Incomplete => "unfinished".to_string(),
+            Self::DivideByZero => "cannot divide by zero".to_string(),
+            Self::Unexpected(c) => format!("`{c}` means nothing here"),
+            Self::OutOfRange => "the answer is too large".to_string(),
+        }
+    }
+}
+
+/// Evaluate a typed expression.
+pub fn evaluate(text: &str) -> Result<f64, CalcError> {
+    if text.len() > MAX_LEN {
+        return Err(CalcError::TooLong);
+    }
+    if text.trim().is_empty() {
+        return Err(CalcError::Empty);
+    }
+
+    let chars: Vec<char> = text.chars().collect();
+    let mut parser = Parser {
+        chars: &chars,
+        at: 0,
+        depth: 0,
+    };
+    let value = parser.expr()?;
+    parser.skip_spaces();
+    if parser.at < parser.chars.len() {
+        // The only way to be left mid-input with no error is a stray closing
+        // bracket, which the recursive descent has no rule to consume.
+        return Err(match parser.chars[parser.at] {
+            ')' => CalcError::UnbalancedParens,
+            c => CalcError::Unexpected(c),
+        });
+    }
+    if !value.is_finite() {
+        return Err(CalcError::OutOfRange);
+    }
+    Ok(value)
+}
+
+struct Parser<'a> {
+    chars: &'a [char],
+    at: usize,
+    depth: usize,
+}
+
+impl Parser<'_> {
+    fn skip_spaces(&mut self) {
+        while self.chars.get(self.at) == Some(&' ') {
+            self.at += 1;
+        }
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.skip_spaces();
+        self.chars.get(self.at).copied()
+    }
+
+    /// `term (('+' | '-') term)*`
+    fn expr(&mut self) -> Result<f64, CalcError> {
+        let mut value = self.term()?;
+        while let Some(op @ ('+' | '-')) = self.peek() {
+            self.at += 1;
+            let rhs = self.term()?;
+            value = if op == '+' { value + rhs } else { value - rhs };
+        }
+        Ok(value)
+    }
+
+    /// `factor (('*' | '/') factor)*`
+    fn term(&mut self) -> Result<f64, CalcError> {
+        let mut value = self.factor()?;
+        // `x` and `×` are accepted for multiply because both are what people
+        // reach for; `÷` for the same reason. None of them can mean anything
+        // else here.
+        while let Some(op @ ('*' | '/' | 'x' | '\u{00D7}' | '\u{00F7}')) = self.peek() {
+            self.at += 1;
+            let rhs = self.factor()?;
+            if matches!(op, '*' | 'x' | '\u{00D7}') {
+                value *= rhs;
+            } else {
+                if rhs == 0.0 {
+                    return Err(CalcError::DivideByZero);
+                }
+                value /= rhs;
+            }
+        }
+        Ok(value)
+    }
+
+    /// `'-' factor | '+' factor | number | '(' expr ')'`
+    fn factor(&mut self) -> Result<f64, CalcError> {
+        match self.peek() {
+            // Nothing left, or a bracket closing where a value was due. Both
+            // are the same thing to the reader — the sum stops before it says
+            // anything — so they get the same word rather than a taxonomy.
+            None | Some(')') => Err(CalcError::Incomplete),
+            Some('-') => {
+                self.at += 1;
+                Ok(-self.factor()?)
+            }
+            // A leading `+` is meaningless but harmless, and refusing it would
+            // be pedantry aimed at somebody who typed what they meant.
+            Some('+') => {
+                self.at += 1;
+                self.factor()
+            }
+            Some('(') => {
+                self.at += 1;
+                self.depth += 1;
+                if self.depth > MAX_DEPTH {
+                    return Err(CalcError::TooDeep);
+                }
+                let value = self.expr()?;
+                if self.peek() != Some(')') {
+                    return Err(CalcError::UnbalancedParens);
+                }
+                self.at += 1;
+                self.depth -= 1;
+                Ok(value)
+            }
+            Some(c) if c.is_ascii_digit() || c == '.' => self.number(),
+            Some(c) => Err(CalcError::Unexpected(c)),
+        }
+    }
+
+    fn number(&mut self) -> Result<f64, CalcError> {
+        let start = self.at;
+        let mut seen_dot = false;
+        while let Some(&c) = self.chars.get(self.at) {
+            if c.is_ascii_digit() {
+                self.at += 1;
+            } else if c == '.' && !seen_dot {
+                seen_dot = true;
+                self.at += 1;
+            } else {
+                break;
+            }
+        }
+        let text: String = self.chars[start..self.at].iter().collect();
+        // A bare `.` reaches here, and `parse` refuses it. So does a second dot
+        // in the same number, which stops the loop above and is then caught as
+        // an unexpected character by the caller.
+        text.parse::<f64>().map_err(|_| CalcError::Incomplete)
+    }
+}
+
+/// A result as text, at the precision a calculator shows.
+///
+/// Rounded to [`SIGNIFICANT_DIGITS`] and stripped of trailing zeros, so
+/// `0.1 + 0.2` reads `0.3` rather than exposing the binary representation.
+/// Whole numbers keep no decimal point.
+pub fn format_result(value: f64) -> String {
+    if value == 0.0 {
+        // Covers `-0.0`, which `{}` prints as `-0` — an answer nobody wants to
+        // see and which reads as a bug in the arithmetic.
+        return "0".to_string();
+    }
+    if !value.is_finite() {
+        return "—".to_string();
+    }
+
+    let text = format!("{value:.prec$e}", prec = SIGNIFICANT_DIGITS - 1);
+    // Back through `f64` so the rounded value is what gets laid out in decimal;
+    // formatting the original again would reintroduce what was just rounded off.
+    let rounded: f64 = text.parse().unwrap_or(value);
+
+    let mut out = format!("{rounded}");
+    if out.contains('e') {
+        // Rust's `{}` only reaches for an exponent at extremes, and where it
+        // does there is no decimal form worth showing instead.
+        return out;
+    }
+    if out.contains('.') {
+        while out.ends_with('0') {
+            out.pop();
+        }
+        if out.ends_with('.') {
+            out.pop();
+        }
+    }
+    out
+}
+
+/// A result as text, guaranteed to fit `width` cells.
+///
+/// **A calculator is the one panel where a clipped number is unambiguously a
+/// lie.** Everywhere else in mirador a value cut short reads as a narrow
+/// terminal; here `1234567` cut to `12345` is a plausible answer that is not
+/// the one that was worked out, and an ellipsis does not help — `1.2345…`
+/// hides the magnitude, which is the part that was worth knowing.
+///
+/// So this never truncates. When the decimal form will not fit it moves to
+/// scientific notation, which is short, honest about being approximate, and
+/// still says how big the number is. Below the width even that needs, it gives
+/// up and says so rather than showing a digit somebody might read as an answer.
+pub fn fit_result(value: f64, width: usize) -> String {
+    let plain = format_result(value);
+    if plain.chars().count() <= width {
+        return plain;
+    }
+
+    // Drop a significant digit at a time until the exponent form fits. The
+    // exponent itself is not negotiable, so this bottoms out rather than
+    // looping for ever.
+    for digits in (0..=SIGNIFICANT_DIGITS.saturating_sub(1)).rev() {
+        let candidate = format!("{value:.digits$e}");
+        if candidate.chars().count() <= width {
+            return candidate;
+        }
+    }
+    "—".to_string()
+}
+
+// Exact comparison is deliberate here: these are answers, not measurements.
+// A calculator that is approximately right is broken.
+#[allow(clippy::float_cmp)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok(text: &str) -> f64 {
+        evaluate(text).unwrap_or_else(|e| panic!("{text:?} failed: {:?}", e.message()))
+    }
+
+    #[test]
+    fn precedence_is_the_arithmetic_kind() {
+        // The decision the whole module turns on. A pocket calculator gives 20.
+        assert_eq!(ok("2 + 3 * 4"), 14.0);
+        assert_eq!(ok("2 * 3 + 4"), 10.0);
+        assert_eq!(ok("100 - 10 / 2"), 95.0);
+    }
+
+    #[test]
+    fn brackets_override_precedence() {
+        assert_eq!(ok("(2 + 3) * 4"), 20.0);
+        assert_eq!(ok("((1 + 2) * (3 + 4))"), 21.0);
+    }
+
+    #[test]
+    fn the_display_hides_the_binary_representation() {
+        // The first thing anybody types into a new calculator.
+        assert_eq!(format_result(ok("0.1 + 0.2")), "0.3");
+        assert_eq!(format_result(ok("1 / 3")), "0.333333333333");
+        assert_eq!(format_result(ok("2 / 2")), "1");
+        assert_eq!(format_result(ok("10 * 10")), "100");
+    }
+
+    #[test]
+    fn a_negative_zero_is_shown_as_zero() {
+        assert_eq!(format_result(ok("0 * -1")), "0");
+    }
+
+    #[test]
+    fn unary_minus_binds_tighter_than_the_operators() {
+        assert_eq!(ok("-5 + 3"), -2.0);
+        assert_eq!(ok("3 - -5"), 8.0);
+        assert_eq!(ok("-(2 + 3)"), -5.0);
+    }
+
+    #[test]
+    fn the_alternative_operator_glyphs_work() {
+        assert_eq!(ok("6 x 7"), 42.0);
+        assert_eq!(ok("6 \u{00D7} 7"), 42.0);
+        assert_eq!(ok("84 \u{00F7} 2"), 42.0);
+    }
+
+    #[test]
+    fn dividing_by_zero_is_an_error_rather_than_infinity() {
+        assert_eq!(evaluate("1 / 0"), Err(CalcError::DivideByZero));
+        assert_eq!(evaluate("1 / (2 - 2)"), Err(CalcError::DivideByZero));
+    }
+
+    #[test]
+    fn a_half_typed_expression_reads_as_unfinished() {
+        // This is the state the panel is in for most of every keystroke, so it
+        // has to be the gentlest of the errors rather than the loudest.
+        assert_eq!(evaluate("2 +"), Err(CalcError::Incomplete));
+        assert_eq!(evaluate("2 * "), Err(CalcError::Incomplete));
+        assert_eq!(evaluate("(2 + 3"), Err(CalcError::UnbalancedParens));
+    }
+
+    #[test]
+    fn a_stray_closing_bracket_is_refused() {
+        assert_eq!(evaluate("2 + 3)"), Err(CalcError::UnbalancedParens));
+        assert_eq!(evaluate(")"), Err(CalcError::Incomplete));
+    }
+
+    #[test]
+    fn nonsense_names_the_character() {
+        assert_eq!(evaluate("2 & 3"), Err(CalcError::Unexpected('&')));
+        assert!(
+            CalcError::Unexpected('&').message().contains('&'),
+            "the message has to name what was typed"
+        );
+    }
+
+    /// The bound that is not about correctness but about not aborting.
+    ///
+    /// Recursive descent recurses once per bracket, and a stack overflow is an
+    /// abort — no unwinding, no error, no message. `(((((…` is one key held
+    /// down. Checked at a depth far past the limit so this fails by refusing
+    /// rather than by dying.
+    #[test]
+    fn deep_nesting_is_refused_rather_than_overflowing_the_stack() {
+        let deep = format!("{}1{}", "(".repeat(120), ")".repeat(120));
+        assert_eq!(evaluate(&deep), Err(CalcError::TooDeep));
+
+        // And the limit is generous enough that nothing real reaches it.
+        let ordinary = format!("{}1{}", "(".repeat(8), ")".repeat(8));
+        assert_eq!(ok(&ordinary), 1.0);
+    }
+
+    #[test]
+    fn an_over_long_expression_is_refused_by_length() {
+        let long = "1+".repeat(MAX_LEN);
+        assert_eq!(evaluate(&long), Err(CalcError::TooLong));
+    }
+
+    /// `OutOfRange` cannot be reached by typing, and the guard stays anyway.
+    ///
+    /// Worth recording rather than leaving to be rediscovered: within
+    /// [`MAX_LEN`] there is no expression that overflows an `f64`. The largest
+    /// magnitude 256 characters can express is about 1e252 — 126 two-digit
+    /// numbers multiplied together — against an `f64`'s ceiling near 1e308, and
+    /// `e` notation is not part of the input language so no literal shortcut
+    /// exists. Division cannot get there either: the smallest divisor that fits
+    /// is around 1e-250.
+    ///
+    /// The check in `evaluate` is therefore latent, and kept for the same
+    /// reason as the capacity-zero guard in `samples`: it costs a line, and the
+    /// bound it depends on is a constant somebody may raise. What *is* testable
+    /// is that the formatting never prints `inf` if it ever does arrive.
+    #[test]
+    fn a_non_finite_result_is_never_printed_as_a_number() {
+        assert_eq!(format_result(f64::INFINITY), "\u{2014}");
+        assert_eq!(format_result(f64::NEG_INFINITY), "\u{2014}");
+        assert_eq!(format_result(f64::NAN), "\u{2014}");
+
+        // And the length bound is what makes the above unreachable in practice,
+        // so it is pinned here rather than only in prose.
+        let widest = "99 * ".repeat(50) + "99";
+        assert!(widest.len() <= MAX_LEN);
+        assert!(
+            evaluate(&widest).is_ok_and(f64::is_finite),
+            "the longest product that fits must still be a finite number"
+        );
+    }
+
+    /// The rule this panel exists under: never show a number that is not the
+    /// answer.
+    #[test]
+    fn a_result_too_wide_goes_scientific_rather_than_being_cut() {
+        let value = 123_456_789_012.0;
+        let plain = format_result(value);
+        assert!(
+            plain.chars().count() > 8,
+            "the fixture must not already fit"
+        );
+
+        let fitted = fit_result(value, 8);
+        assert!(
+            fitted.chars().count() <= 8,
+            "{fitted:?} does not fit in 8 cells"
+        );
+        assert!(
+            fitted.contains('e'),
+            "a number that will not fit must become scientific, not truncated; got {fitted:?}"
+        );
+        assert!(
+            !fitted.starts_with("1234"),
+            "{fitted:?} is a prefix of the real answer, which reads as a different number"
+        );
+    }
+
+    #[test]
+    fn a_result_that_fits_is_left_alone() {
+        assert_eq!(fit_result(42.0, 20), "42");
+        assert_eq!(fit_result(0.3, 20), "0.3");
+    }
+
+    /// Below the width even an exponent needs, there is no honest digit to show.
+    #[test]
+    fn an_impossible_width_gives_up_rather_than_lying() {
+        let out = fit_result(123_456_789_012.0, 2);
+        assert!(
+            !out.chars().next().is_some_and(|c| c.is_ascii_digit()),
+            "{out:?} starts with a digit, which reads as an answer"
+        );
+    }
+
+    /// Generated input, in the shape the untrusted-input pass established:
+    /// fragments chosen because of what the parser does with them, not sampled
+    /// from all possible bytes.
+    #[test]
+    fn generated_expressions_never_panic_or_hang() {
+        const PIECES: &[&str] = &[
+            "1",
+            "0",
+            ".",
+            "..",
+            "+",
+            "-",
+            "*",
+            "/",
+            "(",
+            ")",
+            " ",
+            "x",
+            "\u{00D7}",
+            "\u{00F7}",
+            "99999999",
+            "0.0000001",
+            "&",
+            "\u{65E5}",
+            "\u{1F31E}",
+            "\u{0301}",
+            "e",
+            "--",
+            "()",
+        ];
+        let mut seed = 12_345u64;
+        for _ in 0..20_000 {
+            let mut text = String::new();
+            // A deterministic shuffle: the corpus is the point, not the source
+            // of randomness, and a fixed seed keeps a failure reproducible.
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            let count = (seed >> 33) as usize % 12;
+            for i in 0..count {
+                seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+                text.push_str(PIECES[(seed >> 33) as usize % PIECES.len()]);
+                let _ = i;
+            }
+            // The contract is only that it returns. Whether it returns a value
+            // or an error is the parser's business.
+            if let Ok(value) = evaluate(&text) {
+                assert!(
+                    value.is_finite(),
+                    "{text:?} evaluated to {value}, which should have been an error"
+                );
+                // Formatting must survive whatever evaluation produced.
+                let _ = format_result(value);
+                for width in [0usize, 1, 3, 8, 40] {
+                    let fitted = fit_result(value, width);
+                    assert!(
+                        fitted.chars().count() <= width.max(1),
+                        "{text:?} at width {width} produced {fitted:?}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -43,7 +43,14 @@ impl Default for Layout {
                 // than columns of numbers, which is why they get a row instead
                 // of being squeezed in beside the lists — and why the default
                 // is four rows now rather than three.
-                row(24, &[("news", 55), ("watchlog", 45)]),
+                // The calculator sits here rather than on the instrument row
+                // below, and the reason is arithmetic rather than taste: a
+                // fifth panel in that row takes `stocks` from 36 cells to 30 at
+                // 120 columns, and it needs 35 to keep the change column that
+                // 1.1.2 went to some trouble to save. Prose gives way more
+                // gracefully than a table does — these two wrap, where a
+                // dropped column is a fact the reader no longer has.
+                row(24, &[("news", 48), ("watchlog", 38), ("calculator", 24)]),
                 row(
                     18,
                     &[

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,8 +45,9 @@ mod widgets;
 pub use layout::{Layout, LayoutPanel, LayoutRow};
 #[allow(unused_imports)]
 pub use widgets::{
-    AgendaConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig, NetworkConfig, NewsConfig,
-    NewsFeed, NotesConfig, PomodoroConfig, StocksConfig, TodoConfig, WeatherConfig,
+    AgendaConfig, CalculatorConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig,
+    NetworkConfig, NewsConfig, NewsFeed, NotesConfig, PomodoroConfig, StocksConfig, TodoConfig,
+    WeatherConfig,
 };
 
 /// Top-level configuration.
@@ -72,6 +73,7 @@ pub struct Config {
     pub calendar: CalendarConfig,
     pub news: NewsConfig,
     pub pomodoro: PomodoroConfig,
+    pub calculator: CalculatorConfig,
     pub cpu: CpuConfig,
     pub network: NetworkConfig,
 }

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -253,6 +253,17 @@ impl Default for CalendarConfig {
     }
 }
 
+/// Calculator settings.
+///
+/// Empty on purpose. Every key in this file is a promise that outlives the
+/// release it ships in — removing or renaming one costs a major version now —
+/// and no setting here has earned that yet. Thousands separators is the only
+/// candidate, and it can wait until somebody asks. Adding a key later is not a
+/// breaking change; taking one back is.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct CalculatorConfig {}
+
 /// Pomodoro timer settings.
 ///
 /// These are the *starting* values. `+` and `-` change the timer in the panel,

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 283;
+        const CITED: usize = 286;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 mod app;
 mod arrange;
+mod calc;
 mod chart;
 mod clipboard;
 mod config;

--- a/src/widgets/calculator.rs
+++ b/src/widgets/calculator.rs
@@ -1,0 +1,897 @@
+//! A calculator: type an expression, press Enter, get the answer.
+//!
+//! The arithmetic lives in [`crate::calc`]; this is the instrument around it.
+//!
+//! # Why this panel exists
+//!
+//! It answers none of the four questions the dashboard was built for, which is
+//! the same thing that is true of the pomodoro timer. Both are here because
+//! they were asked for — this one by a reader, and endorsed. Recorded so the
+//! next person does not conclude the filter was forgotten.
+//!
+//! There is an argument for it beyond that, and it is about *reaching* rather
+//! than reading. mirador's whole premise is a tab left open all day; the thing
+//! you actually reach for during that day is a quick sum, and the alternative
+//! is `bc` or `python3 -c` in a shell you have to go and find. This is the
+//! first panel that is purely an instrument, with no data source behind it at
+//! all.
+//!
+//! # The input problem, and why `captures_input` stays false
+//!
+//! A calculator needs the digits, and `1`–`9` are the shell's jump-to-panel
+//! keys. The obvious fix is [`Panel::captures_input`], and it is a trap: that
+//! is an *absolute* veto (invariant 2), meant for transient modal states like
+//! typing a task title. A panel that captured permanently would kill `Tab`,
+//! `q` and `?` for as long as it held focus — a room with no door.
+//!
+//! It is not needed. `App::dispatch_key` offers every key to the focused panel
+//! *first* and consults the global table only if the panel returns `Ignored`.
+//! So this panel consumes what it needs and ignores the rest, and every global
+//! key except the digits keeps working.
+//!
+//! The price, stated plainly because it is a real one: **while this panel is
+//! focused, `1`–`9` type digits instead of jumping to panels.** `Tab` still
+//! cycles, which is the way out.
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+
+use crate::calc::{self, CalcError};
+use crate::config::CalculatorConfig;
+use crate::frame::{Binding, FRAME_HEIGHT, FRAME_WIDTH};
+use crate::glyphs::{self, BigText};
+use crate::grid::display_width;
+use crate::panel::{KeyOutcome, Panel, RenderContext};
+
+const BINDINGS: &[Binding] = &[
+    Binding::primary("0-9 + - * /", "type"),
+    Binding::primary("Enter", "work it out"),
+    Binding::primary("y", "copy"),
+    Binding::extra("( )", "group"),
+    Binding::extra("Backspace", "rub out"),
+    Binding::extra("Esc", "clear"),
+    Binding::extra("↑ / ↓", "scroll the tape"),
+    Binding::extra("x", "multiply"),
+];
+
+/// Numerals are never drawn larger than this.
+///
+/// One, for the reason the pomodoro's is one: a result occupying half a
+/// dashboard reads as an alarm. It also keeps `max_width` small enough to be
+/// worth declaring.
+const MAX_SCALE: u16 = 1;
+
+/// Entries kept on the tape.
+///
+/// A bound rather than a target — the tape shows what fits, and this only stops
+/// a long session growing without limit. Nothing reads past what is drawn.
+const MAX_TAPE: usize = 200;
+
+/// Interior width past which the panel gains nothing.
+///
+/// An expression, a result and a tape line all fit comfortably; wider only buys
+/// whitespace, and taking room the task list could use would be worse. See
+/// invariant 15.
+const USEFUL_WIDTH: u16 = 44;
+
+/// Rows the panel needs besides the numerals: the expression line above, and
+/// one tape row below.
+const EXPRESSION_AND_TAPE: u16 = 2;
+
+/// One finished calculation.
+#[derive(Debug, Clone, PartialEq)]
+struct Entry {
+    expression: String,
+    result: f64,
+}
+
+/// What is on the display right now.
+#[derive(Debug, Clone, PartialEq)]
+enum Shown {
+    /// Nothing worked out yet this session.
+    Nothing,
+    /// The answer to the expression on the tape.
+    Answer(f64),
+    /// Why the last attempt did not work.
+    Failed(CalcError),
+}
+
+pub struct CalculatorPanel {
+    #[allow(dead_code)]
+    config: CalculatorConfig,
+    /// What is being typed.
+    typing: String,
+    shown: Shown,
+    /// Finished calculations, newest first.
+    tape: Vec<Entry>,
+    scroll: ListState,
+    /// Tape rows drawn last frame, so scrolling cannot leave what is on screen.
+    drawn: usize,
+    /// What the last `y` did. Cleared by the next keystroke.
+    ///
+    /// OSC 52 is write-only, so this says what was *sent* rather than claiming
+    /// the clipboard changed — the same honesty the news panel's copy uses.
+    action: Option<String>,
+}
+
+impl std::fmt::Debug for CalculatorPanel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CalculatorPanel")
+            .field("typing", &self.typing)
+            .field("shown", &self.shown)
+            .field("tape", &self.tape.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CalculatorPanel {
+    pub fn new(config: CalculatorConfig) -> Self {
+        Self {
+            config,
+            typing: String::new(),
+            shown: Shown::Nothing,
+            tape: Vec::new(),
+            scroll: ListState::default(),
+            drawn: 0,
+            action: None,
+        }
+    }
+
+    /// The answer currently on display, if there is one.
+    fn answer(&self) -> Option<f64> {
+        match self.shown {
+            Shown::Answer(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Add a character to the expression being typed.
+    ///
+    /// An operator typed straight after an answer continues from it — `57`,
+    /// then `+10`, reads as `57 + 10`. A digit starts fresh instead. That is
+    /// how a desk calculator chains, and it is what removes the need for a
+    /// memory key: "and now add the tax" costs no extra concept.
+    fn push(&mut self, c: char) {
+        if self.typing.is_empty()
+            && let Some(value) = self.answer()
+            && matches!(c, '+' | '-' | '*' | '/' | 'x' | '\u{00D7}' | '\u{00F7}')
+        {
+            self.typing = calc::format_result(value);
+        }
+        // Refused rather than silently dropped: past this the expression cannot
+        // be evaluated anyway, and a key that does nothing with no explanation
+        // reads as a stuck terminal.
+        if self.typing.chars().count() >= calc::MAX_LEN {
+            self.shown = Shown::Failed(CalcError::TooLong);
+            return;
+        }
+        self.typing.push(c);
+    }
+
+    fn evaluate(&mut self) {
+        match calc::evaluate(&self.typing) {
+            Ok(value) => {
+                let expression = self.typing.trim().to_string();
+                self.tape.insert(
+                    0,
+                    Entry {
+                        expression,
+                        result: value,
+                    },
+                );
+                self.tape.truncate(MAX_TAPE);
+                self.shown = Shown::Answer(value);
+                self.typing.clear();
+                // A new entry belongs at the top of the tape, and the cursor
+                // with it; leaving it where it was would scroll the newest
+                // result off the moment it arrived.
+                self.scroll.select(None);
+            }
+            Err(error) => self.shown = Shown::Failed(error),
+        }
+    }
+
+    /// The line above the numerals: what is being typed, or what went wrong.
+    fn expression_line(&self, theme: &crate::theme::Theme) -> (String, Color) {
+        if let Some(action) = &self.action {
+            return (action.clone(), theme.label);
+        }
+        if !self.typing.is_empty() {
+            return (self.typing.clone(), theme.text);
+        }
+        match &self.shown {
+            // Never blank: a panel showing nothing at all reads as broken
+            // rather than as idle (invariant 11).
+            Shown::Nothing => ("type a sum".to_string(), theme.muted),
+            Shown::Failed(error) => (error.message(), theme.error),
+            Shown::Answer(_) => (
+                self.tape
+                    .first()
+                    .map_or_else(String::new, |entry| entry.expression.clone()),
+                theme.muted,
+            ),
+        }
+    }
+
+    /// What fills the display area, and whether it is a number.
+    ///
+    /// The distinction matters because only a number is drawn in block
+    /// numerals. Two bugs came out of not making it, and both were found by
+    /// running the thing rather than by any test:
+    ///
+    /// - `glyphs` has no glyph for `–`, and an unknown character renders as a
+    ///   *blank cell* rather than as anything visible. So an idle calculator
+    ///   drew five empty rows, which reads as a broken panel.
+    /// - A failed sum kept its text on the line above so it could be corrected,
+    ///   and the error message was written to that same line — where the text
+    ///   took priority. The message was unreachable, so `1/0` looked like a key
+    ///   that did nothing.
+    ///
+    /// Putting the reason in the display area fixes both at once, and it is the
+    /// better arrangement anyway: the expression stays where it is being edited
+    /// and the large empty space says what went wrong.
+    fn display(&self, width: u16) -> (String, bool) {
+        match &self.shown {
+            Shown::Answer(value) => (calc::fit_result(*value, usize::from(width)), true),
+            Shown::Failed(error) => (error.message(), false),
+            // A dash rather than a zero. Zero is an answer, and nothing has
+            // been asked yet — the same reason the markets panel shows `–`
+            // rather than a price it has not got.
+            Shown::Nothing => ("\u{2013}".to_string(), false),
+        }
+    }
+}
+
+impl Panel for CalculatorPanel {
+    fn title(&self) -> String {
+        "Calculator".to_string()
+    }
+
+    /// Deliberately `None`.
+    ///
+    /// A count of tape entries is a badge, and a badge that only goes up is the
+    /// unread counter this dashboard turned down. Nothing here accumulates that
+    /// you are expected to deal with.
+    fn counter(&self) -> Option<String> {
+        None
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn max_width(&self) -> Option<u16> {
+        Some(USEFUL_WIDTH + FRAME_WIDTH)
+    }
+
+    /// Deliberately `None`: the tape is content, and rows are what it is made
+    /// of. Same reasoning as the watch log.
+    fn max_height(&self) -> Option<u16> {
+        None
+    }
+
+    /// Nothing here changes on its own.
+    ///
+    /// The tick exists for panels with a data source behind them, and this one
+    /// has none — it moves only when a key is pressed. Reporting `false`
+    /// unconditionally is what keeps an idle dashboard from repainting for it.
+    fn tick(&mut self) -> bool {
+        false
+    }
+
+    /// Never. See the module header: this panel gets the keys it needs by
+    /// consuming them, not by vetoing the shell.
+    fn captures_input(&self) -> bool {
+        false
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        // Ctrl and Alt belong to the shell — Ctrl+arrows resize, Ctrl+C quits.
+        if key.modifiers.contains(KeyModifiers::CONTROL)
+            || key.modifiers.contains(KeyModifiers::ALT)
+        {
+            return KeyOutcome::Ignored;
+        }
+
+        // Any key retires the copy notice; it has been read or it has not.
+        let had_action = self.action.take().is_some();
+
+        match key.code {
+            KeyCode::Char(
+                c @ ('0'..='9'
+                | '.'
+                | '+'
+                | '-'
+                | '*'
+                | '/'
+                | '('
+                | ')'
+                | 'x'
+                | '\u{00D7}'
+                | '\u{00F7}'),
+            ) => self.push(c),
+            KeyCode::Char('=') | KeyCode::Enter => self.evaluate(),
+            KeyCode::Backspace => {
+                // With nothing typed, this clears the answer rather than doing
+                // nothing — the display is the only thing left to rub out.
+                if self.typing.pop().is_none() {
+                    self.shown = Shown::Nothing;
+                }
+            }
+            KeyCode::Esc => {
+                // Esc backs out of something everywhere in this program. Here
+                // there are two things to back out of, innermost first: what is
+                // half-typed, then the answer. It is consumed only while there
+                // is something to clear, so Esc on an empty calculator falls
+                // through to the shell like Esc anywhere else.
+                if !self.typing.is_empty() {
+                    self.typing.clear();
+                } else if self.shown != Shown::Nothing {
+                    self.shown = Shown::Nothing;
+                } else if !had_action {
+                    return KeyOutcome::Ignored;
+                }
+            }
+            KeyCode::Char('y') => {
+                let Some(value) = self.answer() else {
+                    return KeyOutcome::Consumed;
+                };
+                let text = calc::format_result(value);
+                self.action = Some(match crate::clipboard::copy(&text) {
+                    // OSC 52 is write-only: the terminal never answers, so this
+                    // says what was sent rather than that anything was copied.
+                    Ok(()) => format!("sent {text} to the clipboard"),
+                    Err(e) => format!("clipboard failed: {e}"),
+                });
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                crate::selection::down(&mut self.scroll, 1, self.drawn);
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                crate::selection::up(&mut self.scroll, 1, self.drawn);
+            }
+            _ => {
+                // A key this panel does not want goes to the shell — unless it
+                // only served to retire the copy notice, which is a visible
+                // change and so counts as having been used.
+                if had_action {
+                    return KeyOutcome::Consumed;
+                }
+                return KeyOutcome::Ignored;
+            }
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> KeyOutcome {
+        match event.kind {
+            MouseEventKind::ScrollDown => crate::selection::down(&mut self.scroll, 1, self.drawn),
+            MouseEventKind::ScrollUp => crate::selection::up(&mut self.scroll, 1, self.drawn),
+            _ => return KeyOutcome::Ignored,
+        }
+        KeyOutcome::Consumed
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        if area.width == 0 || area.height == 0 {
+            self.drawn = 0;
+            return;
+        }
+        let theme = ctx.theme;
+
+        // What the display will say, decided before anything is laid out: the
+        // numerals are sized to the text, so the text has to exist first.
+        let (text, is_number) = self.display(area.width);
+        let colour = match self.shown {
+            Shown::Failed(_) => theme.error,
+            _ => theme.accent,
+        };
+
+        // Only a number is drawn in block numerals. Anything else — a reason,
+        // a resting dash — goes as plain text, because `glyphs` renders a
+        // character it does not know as a blank cell rather than as a
+        // substitute, so an error in numerals is an error nobody can read.
+        //
+        // The numerals give way before the expression line does. They are the
+        // decoration; the line above says what is being worked out, and losing
+        // that leaves a number with no question attached to it.
+        let scale = is_number
+            .then(|| {
+                glyphs::fitting_scale(
+                    &text,
+                    area.width,
+                    area.height.saturating_sub(EXPRESSION_AND_TAPE).max(1),
+                    MAX_SCALE,
+                )
+            })
+            .flatten();
+        let numeral_rows = scale.map_or(1, |s| BigText::new(&text, s).height);
+
+        let bottom = area.y + area.height;
+        let mut cursor = area.y;
+
+        // The expression, or the error, or what the last copy did.
+        if cursor < bottom {
+            let (line, line_colour) = self.expression_line(theme);
+            frame.render_widget(
+                Paragraph::new(Span::styled(
+                    crate::grid::truncate(&line, usize::from(area.width)),
+                    Style::default().fg(line_colour),
+                )),
+                Rect::new(area.x, cursor, area.width, 1),
+            );
+            cursor += 1;
+        }
+
+        // The answer.
+        if let Some(scale) = scale {
+            let big = BigText::new(&text, scale);
+            let x = area.x + area.width.saturating_sub(big.width) / 2;
+            for (index, row) in big.rows.iter().enumerate() {
+                let y = cursor + u16::try_from(index).unwrap_or(0);
+                if y >= bottom {
+                    break;
+                }
+                frame.render_widget(
+                    Paragraph::new(Span::styled(row.clone(), Style::default().fg(colour))),
+                    Rect::new(x, y, big.width.min(area.width), 1),
+                );
+            }
+            cursor += numeral_rows;
+        } else if cursor < bottom {
+            // Everything the numerals cannot take: an answer too long for them,
+            // a reason a sum failed, the resting dash. Wrapped rather than cut,
+            // since a reason is prose and half a reason is no use — and wrapped
+            // here rather than by ratatui, which panics on text it was not
+            // given by this program (see `grid::wrapped`).
+            //
+            // Centred line by line so a one-line answer still sits under the
+            // expression the way the numerals would.
+            let rows = crate::grid::wrap(&text, usize::from(area.width));
+            let style = Style::default().fg(colour).add_modifier(Modifier::BOLD);
+            for row in rows {
+                if cursor >= bottom {
+                    break;
+                }
+                let width = u16::try_from(display_width(&row)).unwrap_or(area.width);
+                let x = area.x + area.width.saturating_sub(width) / 2;
+                frame.render_widget(
+                    Paragraph::new(Span::styled(row, style)),
+                    Rect::new(x, cursor, width.min(area.width), 1),
+                );
+                cursor += 1;
+            }
+        }
+
+        self.draw_tape(frame, area, cursor, bottom, theme);
+    }
+}
+
+impl CalculatorPanel {
+    /// The tape, filling whatever is left below the display.
+    ///
+    /// Rows are built only for the space there is, never for the whole buffer:
+    /// a panel may allocate in proportion to what is on screen, and must not
+    /// allocate in proportion to how much data it holds.
+    fn draw_tape(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        cursor: u16,
+        bottom: u16,
+        theme: &crate::theme::Theme,
+    ) {
+        let room = bottom.saturating_sub(cursor);
+        self.drawn = usize::from(room).min(self.tape.len());
+        if room == 0 || self.tape.is_empty() {
+            if room > 0 {
+                self.drawn = 0;
+            }
+            return;
+        }
+
+        let width = usize::from(area.width);
+        let items: Vec<ListItem> = self
+            .tape
+            .iter()
+            .take(self.drawn)
+            .map(|entry| {
+                // The rule that governs the display governs the tape too, and
+                // it is easier to break here. Composing `expr = result` and
+                // trimming the whole line cut the *result* — a tape row reading
+                // ` = 123456789` for an answer of 123456789000, which is the
+                // exact lie this panel exists not to tell. So the answer is
+                // fitted first and never cut, and the expression takes what is
+                // left over.
+                const SEP: &str = " = ";
+                let sep_width = display_width(SEP);
+                let result = calc::fit_result(entry.result, width);
+                let used = display_width(&result);
+
+                let line = if used + sep_width < width {
+                    let expression =
+                        crate::grid::truncate(&entry.expression, width - used - sep_width);
+                    if expression.is_empty() {
+                        result
+                    } else {
+                        format!("{expression}{SEP}{result}")
+                    }
+                } else {
+                    // No room for both. The answer is why the tape is here.
+                    result
+                };
+                ListItem::new(Span::styled(line, Style::default().fg(theme.muted)))
+            })
+            .collect();
+
+        frame.render_stateful_widget(
+            List::new(items).highlight_style(Style::default().fg(theme.text)),
+            Rect::new(area.x, cursor, area.width, room),
+            &mut self.scroll,
+        );
+    }
+}
+
+/// Rows the frame costs, named so `max_height`'s reasoning is checkable.
+#[allow(dead_code)]
+const _: u16 = FRAME_HEIGHT;
+
+// Exact comparison is the point: these are answers a calculator must get
+// exactly right, not measurements to be compared within a tolerance. `2 + 3 * 4`
+// is 14 or the panel is broken.
+#[allow(clippy::float_cmp)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn new_panel() -> CalculatorPanel {
+        CalculatorPanel::new(CalculatorConfig::default())
+    }
+
+    fn press(panel: &mut CalculatorPanel, c: char) -> KeyOutcome {
+        panel.handle_key(KeyEvent::from(KeyCode::Char(c)))
+    }
+
+    fn type_in(panel: &mut CalculatorPanel, text: &str) {
+        for c in text.chars() {
+            press(panel, c);
+        }
+    }
+
+    fn draw(panel: &mut CalculatorPanel, width: u16, height: u16) -> String {
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| {
+                panel.render(
+                    frame,
+                    frame.area(),
+                    RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The whole input design in one test.
+    ///
+    /// Digits must reach the calculator, and everything the shell owns must
+    /// still reach the shell. Get the first half wrong and the panel is
+    /// useless; get the second half wrong and it is a room with no door — no
+    /// `Tab` to leave by, no `q` to quit with, no `?` for help.
+    #[test]
+    fn digits_are_taken_and_the_shell_keys_are_left_alone() {
+        let mut panel = new_panel();
+        for c in "0123456789.+-*/()x".chars() {
+            assert_eq!(
+                press(&mut panel, c),
+                KeyOutcome::Consumed,
+                "{c:?} has to reach the calculator"
+            );
+        }
+
+        let mut panel = new_panel();
+        for code in [
+            KeyCode::Tab,
+            KeyCode::BackTab,
+            KeyCode::Char('q'),
+            KeyCode::Char('?'),
+            KeyCode::Char('w'),
+            KeyCode::Char('t'),
+            KeyCode::Char('m'),
+        ] {
+            assert_eq!(
+                panel.handle_key(KeyEvent::from(code)),
+                KeyOutcome::Ignored,
+                "{code:?} belongs to the shell; consuming it locks the user in"
+            );
+        }
+        assert!(
+            !panel.captures_input(),
+            "capturing input would veto every global key, which is the trap this design avoids"
+        );
+    }
+
+    #[test]
+    fn typing_a_sum_and_pressing_enter_works_it_out() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "2+3*4");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(panel.answer(), Some(14.0));
+        assert_eq!(panel.tape.len(), 1);
+        assert_eq!(panel.tape[0].expression, "2+3*4");
+        assert!(panel.typing.is_empty(), "the line clears for the next sum");
+    }
+
+    /// Chaining, which is what removes the need for a memory key.
+    #[test]
+    fn an_operator_after_an_answer_carries_it_forward() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "50+7");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        press(&mut panel, '+');
+        assert_eq!(panel.typing, "57+");
+        type_in(&mut panel, "10");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(panel.answer(), Some(67.0));
+    }
+
+    #[test]
+    fn a_digit_after_an_answer_starts_over() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "50+7");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        press(&mut panel, '9');
+        assert_eq!(
+            panel.typing, "9",
+            "a digit begins a new sum, not a longer one"
+        );
+    }
+
+    #[test]
+    fn a_failed_sum_says_why_and_keeps_what_was_typed() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "1/0");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        assert!(matches!(
+            panel.shown,
+            Shown::Failed(CalcError::DivideByZero)
+        ));
+        assert_eq!(
+            panel.typing, "1/0",
+            "a rejected sum must stay on the line so it can be corrected"
+        );
+        assert!(
+            panel.tape.is_empty(),
+            "nothing that failed reaches the tape"
+        );
+    }
+
+    #[test]
+    fn esc_clears_what_is_typed_then_the_answer_then_gives_up_the_key() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "12+3");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        type_in(&mut panel, "99");
+
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Esc)),
+            KeyOutcome::Consumed
+        );
+        assert!(panel.typing.is_empty());
+
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Esc)),
+            KeyOutcome::Consumed
+        );
+        assert_eq!(panel.shown, Shown::Nothing);
+
+        // With nothing left to clear, Esc means what it means everywhere else.
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Esc)),
+            KeyOutcome::Ignored
+        );
+    }
+
+    #[test]
+    fn the_tape_is_bounded() {
+        let mut panel = new_panel();
+        for n in 0..MAX_TAPE + 50 {
+            panel.typing = format!("{n}+1");
+            panel.evaluate();
+        }
+        assert_eq!(panel.tape.len(), MAX_TAPE);
+        assert_eq!(
+            panel.tape[0].expression,
+            format!("{}+1", MAX_TAPE + 49),
+            "newest first"
+        );
+    }
+
+    #[test]
+    fn an_over_long_expression_is_refused_rather_than_swallowed() {
+        let mut panel = new_panel();
+        for _ in 0..calc::MAX_LEN + 20 {
+            press(&mut panel, '1');
+        }
+        assert_eq!(panel.typing.chars().count(), calc::MAX_LEN);
+        assert!(
+            matches!(panel.shown, Shown::Failed(CalcError::TooLong)),
+            "a key that does nothing with no explanation reads as a stuck terminal"
+        );
+    }
+
+    /// The rule this panel is held to more strictly than any other.
+    ///
+    /// Everywhere else in mirador a clipped value reads as a narrow terminal.
+    /// Here it reads as a different answer, because a prefix of a number is a
+    /// number. Checked on screen rather than on the formatter, since the screen
+    /// is where the lie would appear.
+    #[test]
+    fn a_result_too_wide_for_the_panel_is_never_shown_truncated() {
+        let mut panel = new_panel();
+        panel.typing = "123456789 * 1000".to_string();
+        panel.evaluate();
+        assert_eq!(calc::format_result(panel.answer().unwrap()), "123456789000");
+
+        // Narrow enough that twelve digits cannot fit, tall enough that the
+        // tape is drawn as well as the display. Both are checked, because the
+        // first version of this only looked at the display and the bug was in
+        // the tape: composing `expr = result` and trimming the finished line
+        // cut the answer down to ` = 123456789`, which is a real number and
+        // the wrong one.
+        for row in draw(&mut panel, 8, 6).lines() {
+            let stripped: String = row.chars().filter(|c| !c.is_whitespace()).collect();
+            assert!(
+                !stripped.contains("123456789") || stripped.contains('e'),
+                "a prefix of the answer reached the screen: {row:?}"
+            );
+        }
+
+        // And the honest form did arrive.
+        assert!(
+            draw(&mut panel, 8, 6).contains('e'),
+            "the answer should have become scientific"
+        );
+    }
+
+    /// Every row a tape draws has to fit the panel, for the same reason.
+    #[test]
+    fn no_tape_row_is_ever_wider_than_the_panel() {
+        let mut panel = new_panel();
+        for expression in [
+            "123456789 * 1000",
+            "1/3",
+            "2+2",
+            "999999 * 999999 * 999999",
+            "0.1+0.2",
+        ] {
+            panel.typing = expression.to_string();
+            panel.evaluate();
+        }
+        for width in 1u16..=44 {
+            for row in draw(&mut panel, width, 10).lines() {
+                assert!(
+                    crate::grid::display_width(row) <= usize::from(width),
+                    "a {}-cell row was drawn into a {width}-cell panel: {row:?}",
+                    crate::grid::display_width(row)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_panel_draws_at_any_size_without_panicking() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "12345+6789");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+        for width in [1u16, 2, 3, 7, 12, 20, 44, 120] {
+            for height in [1u16, 2, 3, 5, 9, 30] {
+                let _ = draw(&mut panel, width, height);
+            }
+        }
+    }
+
+    /// Both bugs a real terminal found, and neither test existed before it did.
+    ///
+    /// The unit tests all passed while `1/0` looked like a key that did
+    /// nothing: the reason was written to the line above, where the text being
+    /// corrected already sat and took priority, so it was never drawn. And the
+    /// resting `–` was handed to the block numerals, which render an unknown
+    /// character as a *blank cell* — five empty rows that read as a panel that
+    /// had crashed.
+    ///
+    /// Neither is visible from the state; both are obvious on screen. That is
+    /// the argument for driving the thing.
+    #[test]
+    fn a_failed_sum_says_why_on_screen() {
+        let mut panel = new_panel();
+        type_in(&mut panel, "1/0");
+        panel.handle_key(KeyEvent::from(KeyCode::Enter));
+
+        let screen = draw(&mut panel, 30, 9);
+        assert!(
+            screen.contains("cannot divide by zero"),
+            "the reason has to reach the screen, not just the state:\n{screen}"
+        );
+        assert!(
+            screen.contains("1/0"),
+            "and what was typed has to stay there to be corrected:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn the_resting_display_is_visible_rather_than_blank() {
+        let mut panel = new_panel();
+        let screen = draw(&mut panel, 30, 9);
+        assert!(
+            screen.contains('\u{2013}'),
+            "an idle calculator draws a dash, not five blank rows — `glyphs` has \
+             no numeral for it and renders unknown characters as empty cells:\n{screen}"
+        );
+    }
+
+    /// A panel with nothing in it must not look broken (invariant 11).
+    #[test]
+    fn an_untouched_calculator_says_what_to_do() {
+        let mut panel = new_panel();
+        let screen = draw(&mut panel, 30, 8);
+        assert!(
+            screen.contains("type a sum"),
+            "an empty calculator has to invite the first keystroke:\n{screen}"
+        );
+    }
+
+    /// The tape must cost what is on screen, not what is in the buffer.
+    #[test]
+    fn only_the_tape_rows_that_fit_are_built() {
+        let mut panel = new_panel();
+        for n in 0..MAX_TAPE {
+            panel.typing = format!("{n}+1");
+            panel.evaluate();
+        }
+        draw(&mut panel, 30, 9);
+        assert!(
+            panel.drawn <= 9,
+            "{} rows were built for a nine-row panel",
+            panel.drawn
+        );
+        assert!(panel.drawn > 0, "a tall panel should show some of the tape");
+    }
+
+    /// Scrolling is bounded by what was drawn, so a shorter panel cannot leave
+    /// the cursor past the end — the defect `selection::up` had.
+    #[test]
+    fn the_cursor_cannot_leave_the_visible_tape() {
+        let mut panel = new_panel();
+        for n in 0..40 {
+            panel.typing = format!("{n}+1");
+            panel.evaluate();
+        }
+        draw(&mut panel, 30, 12);
+        for _ in 0..100 {
+            panel.handle_key(KeyEvent::from(KeyCode::Down));
+        }
+        assert!(panel.scroll.selected().is_some_and(|i| i < panel.drawn));
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -5,6 +5,7 @@
 //! codebase needs to know it exists.
 
 pub mod agenda;
+pub mod calculator;
 pub mod calendar;
 pub mod clocks;
 pub mod cpu;
@@ -24,8 +25,19 @@ use crate::panel::Panel;
 
 /// Every widget id accepted in the `[layout]` table.
 pub const WIDGET_NAMES: &[&str] = &[
-    "clocks", "weather", "todo", "notes", "stocks", "calendar", "agenda", "pomodoro", "watchlog",
-    "news", "cpu", "network",
+    "clocks",
+    "weather",
+    "todo",
+    "notes",
+    "stocks",
+    "calendar",
+    "agenda",
+    "pomodoro",
+    "watchlog",
+    "news",
+    "cpu",
+    "network",
+    "calculator",
 ];
 
 /// Whether `name` refers to a widget mirador knows how to build.
@@ -66,6 +78,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
         "pomodoro" => Box::new(pomodoro::PomodoroPanel::new(config.pomodoro.clone())),
         "cpu" => Box::new(cpu::CpuPanel::new(config.cpu.clone())),
         "network" => Box::new(network::NetworkPanel::new(config.network.clone())),
+        "calculator" => Box::new(calculator::CalculatorPanel::new(config.calculator)),
         _ => return Ok(None),
     };
     Ok(Some(panel))


### PR DESCRIPTION
Suggested by a reader on r/rust.

## Does it belong?

It answers none of the four questions the dashboard was built for — which is also true of the pomodoro timer. Recorded in CLAUDE.md beside that one rather than left looking like the filter was forgotten.

The argument for it is about **reaching** rather than reading. A tab you leave open all day is one you reach into for a quick sum, and the alternative is `bc` or `python3 -c` in a shell you have to go and find. It's the first panel with no data source behind it at all.

## Semantics

`2 + 3 * 4` is **14, not 20**. A pocket calculator gives 20 and that was the other candidate; it lost on who is typing. Someone at a terminal reaching for this instead of `bc` expects precedence and would file 20 as a bug. Brackets come nearly free once there's a `factor` rule, and their absence would be the surprise.

An operator typed straight after an answer chains from it (`57`, then `+10`). That's what removes the need for a memory key.

`f64`, displayed at 12 significant digits with trailing zeros stripped, so `0.1 + 0.2` prints `0.3`.

## The input problem

A calculator needs the digits; `1`–`9` are the shell's jump keys. `captures_input()` is the obvious answer and **it's a trap** — an absolute veto meant for transient modal states, so a panel holding it permanently kills `Tab`, `q` and `?` for as long as it has focus. A room with no door.

It isn't needed: `dispatch_key` offers keys to the focused panel *first*. The panel consumes what it needs and ignores the rest.

The price is real and documented in the README: **while this panel has focus, `1`–`9` type digits.** `Tab` is the way out. `digits_are_taken_and_the_shell_keys_are_left_alone` pins both halves.

## Never a truncated number

The one panel where a clipped value is unambiguously a lie — `12345` from `123456789012` is a plausible answer that isn't the one worked out, and an ellipsis hides the magnitude. Too wide goes to **scientific notation**. The tape follows the same rule: it drops the expression before it touches the result.

## Bounds first

Per the untrusted-input pass: expression length capped, bracket nesting capped **explicitly** rather than left to the stack (a stack overflow aborts — no error to show), tape bounded, rows built only for what's on screen.

`OutOfRange` turns out to be **unreachable** through the input language — 256 characters reach about 1e252 against a ceiling near 1e308. The guard stays, with the reasoning recorded so it isn't deleted as dead code.

## Placement

Reading row, not the instrument row, and it's arithmetic rather than taste: a fifth panel beside the markets takes `stocks` from 36 cells to 30 at 120 columns, and it needs 35 to keep the change column #161 restored. Prose gives way more gracefully than a table does.

Knock-on: jump keys stop at `9`, so `pomodoro` joins `cpu` and `network` in having none. The dashboard already had more panels than digits.

## Two defects only the terminal found

Both passed every unit test:

- **`1/0` looked like a key that did nothing.** The reason was written to the line where the text being corrected already sat, and took second place — so it was never drawn.
- **The resting `–` drew five blank rows.** It was handed to the block numerals, and `glyphs` renders an unknown character as an empty cell rather than a substitute.

Both now have tests, and both were checked by restoring the old behaviour and watching them go red.

## Verification

Four gates silent, 743 tests. Driven in a real terminal at 120 and 60 columns: precedence, chaining, divide-by-zero, backspace, Esc, clipboard, the tape, scientific fallback, the help overlay, `Tab`, and `q` quitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)