### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-08-01
+
+### Fixed
+
+- **A long note or task note no longer slows the whole dashboard down.** The
+  notes reader wrapped a note's entire body on every frame and then scrolled
+  past most of it, and the task panel did the same to fill a two-row preview —
+  so the cost of drawing was proportional to what you had written rather than
+  to what was on screen. A two-megabyte note cost 62ms a frame against a 250ms
+  tick; it now costs under a third of a millisecond, and the cost no longer
+  grows with the note.
+
+  Nothing about what is drawn has changed.
+
 ## [1.4.0] - 2026-08-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1552,7 +1552,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.4.0` is released**, on crates.io and as a GitHub release with binaries
+- **`1.4.1` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog for #180, which closed #178.

Patch: a performance fix with no change to what is drawn. A 2 MB note cost 62 ms a frame against a 250 ms tick and now costs under a third of a millisecond, with the cost no longer growing with the note.

No config key added, removed or renamed; no data file changed shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)