### PR TITLE
Add clipboard editing to notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Notes can select, copy and paste body text as a scratchpad.** Shift plus
+  the navigation keys extend a visible selection and `Ctrl+A` selects the
+  whole body. `Ctrl+C` sends the selection to the terminal clipboard while
+  retaining an internal copy, and `Ctrl+V` inserts or replaces from that copy
+  even when the terminal declines OSC 52. Typing and deletion replace selected
+  text as expected, bracketed terminal paste preserves outside multiline text,
+  and the editing border and footer expose the active keys.
+
 ## [1.4.1] - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -381,6 +381,15 @@ it turns "glance at the dashboard" into "operate the dashboard". `/` searches
 bodies as well as titles, because the title you wrote in a hurry is often not
 what you later search for.
 
+Open a note with `Enter`, then move to its body with `Tab`. `Shift` plus the
+arrow keys (or `Home`/`End`) selects text, and `Ctrl+A` selects the whole body.
+`Ctrl+C` sends that selection to the terminal clipboard and also keeps an
+in-Mirador copy; `Ctrl+V` pastes that copy at the cursor or replaces the next
+selection. Typing, Backspace and Delete replace selected text too. With
+nothing selected, `Ctrl+C` keeps its ordinary terminal meaning and quits.
+Your terminal's normal paste shortcut remains the way to bring outside text
+into the note; multiline pastes and literal tabs are kept intact in the body.
+
 ### Clock and calendar
 
 The first configured zone renders large; the rest become a table showing their

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -225,8 +225,8 @@ horizon_days   = 0             # hide tasks due further out than this; 0 = show 
 #
 # Free-form notes, listed by title and date with the selected one's body beside
 # the list. `a` writes one, `Enter` opens it, `d` deletes, `/` searches both
-# titles and bodies. In the editor, Tab moves between title and body, Enter in
-# the body is a new line, and Ctrl+S saves.
+# titles and bodies. Editor: Tab changes field, Enter makes a body line, Ctrl+S
+# saves; Shift+arrows selects, Ctrl+A all, Ctrl+C copies, and Ctrl+V pastes.
 #
 # `preview` puts the note body "below" the list or "beside" it. Below by
 # default: beside splits a finite width between a list that wants room for

--- a/src/app.rs
+++ b/src/app.rs
@@ -565,6 +565,7 @@ impl App {
                         self.persist_preferences();
                         dirty = true;
                     }
+                    Event::Paste(text) => dirty |= self.handle_paste(&text),
                     Event::Mouse(mouse) => dirty |= self.handle_mouse(mouse),
                     // Resize re-runs layout against the new frame size, which
                     // is the next draw's job — but that draw has to happen.
@@ -767,9 +768,17 @@ impl App {
 
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
-        // Ctrl+C always quits, even mid-form, because a terminal user expects
-        // it to and there is no state we would lose: panels save as they go.
+        // Ctrl+C remains the terminal's quit key unless the focused editor has
+        // an actual text selection to copy. Merely being inside a form is not
+        // enough to steal the interrupt: with no selection, it still quits as
+        // it always has.
         if ctrl && matches!(key.code, KeyCode::Char('c')) {
+            let copied = self.slots.get_mut(self.focus).is_some_and(|slot| {
+                slot.panel.copy_selection() == crate::panel::KeyOutcome::Consumed
+            });
+            if copied {
+                return;
+            }
             self.should_quit = true;
             return;
         }
@@ -850,6 +859,53 @@ impl App {
         }
 
         self.dispatch_key(key);
+    }
+
+    /// Route a terminal bracketed paste to the focused editor.
+    ///
+    /// A panel can consume the whole block so a multiline editor preserves
+    /// hard lines and literal tabs. Older form fields still receive the same
+    /// printable key stream they did before bracketed paste was enabled; it is
+    /// dispatched straight to the capturing panel so pasted `q` cannot become
+    /// a global quit command.
+    fn handle_paste(&mut self, text: &str) -> bool {
+        self.show_update_hint = false;
+        self.watch.mark_seen();
+
+        if self.show_help {
+            self.show_help = false;
+            return true;
+        }
+        if self.theme_picker.is_some() || self.picker.is_some() || self.arranging.is_some() {
+            return false;
+        }
+
+        let Some(slot) = self.slots.get_mut(self.focus) else {
+            return false;
+        };
+        if slot.panel.handle_paste(text) == crate::panel::KeyOutcome::Consumed {
+            return true;
+        }
+        if !slot.panel.captures_input() {
+            return false;
+        }
+
+        let text = text.replace("\r\n", "\n").replace('\r', "\n");
+        let mut used = false;
+        for character in text.chars() {
+            let code = match character {
+                '\n' => KeyCode::Enter,
+                '\t' => KeyCode::Tab,
+                c if !c.is_control() => KeyCode::Char(c),
+                _ => continue,
+            };
+            used = slot
+                .panel
+                .handle_key(KeyEvent::new(code, KeyModifiers::NONE))
+                == crate::panel::KeyOutcome::Consumed
+                || used;
+        }
+        used
     }
 
     /// Open arrange mode, remembering what to go back to.
@@ -3170,6 +3226,56 @@ mod tests {
             !app.should_quit,
             "Esc means back out of something, not quit"
         );
+    }
+
+    #[test]
+    fn clipboard_inputs_reach_the_editor_before_global_keys() {
+        struct CopyPanel {
+            selected: bool,
+            pasted: std::rc::Rc<std::cell::RefCell<String>>,
+        }
+
+        impl crate::panel::Panel for CopyPanel {
+            fn title(&self) -> String {
+                "copy test".to_string()
+            }
+
+            fn render(
+                &mut self,
+                _frame: &mut ratatui::Frame,
+                _area: Rect,
+                _ctx: crate::panel::RenderContext<'_>,
+            ) {
+            }
+
+            fn copy_selection(&mut self) -> crate::panel::KeyOutcome {
+                if std::mem::take(&mut self.selected) {
+                    crate::panel::KeyOutcome::Consumed
+                } else {
+                    crate::panel::KeyOutcome::Ignored
+                }
+            }
+
+            fn handle_paste(&mut self, text: &str) -> crate::panel::KeyOutcome {
+                self.pasted.borrow_mut().push_str(text);
+                crate::panel::KeyOutcome::Consumed
+            }
+        }
+
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        let pasted = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+        app.slots[0].panel = Box::new(CopyPanel {
+            selected: true,
+            pasted: pasted.clone(),
+        });
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+        app.handle_key(ctrl_c);
+        assert!(!app.should_quit, "the selection gets Ctrl+C first");
+        assert!(app.handle_paste("one\n\ttwo"));
+        assert_eq!(&*pasted.borrow(), "one\n\ttwo", "paste stays one block");
+        app.handle_key(ctrl_c);
+        assert!(app.should_quit, "without a selection Ctrl+C still quits");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,8 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use ratatui::crossterm::event::{
-    DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture,
+    DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+    EnableFocusChange, EnableMouseCapture,
 };
 use ratatui::crossterm::execute;
 
@@ -407,15 +408,15 @@ fn run() -> Result<()> {
     // else measures interaction, and a dashboard you glance at is precisely one
     // you do not touch. Failure is ignored on purpose: plenty of terminals do
     // not implement it, and the watch log falls back to the last keypress.
-    let _ = execute!(std::io::stdout(), EnableFocusChange);
+    let _ = execute!(std::io::stdout(), EnableFocusChange, EnableBracketedPaste);
 
-    // Released on the way out, and on a panic, for the same reason mouse
-    // capture is: a terminal left reporting focus writes escape sequences into
-    // the user's shell every time they switch windows.
+    // Focus reporting and bracketed paste are released on the way out, and on
+    // a panic, for the same reason mouse capture is: either mode left enabled
+    // writes control sequences into the user's shell after mirador is gone.
     {
         let previous = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
-            let _ = execute!(std::io::stdout(), DisableFocusChange);
+            let _ = execute!(std::io::stdout(), DisableBracketedPaste, DisableFocusChange);
             previous(info);
         }));
     }
@@ -437,6 +438,7 @@ fn run() -> Result<()> {
     if mouse {
         let _ = execute!(std::io::stdout(), DisableMouseCapture);
     }
+    let _ = execute!(std::io::stdout(), DisableBracketedPaste);
     let _ = execute!(std::io::stdout(), DisableFocusChange);
     ratatui::restore();
     result

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -46,8 +46,9 @@ use crate::theme::{Gradients, Theme};
 /// Whether a panel handled an input event, or wants it to fall through to the
 /// application's global bindings.
 ///
-/// Shared by [`Panel::handle_key`] and [`Panel::handle_mouse`]: the two differ
-/// in what they receive, not in how the shell reacts to the answer.
+/// Shared by [`Panel::handle_key`], [`Panel::copy_selection`],
+/// [`Panel::handle_paste`] and [`Panel::handle_mouse`]: they differ in what
+/// they receive, not in how the shell reacts to the answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyOutcome {
     /// The panel used the event; the app should not act on it.
@@ -271,6 +272,20 @@ pub trait Panel {
 
     /// Handle a key event while focused.
     fn handle_key(&mut self, _key: KeyEvent) -> KeyOutcome {
+        KeyOutcome::Ignored
+    }
+
+    /// Copy an active editor selection before the shell treats `Ctrl+C` as
+    /// quit. Returning [`KeyOutcome::Ignored`] preserves the ordinary terminal
+    /// interrupt everywhere there is no text selected.
+    fn copy_selection(&mut self) -> KeyOutcome {
+        KeyOutcome::Ignored
+    }
+
+    /// Insert one bracketed paste while focused. Editors that care about hard
+    /// lines or literal tabs override this; the shell retains a key-by-key
+    /// fallback for older single-line forms.
+    fn handle_paste(&mut self, _text: &str) -> KeyOutcome {
         KeyOutcome::Ignored
     }
 

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -10,6 +10,8 @@
 //! soft wrap that moves as you type makes the cursor impossible to follow. The
 //! reader wraps; the editor does not.
 
+use std::ops::Range;
+
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 #[derive(Debug, Clone)]
@@ -20,6 +22,8 @@ pub struct TextArea {
     row: usize,
     /// Cursor position within the line, in characters.
     col: usize,
+    /// Fixed end of a keyboard selection. The cursor is its moving end.
+    selection_anchor: Option<(usize, usize)>,
 }
 
 impl Default for TextArea {
@@ -34,6 +38,7 @@ impl TextArea {
             lines: vec![String::new()],
             row: 0,
             col: 0,
+            selection_anchor: None,
         }
     }
 
@@ -46,7 +51,12 @@ impl TextArea {
         }
         let row = lines.len() - 1;
         let col = lines[row].chars().count();
-        Self { lines, row, col }
+        Self {
+            lines,
+            row,
+            col,
+            selection_anchor: None,
+        }
     }
 
     /// The text, with lines joined by `\n`.
@@ -78,14 +88,130 @@ impl TextArea {
         self.lines.get(row).map_or(0, |l| l.chars().count())
     }
 
-    pub fn insert(&mut self, c: char) {
+    fn position(&self) -> (usize, usize) {
+        (self.row, self.col)
+    }
+
+    /// The selection in document order, excluding a collapsed anchor.
+    fn selection(&self) -> Option<((usize, usize), (usize, usize))> {
+        let anchor = self.selection_anchor?;
+        let cursor = self.position();
+        if anchor == cursor {
+            return None;
+        }
+        Some(if anchor < cursor {
+            (anchor, cursor)
+        } else {
+            (cursor, anchor)
+        })
+    }
+
+    pub fn has_selection(&self) -> bool {
+        self.selection().is_some()
+    }
+
+    /// Text between the anchor and cursor, preserving hard line breaks.
+    pub fn selected_text(&self) -> Option<String> {
+        let ((start_row, start_col), (end_row, end_col)) = self.selection()?;
+        if start_row == end_row {
+            let line = &self.lines[start_row];
+            return Some(
+                line[Self::byte_at(line, start_col)..Self::byte_at(line, end_col)].to_string(),
+            );
+        }
+
+        let mut selected = String::new();
+        let first = &self.lines[start_row];
+        selected.push_str(&first[Self::byte_at(first, start_col)..]);
+        selected.push('\n');
+        for row in start_row + 1..end_row {
+            selected.push_str(&self.lines[row]);
+            selected.push('\n');
+        }
+        let last = &self.lines[end_row];
+        selected.push_str(&last[..Self::byte_at(last, end_col)]);
+        Some(selected)
+    }
+
+    /// Select the complete body. An empty body has nothing to select.
+    pub fn select_all(&mut self) {
+        let end_row = self.lines.len() - 1;
+        let end_col = self.line_len(end_row);
+        self.row = end_row;
+        self.col = end_col;
+        self.selection_anchor = ((end_row, end_col) != (0, 0)).then_some((0, 0));
+    }
+
+    /// Delete the selected range and leave the cursor where it began.
+    fn delete_selection(&mut self) -> bool {
+        let Some(((start_row, start_col), (end_row, end_col))) = self.selection() else {
+            self.selection_anchor = None;
+            return false;
+        };
+
+        if start_row == end_row {
+            let line = &mut self.lines[start_row];
+            let start = Self::byte_at(line, start_col);
+            let end = Self::byte_at(line, end_col);
+            line.replace_range(start..end, "");
+        } else {
+            let first = &self.lines[start_row];
+            let mut joined = first[..Self::byte_at(first, start_col)].to_string();
+            let last = &self.lines[end_row];
+            joined.push_str(&last[Self::byte_at(last, end_col)..]);
+            self.lines
+                .splice(start_row..=end_row, std::iter::once(joined));
+        }
+
+        self.row = start_row;
+        self.col = start_col;
+        self.selection_anchor = None;
+        true
+    }
+
+    fn insert_at_cursor(&mut self, c: char) {
         let byte = Self::byte_at(&self.lines[self.row], self.col);
         self.lines[self.row].insert(byte, c);
         self.col += 1;
     }
 
+    pub fn insert(&mut self, c: char) {
+        self.delete_selection();
+        self.insert_at_cursor(c);
+    }
+
+    /// Insert a block at the cursor, replacing the active selection.
+    /// Windows and old-Mac line endings become the editor's `\n` hard lines.
+    pub fn insert_text(&mut self, text: &str) {
+        self.delete_selection();
+        let text = text.replace("\r\n", "\n").replace('\r', "\n");
+        let mut parts = text.split('\n');
+        let first = parts.next().unwrap_or_default();
+        let rest: Vec<&str> = parts.collect();
+
+        let byte = Self::byte_at(&self.lines[self.row], self.col);
+        let tail = self.lines[self.row].split_off(byte);
+        self.lines[self.row].push_str(first);
+        self.col += first.chars().count();
+
+        if rest.is_empty() {
+            self.lines[self.row].push_str(&tail);
+            return;
+        }
+
+        let start_row = self.row;
+        for (offset, part) in rest.iter().enumerate() {
+            self.lines
+                .insert(start_row + offset + 1, (*part).to_string());
+        }
+        self.row = start_row + rest.len();
+        self.col = rest.last().map_or(0, |part| part.chars().count());
+        self.lines[self.row].push_str(&tail);
+    }
+
     /// Split the current line at the cursor.
     pub fn newline(&mut self) {
+        self.delete_selection();
         let byte = Self::byte_at(&self.lines[self.row], self.col);
         let tail = self.lines[self.row].split_off(byte);
         self.lines.insert(self.row + 1, tail);
@@ -95,6 +221,9 @@ impl TextArea {
 
     /// Delete backwards, joining with the previous line at the start of a line.
     pub fn backspace(&mut self) {
+        if self.delete_selection() {
+            return;
+        }
         if self.col > 0 {
             let byte = Self::byte_at(&self.lines[self.row], self.col - 1);
             self.lines[self.row].remove(byte);
@@ -109,6 +238,9 @@ impl TextArea {
 
     /// Delete forwards, pulling the next line up at the end of a line.
     pub fn delete(&mut self) {
+        if self.delete_selection() {
+            return;
+        }
         if self.col < self.line_len(self.row) {
             let byte = Self::byte_at(&self.lines[self.row], self.col);
             self.lines[self.row].remove(byte);
@@ -118,7 +250,7 @@ impl TextArea {
         }
     }
 
-    pub fn left(&mut self) {
+    fn move_left(&mut self) {
         if self.col > 0 {
             self.col -= 1;
         } else if self.row > 0 {
@@ -127,7 +259,7 @@ impl TextArea {
         }
     }
 
-    pub fn right(&mut self) {
+    fn move_right(&mut self) {
         if self.col < self.line_len(self.row) {
             self.col += 1;
         } else if self.row + 1 < self.lines.len() {
@@ -136,7 +268,7 @@ impl TextArea {
         }
     }
 
-    pub fn up(&mut self) {
+    fn move_up(&mut self) {
         if self.row > 0 {
             self.row -= 1;
             // Keep the column where it was if the new line is long enough,
@@ -145,19 +277,69 @@ impl TextArea {
         }
     }
 
-    pub fn down(&mut self) {
+    fn move_down(&mut self) {
         if self.row + 1 < self.lines.len() {
             self.row += 1;
             self.col = self.col.min(self.line_len(self.row));
         }
     }
 
-    pub fn home(&mut self) {
+    fn move_home(&mut self) {
         self.col = 0;
     }
 
-    pub fn end(&mut self) {
+    fn move_end(&mut self) {
         self.col = self.line_len(self.row);
+    }
+
+    fn extend(&mut self, movement: fn(&mut Self)) {
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some(self.position());
+        }
+        movement(self);
+        if self.selection_anchor == Some(self.position()) {
+            self.selection_anchor = None;
+        }
+    }
+
+    pub fn left(&mut self) {
+        if let Some((start, _)) = self.selection() {
+            (self.row, self.col) = start;
+            self.selection_anchor = None;
+        } else {
+            self.selection_anchor = None;
+            self.move_left();
+        }
+    }
+
+    pub fn right(&mut self) {
+        if let Some((_, end)) = self.selection() {
+            (self.row, self.col) = end;
+            self.selection_anchor = None;
+        } else {
+            self.selection_anchor = None;
+            self.move_right();
+        }
+    }
+
+    pub fn up(&mut self) {
+        self.selection_anchor = None;
+        self.move_up();
+    }
+
+    pub fn down(&mut self) {
+        self.selection_anchor = None;
+        self.move_down();
+    }
+
+    pub fn home(&mut self) {
+        self.selection_anchor = None;
+        self.move_home();
+    }
+
+    pub fn end(&mut self) {
+        self.selection_anchor = None;
+        self.move_end();
     }
 
     /// Handle a key, returning whether it was used.
@@ -167,7 +349,12 @@ impl TextArea {
     pub fn handle_key(&mut self, key: KeyEvent) -> bool {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
         match key.code {
+            KeyCode::Char('a') if ctrl => {
+                self.select_all();
+                true
+            }
             // Alt is excluded as well as Ctrl, which it was not: `Alt+x` typed
             // an `x` into the note. `TextField` had always excluded both, and
             // two editors sitting side by side disagreeing about what a chord
@@ -187,6 +374,30 @@ impl TextArea {
             }
             KeyCode::Delete => {
                 self.delete();
+                true
+            }
+            KeyCode::Left if shift => {
+                self.extend(Self::move_left);
+                true
+            }
+            KeyCode::Right if shift => {
+                self.extend(Self::move_right);
+                true
+            }
+            KeyCode::Up if shift => {
+                self.extend(Self::move_up);
+                true
+            }
+            KeyCode::Down if shift => {
+                self.extend(Self::move_down);
+                true
+            }
+            KeyCode::Home if shift => {
+                self.extend(Self::move_home);
+                true
+            }
+            KeyCode::End if shift => {
+                self.extend(Self::move_end);
                 true
             }
             KeyCode::Left => {
@@ -261,13 +472,27 @@ impl TextArea {
     ///
     /// Measured in cells throughout, per invariant 9: a note written in
     /// Japanese would otherwise scroll by half a glyph at a time.
+    #[cfg(test)]
     pub fn visible(&self, row: usize, width: usize) -> (String, Option<usize>) {
+        let (text, caret, _) = self.visible_with_selection(row, width);
+        (text, caret)
+    }
+
+    /// The visible line plus the selected byte range inside that visible text.
+    /// Byte offsets are safe to slice because they are recorded only at UTF-8
+    /// character boundaries while the string is assembled.
+    pub fn visible_with_selection(
+        &self,
+        row: usize,
+        width: usize,
+    ) -> (String, Option<usize>, Option<Range<usize>>) {
         if width == 0 {
-            return (String::new(), None);
+            return (String::new(), None, None);
         }
         let line = self.lines.get(row).map_or("", String::as_str);
         let skip = self.h_offset(width);
         let here = row == self.row;
+        let selection = self.selection();
         // The caret occupies a cell of its own on the row that carries it.
         let budget = if here { width - 1 } else { width };
 
@@ -275,6 +500,8 @@ impl TextArea {
         let mut consumed = 0usize;
         let mut drawn = 0usize;
         let mut caret = None;
+        let mut selected_start = None;
+        let mut selected_end = 0usize;
         for (index, c) in line.chars().enumerate() {
             if here && index == self.col && caret.is_none() && consumed >= skip {
                 caret = Some(out.len());
@@ -284,7 +511,16 @@ impl TextArea {
                 if drawn + w > budget {
                     break;
                 }
+                let selected = selection
+                    .is_some_and(|(start, end)| (row, index) >= start && (row, index) < end);
+                let at = out.len();
                 out.push(c);
+                if selected {
+                    if selected_start.is_none() {
+                        selected_start = Some(at);
+                    }
+                    selected_end = out.len();
+                }
                 drawn += w;
             }
             consumed += w;
@@ -294,7 +530,24 @@ impl TextArea {
         if here && caret.is_none() && self.col >= line.chars().count() {
             caret = Some(out.len());
         }
-        (out, caret)
+        // A line break is text too. Represent a selected newline with one
+        // reversed cell at the line's end; without it, selecting the break
+        // between two lines (or an empty line) looked exactly like selecting
+        // nothing even though copy and replacement included `\n`.
+        let line_end = (row, line.chars().count());
+        let newline_selected = row + 1 < self.lines.len()
+            && selection.is_some_and(|(start, end)| start <= line_end && end > line_end);
+        let reached_line_end = consumed >= crate::grid::display_width(line);
+        if newline_selected && reached_line_end && drawn < budget {
+            let at = out.len();
+            out.push(' ');
+            if selected_start.is_none() {
+                selected_start = Some(at);
+            }
+            selected_end = out.len();
+        }
+        let selected = selected_start.map(|start| start..selected_end);
+        (out, caret, selected)
     }
 }
 
@@ -308,6 +561,10 @@ mod tests {
 
     fn press(a: &mut TextArea, code: KeyCode) -> bool {
         a.handle_key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn chord(a: &mut TextArea, code: KeyCode, modifiers: KeyModifiers) -> bool {
+        a.handle_key(KeyEvent::new(code, modifiers))
     }
 
     #[test]
@@ -419,6 +676,77 @@ mod tests {
         let mut a = TextArea::new();
         assert!(!a.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)));
         assert_eq!(a.value(), "", "Ctrl+C must not insert a `c`");
+    }
+
+    #[test]
+    fn shift_navigation_selects_exact_text_in_either_direction() {
+        let mut a = area("one\ntwö");
+        for _ in 0..3 {
+            chord(&mut a, KeyCode::Left, KeyModifiers::SHIFT);
+        }
+        assert_eq!(a.selected_text().as_deref(), Some("twö"));
+
+        chord(&mut a, KeyCode::Up, KeyModifiers::SHIFT);
+        assert_eq!(
+            a.selected_text().as_deref(),
+            Some("one\ntwö"),
+            "a backwards multi-line selection keeps its hard line break"
+        );
+        assert_eq!(a.cursor(), (0, 0), "the cursor is the moving end");
+    }
+
+    #[test]
+    fn typing_and_deletion_replace_the_selection() {
+        for key in [KeyCode::Char('x'), KeyCode::Backspace, KeyCode::Delete] {
+            let mut a = area("red blue");
+            for _ in 0..4 {
+                chord(&mut a, KeyCode::Left, KeyModifiers::SHIFT);
+            }
+            press(&mut a, key);
+            let want = if matches!(key, KeyCode::Char(_)) {
+                "red x"
+            } else {
+                "red "
+            };
+            assert_eq!(a.value(), want, "replacement with {key:?}");
+            assert!(!a.has_selection());
+        }
+    }
+
+    #[test]
+    fn ctrl_a_selects_the_whole_body_and_paste_replaces_it() {
+        let mut a = area("first\nsecond");
+        chord(&mut a, KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert_eq!(a.selected_text().as_deref(), Some("first\nsecond"));
+
+        a.insert_text("new\r\nbody");
+        assert_eq!(a.value(), "new\nbody");
+        assert_eq!(a.cursor(), (1, 4));
+        assert!(!a.has_selection());
+    }
+
+    #[test]
+    fn the_visible_window_reports_which_bytes_are_selected() {
+        let mut a = area("aé日z");
+        a.home();
+        for _ in 0..3 {
+            chord(&mut a, KeyCode::Right, KeyModifiers::SHIFT);
+        }
+        let (text, caret, selected) = a.visible_with_selection(0, 20);
+        assert_eq!(text, "aé日z");
+        assert_eq!(caret, Some("aé日".len()));
+        assert_eq!(selected, Some(0.."aé日".len()));
+    }
+
+    #[test]
+    fn selecting_only_a_line_break_is_still_visible() {
+        let mut a = area("one\n");
+        chord(&mut a, KeyCode::Left, KeyModifiers::SHIFT);
+        assert_eq!(a.selected_text().as_deref(), Some("\n"));
+
+        let (text, _, selected) = a.visible_with_selection(0, 20);
+        assert_eq!(text, "one ");
+        assert_eq!(selected, Some(3..4), "the final cell marks the newline");
     }
 
     /// The two editors have to agree about this. `TextField` excluded Alt from

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -110,6 +110,11 @@ impl TextArea {
         self.selection().is_some()
     }
 
+    /// Collapse the active selection without moving the cursor.
+    pub fn clear_selection(&mut self) {
+        self.selection_anchor = None;
+    }
+
     /// Text between the anchor and cursor, preserving hard line breaks.
     pub fn selected_text(&self) -> Option<String> {
         let ((start_row, start_col), (end_row, end_col)) = self.selection()?;

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -32,7 +32,7 @@ use crate::theme::Theme;
 /// One declaration feeds the border hint, the status bar and the help overlay,
 /// and `every_documented_key_works_and_every_working_key_is_documented` fails
 /// if this list and the code drift apart.
-const BINDINGS: &[Binding] = &[
+const LIST_BINDINGS: &[Binding] = &[
     Binding::primary("a", "new"),
     Binding::primary("↵", "edit"),
     Binding::primary("d", "delete"),
@@ -46,6 +46,37 @@ const BINDINGS: &[Binding] = &[
     Binding::extra("/", "search"),
     Binding::extra("Esc", "clear search"),
     Binding::extra("o", "show file path"),
+];
+
+/// Editing has a different vocabulary from browsing. Keeping it separate puts
+/// the scratchpad's selection and clipboard actions in the border while the
+/// form is open instead of continuing to advertise list actions that cannot
+/// work there.
+const TITLE_EDIT_BINDINGS: &[Binding] = &[
+    Binding::primary("Tab", "body"),
+    Binding::primary("Ctrl+S", "save"),
+    Binding::primary("Esc", "cancel"),
+];
+
+const BODY_EDIT_BINDINGS: &[Binding] = &[
+    Binding::primary("Shift+←↑→↓", "select"),
+    Binding::primary("Ctrl+V", "paste"),
+    Binding::primary("Ctrl+S", "save"),
+    Binding::extra("Ctrl+A", "select all"),
+    Binding::extra("Ctrl+C", "copy selection"),
+    Binding::extra("Tab", "change field"),
+    Binding::extra("Esc", "cancel"),
+];
+
+/// Once text is selected, the next useful action is copying or replacing it.
+const SELECTION_BINDINGS: &[Binding] = &[
+    Binding::primary("Ctrl+C", "copy"),
+    Binding::primary("Ctrl+V", "paste"),
+    Binding::primary("Ctrl+S", "save"),
+    Binding::extra("Shift+←↑→↓", "adjust selection"),
+    Binding::extra("Ctrl+A", "select all"),
+    Binding::extra("Tab", "change field"),
+    Binding::extra("Esc", "cancel"),
 ];
 
 /// Columns of the note list. The date is right-aligned so the dates line up.
@@ -144,6 +175,10 @@ pub struct NotesPanel {
     body_area: Option<Rect>,
     /// The selected body, already wrapped. See [`WrappedBody`].
     wrapped_body: Option<WrappedBody>,
+    /// The last body selection copied in this session. OSC 52 cannot read a
+    /// system clipboard back, so keeping the text here is what makes Ctrl+V
+    /// dependable even when the terminal declines the external copy request.
+    clipboard: Option<String>,
 }
 
 impl NotesPanel {
@@ -164,6 +199,7 @@ impl NotesPanel {
             detail_area: None,
             body_area: None,
             wrapped_body: None,
+            clipboard: None,
         };
         panel.refresh_view();
         Ok(panel)
@@ -287,6 +323,55 @@ impl NotesPanel {
         self.status = Some((message.into(), false));
     }
 
+    /// Send the selected body text outward and retain it for an in-editor
+    /// paste. The injected writer keeps the OSC 52 side effect out of tests.
+    fn copy_body_selection_with(
+        &mut self,
+        copy: impl FnOnce(&str) -> std::io::Result<()>,
+    ) -> KeyOutcome {
+        let selected = match &self.mode {
+            Mode::Edit(form) => form.body.selected_text(),
+            _ => None,
+        };
+        let Some(text) = selected else {
+            return KeyOutcome::Ignored;
+        };
+
+        let count = text.chars().count();
+        self.clipboard = Some(text.clone());
+        self.status = Some(match copy(&text) {
+            // OSC 52 is write-only. "Sent" is true; "copied" is unknowable.
+            Ok(()) => (format!("sent {count} chars — Ctrl+V pastes here"), false),
+            // The internal copy still succeeded, so lead with what remains
+            // usable rather than making the whole action sound lost.
+            Err(error) => (
+                format!("ready to paste; terminal clipboard failed: {error}"),
+                true,
+            ),
+        });
+        KeyOutcome::Consumed
+    }
+
+    fn paste_body_clipboard(&mut self) -> KeyOutcome {
+        let Mode::Edit(form) = &mut self.mode else {
+            return KeyOutcome::Ignored;
+        };
+        if form.field != Field::Body {
+            self.set_status("Tab to the body to paste copied text");
+            return KeyOutcome::Consumed;
+        }
+        let Some(text) = self.clipboard.clone() else {
+            self.set_status("nothing copied here yet; terminal paste still works");
+            return KeyOutcome::Consumed;
+        };
+
+        let count = text.chars().count();
+        form.body.insert_text(&text);
+        form.error = None;
+        self.set_status(format!("pasted {count} chars"));
+        KeyOutcome::Consumed
+    }
+
     /// Write the form back, returning an error message to show in the form.
     fn commit_form(&mut self) -> Result<(), String> {
         let Mode::Edit(form) = &self.mode else {
@@ -381,6 +466,10 @@ impl NotesPanel {
     }
 
     fn handle_edit_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('v')) {
+            return self.paste_body_clipboard();
+        }
+
         let Mode::Edit(form) = &mut self.mode else {
             return KeyOutcome::Ignored;
         };
@@ -430,6 +519,7 @@ impl NotesPanel {
                 form.body.handle_key(key);
             }
         }
+        form.error = None;
         KeyOutcome::Consumed
     }
 
@@ -631,8 +721,59 @@ impl NotesPanel {
         }
     }
 
+    /// One editor row, split wherever the selection or caret changes style.
+    fn editor_line(
+        text: &str,
+        caret: Option<usize>,
+        selection: Option<std::ops::Range<usize>>,
+        theme: &Theme,
+    ) -> Line<'static> {
+        let selection = selection.filter(|range| range.start < range.end);
+        let mut cuts = vec![0, text.len()];
+        if let Some(range) = &selection {
+            cuts.extend([range.start, range.end]);
+        }
+        if let Some(at) = caret {
+            cuts.push(at);
+        }
+        cuts.sort_unstable();
+        cuts.dedup();
+
+        let mut spans = Vec::new();
+        for pair in cuts.windows(2) {
+            let (start, end) = (pair[0], pair[1]);
+            if caret == Some(start) {
+                spans.push(Span::styled("▏", Style::default().fg(theme.accent)));
+            }
+            if start == end {
+                continue;
+            }
+            let selected = selection
+                .as_ref()
+                .is_some_and(|range| start >= range.start && end <= range.end);
+            let style = if selected {
+                Style::default()
+                    .fg(theme.text)
+                    .add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default().fg(theme.text)
+            };
+            spans.push(Span::styled(text[start..end].to_string(), style));
+        }
+        if caret == Some(text.len()) {
+            spans.push(Span::styled("▏", Style::default().fg(theme.accent)));
+        }
+        Line::from(spans)
+    }
+
     /// The edit form, drawn over the whole panel.
-    fn render_form(frame: &mut Frame, area: Rect, theme: &Theme, form: &EditForm) {
+    fn render_form(
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        form: &EditForm,
+        status: Option<(&str, bool)>,
+    ) {
         let rows = Layout::vertical([
             Constraint::Length(1), // heading
             Constraint::Length(1), // title field
@@ -692,31 +833,36 @@ impl NotesPanel {
                 .map(|index| {
                     // The editor scrolls sideways as well as down, so a long
                     // line does not carry the caret off the right-hand edge.
-                    // `visible` owns the arithmetic — it is measured in display
-                    // cells, and getting that wrong here is what invariant 9 is
-                    // about.
-                    let (text, caret) = form.body.visible(index, width);
-                    match caret.filter(|_| editing) {
-                        // Draw the caret inline rather than moving the terminal
-                        // cursor: the panel does not own the screen cursor, and
-                        // a caret that only appears in the focused field is
-                        // what tells the user where typing will land.
-                        Some(at) => Line::from(vec![
-                            Span::styled(text[..at].to_string(), Style::default().fg(theme.text)),
-                            Span::styled("▏", Style::default().fg(theme.accent)),
-                            Span::styled(text[at..].to_string(), Style::default().fg(theme.text)),
-                        ]),
-                        None => Line::from(Span::styled(text, Style::default().fg(theme.text))),
-                    }
+                    // `visible_with_selection` owns the arithmetic — it is
+                    // measured in display cells, and getting that wrong here
+                    // is what invariant 9 is about.
+                    let (text, caret, selection) = form.body.visible_with_selection(index, width);
+                    // Draw the caret inline rather than moving the terminal
+                    // cursor: the panel does not own the screen cursor, and a
+                    // caret that only appears in the focused field is what
+                    // tells the user where typing will land.
+                    Self::editor_line(&text, caret.filter(|_| editing), selection, theme)
                 })
                 .collect();
             frame.render_widget(Paragraph::new(lines), rows[3]);
         }
 
-        let footer = match &form.error {
-            Some(message) => Span::styled(message.clone(), Style::default().fg(theme.error)),
-            None => Span::styled(
-                "Tab field   Ctrl+S save   Esc cancel",
+        let footer = match (&form.error, status) {
+            (Some(message), _) => Span::styled(message.clone(), Style::default().fg(theme.error)),
+            (None, Some((message, is_error))) => Span::styled(
+                message.to_string(),
+                Style::default().fg(if is_error { theme.error } else { theme.muted }),
+            ),
+            (None, None) if form.body.has_selection() => Span::styled(
+                "Ctrl+C copy   Ctrl+V replace   Ctrl+S save",
+                Style::default().fg(theme.muted),
+            ),
+            (None, None) if form.field == Field::Body => Span::styled(
+                "Shift+arrows select   Ctrl+A all   Ctrl+V paste",
+                Style::default().fg(theme.muted),
+            ),
+            (None, None) => Span::styled(
+                "Tab body   Ctrl+S save   Esc cancel",
                 Style::default().fg(theme.muted),
             ),
         };
@@ -749,7 +895,12 @@ impl Panel for NotesPanel {
     }
 
     fn bindings(&self) -> &'static [Binding] {
-        BINDINGS
+        match &self.mode {
+            Mode::Edit(form) if form.body.has_selection() => SELECTION_BINDINGS,
+            Mode::Edit(form) if form.field == Field::Body => BODY_EDIT_BINDINGS,
+            Mode::Edit(_) => TITLE_EDIT_BINDINGS,
+            _ => LIST_BINDINGS,
+        }
     }
 
     fn refresh_interval(&self) -> std::time::Duration {
@@ -788,6 +939,37 @@ impl Panel for NotesPanel {
             Mode::Search(_) => self.handle_search_key(key),
             Mode::ConfirmDelete { .. } => self.handle_confirm_key(key),
         }
+    }
+
+    fn copy_selection(&mut self) -> KeyOutcome {
+        self.copy_body_selection_with(crate::clipboard::copy)
+    }
+
+    fn handle_paste(&mut self, text: &str) -> KeyOutcome {
+        self.status = None;
+        let Mode::Edit(form) = &mut self.mode else {
+            return KeyOutcome::Ignored;
+        };
+
+        let text = text.replace("\r\n", "\n").replace('\r', "\n");
+        let count = text.chars().count();
+        match form.field {
+            Field::Body => form.body.insert_text(&text),
+            Field::Title => {
+                // A title is one line. Preserve the words from a multiline
+                // paste without letting Enter accidentally submit the form.
+                for character in text.chars() {
+                    match character {
+                        '\n' | '\t' => form.title.insert(' '),
+                        c if !c.is_control() => form.title.insert(c),
+                        _ => {}
+                    }
+                }
+            }
+        }
+        form.error = None;
+        self.set_status(format!("pasted {count} chars from terminal"));
+        KeyOutcome::Consumed
     }
 
     fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> KeyOutcome {
@@ -833,7 +1015,11 @@ impl Panel for NotesPanel {
         self.detail_area = None;
 
         if let Mode::Edit(form) = &self.mode {
-            Self::render_form(frame, area, theme, form);
+            let status = self
+                .status
+                .as_ref()
+                .map(|(message, is_error)| (message.as_str(), *is_error));
+            Self::render_form(frame, area, theme, form, status);
             return;
         }
 
@@ -966,6 +1152,10 @@ mod tests {
 
     fn press(p: &mut NotesPanel, code: KeyCode) {
         p.handle_key(KeyEvent::new(code, KeyModifiers::NONE));
+    }
+
+    fn chord(p: &mut NotesPanel, code: KeyCode, modifiers: KeyModifiers) {
+        p.handle_key(KeyEvent::new(code, modifiers));
     }
 
     fn type_str(p: &mut NotesPanel, text: &str) {
@@ -1206,6 +1396,112 @@ mod tests {
     }
 
     #[test]
+    fn selected_body_text_can_be_copied_and_reused() {
+        let (mut p, _g) = panel("copy-paste");
+        add_note(&mut p, "Scratch", "red blue");
+        press(&mut p, KeyCode::Enter);
+        assert_eq!(p.bindings()[0].key, "Tab", "the title points to the body");
+        press(&mut p, KeyCode::Tab);
+        assert_eq!(p.bindings()[0].action, "select");
+
+        for _ in 0..4 {
+            chord(&mut p, KeyCode::Left, KeyModifiers::SHIFT);
+        }
+        assert_eq!(p.bindings()[0].key, "Ctrl+C");
+        assert_eq!(
+            p.copy_body_selection_with(|text| {
+                assert_eq!(text, "blue");
+                Ok(())
+            }),
+            KeyOutcome::Consumed
+        );
+        assert_eq!(p.clipboard.as_deref(), Some("blue"));
+
+        // Select another word and replace it with the internal copy. This does
+        // not depend on the terminal accepting OSC 52 or exposing a readable
+        // system clipboard.
+        press(&mut p, KeyCode::Home);
+        for _ in 0..3 {
+            chord(&mut p, KeyCode::Right, KeyModifiers::SHIFT);
+        }
+        chord(&mut p, KeyCode::Char('v'), KeyModifiers::CONTROL);
+
+        let Mode::Edit(form) = &p.mode else {
+            unreachable!()
+        };
+        assert_eq!(form.body.value(), "blue blue");
+        assert!(!form.body.has_selection(), "paste consumes the selection");
+        assert_eq!(
+            p.status.as_ref().map(|s| s.0.as_str()),
+            Some("pasted 4 chars")
+        );
+    }
+
+    #[test]
+    fn terminal_paste_preserves_multiline_scratchpad_text() {
+        let (mut p, _g) = panel("terminal-paste");
+        add_note(&mut p, "Scratch", "red blue");
+        press(&mut p, KeyCode::Enter);
+        press(&mut p, KeyCode::Tab);
+        press(&mut p, KeyCode::Home);
+        for _ in 0..3 {
+            chord(&mut p, KeyCode::Right, KeyModifiers::SHIFT);
+        }
+
+        assert_eq!(p.handle_paste("one\r\ntwo\t"), KeyOutcome::Consumed);
+        let Mode::Edit(form) = &p.mode else {
+            unreachable!()
+        };
+        assert_eq!(form.body.value(), "one\ntwo\t blue");
+        assert!(!form.body.has_selection());
+        assert_eq!(
+            p.status.as_ref().map(|s| s.0.as_str()),
+            Some("pasted 8 chars from terminal")
+        );
+    }
+
+    #[test]
+    fn ctrl_c_remains_quit_when_the_editor_has_nothing_to_copy() {
+        let (mut p, _g) = panel("copy-empty");
+        press(&mut p, KeyCode::Char('a'));
+        press(&mut p, KeyCode::Tab);
+        assert_eq!(
+            p.copy_body_selection_with(|_| panic!("copy must not be called")),
+            KeyOutcome::Ignored
+        );
+    }
+
+    #[test]
+    fn a_body_selection_is_visibly_reversed() {
+        let theme = Theme::default();
+        let line = NotesPanel::editor_line("abcd", Some(3), Some(1..3), &theme);
+        let selected: String = line
+            .spans
+            .iter()
+            .filter(|span| span.style.add_modifier.contains(Modifier::REVERSED))
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert_eq!(selected, "bc");
+        assert!(line.spans.iter().any(|span| span.content == "▏"));
+    }
+
+    #[test]
+    fn copy_and_paste_both_reach_the_border_at_the_default_width() {
+        let line = crate::frame::hint_line(
+            SELECTION_BINDINGS,
+            &Theme::default(),
+            28, // a 36-column default Notes panel reserves eight for its frame
+        )
+        .expect("the selected-text actions should fit");
+        let text: String = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(text.contains("Ctrl+C copy · Ctrl+V paste"), "got {text:?}");
+    }
+
+    #[test]
     fn editing_an_existing_note_updates_it_in_place() {
         let (mut p, _g) = panel("edit");
         add_note(&mut p, "Original", "body");
@@ -1329,7 +1625,7 @@ mod tests {
     fn every_documented_key_works_and_every_working_key_is_documented() {
         for (code, key) in DOCUMENTED_LIST_KEYS {
             assert!(
-                BINDINGS.iter().any(|b| b.key == *key),
+                LIST_BINDINGS.iter().any(|b| b.key == *key),
                 "`{key}` is handled but missing from BINDINGS, so nothing tells the user it exists"
             );
 

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -324,7 +324,8 @@ impl NotesPanel {
     }
 
     /// Send the selected body text outward and retain it for an in-editor
-    /// paste. The injected writer keeps the OSC 52 side effect out of tests.
+    /// paste. The selection then collapses so another Ctrl+C can quit. The
+    /// injected writer keeps the OSC 52 side effect out of tests.
     fn copy_body_selection_with(
         &mut self,
         copy: impl FnOnce(&str) -> std::io::Result<()>,
@@ -349,6 +350,9 @@ impl NotesPanel {
                 true,
             ),
         });
+        if let Mode::Edit(form) = &mut self.mode {
+            form.body.clear_selection();
+        }
         KeyOutcome::Consumed
     }
 
@@ -1416,6 +1420,14 @@ mod tests {
             KeyOutcome::Consumed
         );
         assert_eq!(p.clipboard.as_deref(), Some("blue"));
+        let Mode::Edit(form) = &p.mode else {
+            unreachable!()
+        };
+        assert!(!form.body.has_selection(), "copy collapses the selection");
+        assert_eq!(
+            p.copy_body_selection_with(|_| panic!("a second Ctrl+C must fall through")),
+            KeyOutcome::Ignored
+        );
 
         // Select another word and replace it with the internal copy. This does
         // not depend on the terminal accepting OSC 52 or exposing a readable


### PR DESCRIPTION
# Summary

Turns the Notes body editor into a practical scratchpad with visible keyboard selection and reliable copy/paste, while preserving Mirador's existing `Ctrl+C` quit behaviour when no text is selected.

## What changed

- Shift plus arrows/Home/End extends a visible selection, and `Ctrl+A` selects the complete body.
- Typing, Enter, Backspace, Delete, and paste replace selected text using character-safe multiline ranges.
- `Ctrl+C` sends the selection through OSC 52 and retains an internal copy; `Ctrl+V` inserts or replaces from that copy even when the terminal declines OSC 52.
- Bracketed terminal paste preserves outside multiline text and literal tabs, with terminal modes restored on normal exit and panic.
- The editing border and footer switch contextually so selection, copy, and paste remain discoverable at the default Notes width.

## How it was tested

- Added focused tests for forward/backward and multiline selection, Unicode byte boundaries, selected newlines, replacement editing, selection rendering, internal clipboard reuse, external multiline paste, `Ctrl+C` fallback, and default-width hints.
- Visually checked the default dashboard dump.
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (765 passed, 7 ignored)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
- `cargo +1.95.0 check --all-targets`
- `cargo publish --dry-run`

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes
- [x] New behaviour has tests, or there is a note below explaining why not
- [x] `CHANGELOG.md` updated under `Unreleased` for any user-visible change
- [x] Documentation updated: README and the shipped config guidance; no config option was added

## Notes for the reviewer

Rebased onto v1.4.1, keeping both its bounded Notes reader cache and this branch's clipboard state. The full suite passes on this host.