### PR TITLE
Follow-ups from the first outside contribution

### DIFF
--- a/src/widgets/calculator.rs
+++ b/src/widgets/calculator.rs
@@ -72,31 +72,45 @@ use crate::frame::{Binding, FRAME_HEIGHT, FRAME_WIDTH};
 use crate::grid::{Column, Grid, display_width};
 use crate::panel::{KeyOutcome, Panel, RenderContext};
 
-const ENTRY_BINDINGS: &[Binding] = &[
-    Binding::primary("0-9 + - * /", "type"),
-    Binding::primary("Enter", "keep"),
-    Binding::primary("c", "clear"),
-    Binding::extra("( )", "group"),
-    Binding::extra("x", "multiply"),
-    Binding::extra("C", "clear the tape too"),
-    Binding::extra("Backspace", "rub out"),
-];
+/// This panel's bindings, written once, with the tape actions optional.
+///
+/// A macro rather than two arrays. The two lists share seven entries, and a
+/// `Binding` declaration feeds three surfaces — border hint, status bar, help
+/// overlay — so a list duplicated is hint text that will drift (invariant 3).
+/// Only the two lines that genuinely differ are written twice, which is to say
+/// once each.
+///
+/// The order matters because `frame::hint_line` fills the border with
+/// *primaries* until it runs out of room: whatever is first is what a reader
+/// sees without pressing `?`. Extras never reach the border, so their position
+/// is free.
+macro_rules! calculator_bindings {
+    ($($tape:expr),* $(,)?) => {
+        &[
+            $($tape,)*
+            Binding::primary("0-9 + - * /", "type"),
+            Binding::primary("Enter", "keep"),
+            Binding::primary("c", "clear"),
+            Binding::extra("( )", "group"),
+            Binding::extra("x", "multiply"),
+            Binding::extra("C", "clear the tape too"),
+            Binding::extra("Backspace", "rub out"),
+            Binding::extra("\u{2191} / \u{2193}", "select on the tape"),
+        ]
+    };
+}
+
+/// Before anything has been worked out, the only thing worth advertising is
+/// that the number keys type.
+const ENTRY_BINDINGS: &[Binding] = calculator_bindings!();
 
 /// Once there is a tape, its result actions outrank another reminder that the
-/// number keys type. At the default width this puts `y copy · p paste` in the
-/// border together instead of leaving both behind `?`.
-const TAPE_BINDINGS: &[Binding] = &[
+/// number keys type. At the default width this puts `y copy \u{00b7} p paste` in
+/// the border together instead of leaving both behind `?`.
+const TAPE_BINDINGS: &[Binding] = calculator_bindings!(
     Binding::primary("y", "copy"),
     Binding::primary("p", "paste"),
-    Binding::primary("0-9 + - * /", "type"),
-    Binding::primary("Enter", "keep"),
-    Binding::primary("c", "clear"),
-    Binding::extra("( )", "group"),
-    Binding::extra("x", "multiply"),
-    Binding::extra("C", "clear the tape too"),
-    Binding::extra("Backspace", "rub out"),
-    Binding::extra("↑ / ↓", "select on the tape"),
-];
+);
 
 /// Widest the result column is drawn.
 ///
@@ -922,6 +936,32 @@ mod tests {
         assert_eq!(panel.preview, Ok(12.0));
         assert_eq!(panel.selected_back, 0, "the view returns to the tape foot");
         assert_eq!(panel.scrolled, 0);
+    }
+
+    /// The two binding lists must differ only by the tape actions.
+    ///
+    /// They were two hand-written arrays sharing seven entries, which is the
+    /// shape invariant 3 warns about: a `Binding` feeds the border hint, the
+    /// status bar and the help overlay, so a list kept in two places is hint
+    /// text waiting to disagree with itself. Now one macro emits both. This
+    /// pins the property so a future edit cannot quietly unpick it.
+    #[test]
+    fn the_two_binding_lists_share_everything_but_the_tape_actions() {
+        let tail: Vec<(&str, &str)> = TAPE_BINDINGS
+            .iter()
+            .skip(2)
+            .map(|b| (b.key, b.action))
+            .collect();
+        let entry: Vec<(&str, &str)> = ENTRY_BINDINGS.iter().map(|b| (b.key, b.action)).collect();
+        assert_eq!(
+            entry, tail,
+            "the shared part of the two lists has drifted apart"
+        );
+        assert_eq!(
+            TAPE_BINDINGS[..2].iter().map(|b| b.key).collect::<Vec<_>>(),
+            vec!["y", "p"],
+            "the tape actions lead, because the border fills with primaries in order"
+        );
     }
 
     #[test]

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -1168,9 +1168,8 @@ mod tests {
     #[test]
     fn a_named_command_runs_with_the_link_as_its_own_argument() {
         let mut panel = loaded_panel();
-        // `true` exists everywhere and ignores its arguments, so this checks the
-        // spawn path without depending on a browser.
-        panel.open_command = vec!["true".into()];
+        // Checks the spawn path without depending on a browser being present.
+        panel.open_command = harmless_command();
 
         panel.handle_key(KeyEvent::from(KeyCode::Enter));
 
@@ -1235,13 +1234,32 @@ mod tests {
             "`o` shows the marked story"
         );
 
-        panel.open_command = vec!["true".into()];
+        panel.open_command = harmless_command();
         panel.handle_key(KeyEvent::from(KeyCode::Enter));
         assert_eq!(
             panel.selected.selected(),
             Some(marked),
             "`Enter` must not move the cursor to a different story"
         );
+    }
+
+    /// A command that exists on every platform mirador ships to, and does
+    /// nothing when run.
+    ///
+    /// **Not `true`.** That was used here for a year on the reasoning, written
+    /// into the comment, that "`true` exists everywhere" — and it does not
+    /// exist on Windows. What hid it is that GitHub's Windows runners ship Git
+    /// for Windows, which puts a `true.exe` on `PATH`: the test passed in CI
+    /// and failed for anyone building on an ordinary Windows machine. It took
+    /// an outside contributor running the suite on their own box to find it
+    /// (#174), which is a reminder that a green CI is evidence about the
+    /// runner as much as about the code.
+    fn harmless_command() -> Vec<String> {
+        if cfg!(windows) {
+            vec!["cmd".into(), "/c".into(), "exit".into()]
+        } else {
+            vec!["true".into()]
+        }
     }
 
     /// A panel holding twelve stories, the number the shipped config produces.


### PR DESCRIPTION
The two things promised in the review of #174.

## The news tests spawned `true`, which does not exist on Windows

The comment beside it asserted that it does — *"`true` exists everywhere"* — and that was wrong for a year.

What hid it: GitHub's Windows runners ship Git for Windows, which puts a `true.exe` on `PATH`. So the test passed in CI and failed for anyone building on an ordinary Windows machine. It took @krflol running the suite on their own box to find it.

The reasoning is worth more than the fix, so it's recorded where the next person will meet it: **a green CI is evidence about the runner as much as about the code.** Both call sites now go through one helper that picks a do-nothing command per platform.

## The calculator's two binding lists shared seven entries

#174 split them so the tape actions could reach the border at the default width, which is the right behaviour. But two hand-written arrays holding the same seven lines is the shape invariant 3 exists to refuse — a `Binding` feeds the border hint, the status bar and the help overlay at once, so a list kept in two places is hint text waiting to disagree with itself.

One macro emits both now. Only the two lines that genuinely differ are written twice.

`the_two_binding_lists_share_everything_but_the_tape_actions` pins it, verified by pulling the lists apart and watching it go red. It also pins the **order**, since `hint_line` fills the border with primaries until it runs out of room — whichever is first is what a reader sees without pressing `?`.

One small consequence: with an empty tape the help overlay now lists the arrow keys too. They do nothing until there is a tape, which is true of every key here before there is anything to act on — and a help overlay that stops changing shape as you use the panel is worth more than the line it saves.

Four gates silent, 750 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)