### PR TITLE
Release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-08-01
+
+### Fixed
+
+- **The README's demo recording and its captions.** Both captions said "All
+  twelve panels"; the default layout has placed thirteen since the calculator
+  arrived, and the recording predated it. The GIF is referenced by absolute URL
+  because `/docs` is excluded from the crate, so replacing it updates the image
+  on every published version at once while the prose around it stays frozen at
+  whatever each release baked in — which is why the corrected captions need a
+  release of their own rather than riding along later.
+
+  The recording now shows the calculator, typed a character at a time so the
+  answer can be seen forming before Enter, with three sums chosen to demonstrate
+  the tape's decimal alignment.
+
 ## [1.3.1] - 2026-08-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1532,7 +1532,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.3.1` is released**, on crates.io and as a GitHub release with binaries
+- **`1.3.2` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog for the demo recording merged in #172.

Documentation only — no code changed. It needs a release rather than riding along with the next one because the GIF is served by absolute URL and updated on every published version the moment #172 merged, while captions are frozen per release. Without this, the 1.3.1 page on crates.io shows a thirteen-panel recording above a "twelve panels" caption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)