### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-01
+
+### Added
+
+- **A calculator panel.** Type an expression, press Enter. Suggested by a reader
+  on r/rust.
+
+  `2 + 3 * 4` is 14, not 20 — precedence is the arithmetic kind and brackets
+  work. A pocket calculator gives 20, and that was the other candidate; it lost
+  because what this replaces is `bc` or `python3 -c`, not a desk calculator, and
+  anyone typing `2+3*4` at a terminal would read 20 as a bug. An operator typed
+  straight after an answer carries it forward, which covers what a memory key
+  was for. `y` sends the answer to the clipboard, and what you have worked out
+  lands on a tape below.
+
+  An answer too wide for the panel is shown in scientific notation rather than
+  cut. Everywhere else in mirador a value that will not fit reads as a narrow
+  terminal; here a number missing its tail is a different number, and nothing on
+  screen would say so.
+
+  **While this panel has focus, `1`–`9` type digits instead of jumping to a
+  panel.** It is the only panel that changes what a global key does, and it is
+  unavoidable — a calculator needs the digits. `Tab` still moves focus, and `q`,
+  `?`, `w`, `m` and `t` all still work.
+
+  There is no memory key, no percent key and no functions, and nothing is kept
+  when you quit.
+
+### Changed
+
+- The default layout now places thirteen panels rather than twelve, with the
+  calculator on the reading row beside the news and the watch log. Jump keys
+  stop at `9`, so the pomodoro joins the CPU and network panels in not having
+  one. An existing config is never rewritten, so this affects new installs and
+  configs with no `[layout]` block.
+
 ## [1.2.0] - 2026-08-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1495,7 +1495,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.2.0` is released**, on crates.io and as a GitHub release with binaries
+- **`1.3.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog for the calculator panel merged in #168.

Minor rather than patch: a new widget, and the default layout grows from twelve panels to thirteen.

No config key was removed or renamed and no data file changed shape, so the 1.0 compatibility promise holds. `[calculator]` ships with no settings at all — every key in that file is permanent now, and none has earned it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)