### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-01
+
 ### Added
 
 - **Calculator results can be selected, copied and reused from the tape.**
@@ -14,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that answer to the terminal clipboard, and `p` pastes it into the live
   expression. Once a result exists, the focused panel's compact border hint
   advertises `y copy · p paste` at the default width.
+
+  Contributed by [@krflol](https://github.com/krflol) in
+  [#174](https://github.com/jchultarsky/mirador/pull/174) — the first change to
+  mirador from outside.
+
+### Fixed
+
+- Two tests spawned `true`, which does not exist on Windows, so the suite failed
+  for anyone building there. It passed in CI because GitHub's Windows runners
+  ship Git for Windows and it puts a `true.exe` on `PATH` — a green CI is
+  evidence about the runner as much as about the code. Found by @krflol running
+  the suite on their own machine.
 
 ## [1.3.2] - 2026-08-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1532,7 +1532,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.3.2` is released**, on crates.io and as a GitHub release with binaries
+- **`1.4.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.3.2"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog for #174 and #175.

Minor: new user-visible behaviour on the calculator panel — `↑`/`↓` selection, `y` copying the selected answer rather than the newest, and `p` pasting it into the live expression.

No config key added, removed or renamed; no data file changed shape, so the 1.0 compatibility promise holds.

This is the first release carrying a change from outside the project. The changelog credits @krflol for both the feature and the Windows test bug they found while preparing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)