### PR TITLE
Add a provenance-aware --update entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`mirador --update` upgrades both installer- and Cargo-managed copies.** It
+  hands release installs to the existing `mirador-update` helper and crates.io
+  installs back to Cargo, so the dashboard can advertise one command without
+  knowing how it was installed. On Windows it moves the running executable
+  aside before waiting for the updater, because Cargo cannot replace a mapped
+  `.exe`; the next launch removes that old image. The standalone updater stays
+  available for compatibility, and no network request happens without an
+  explicit update command or the existing opt-in update check.
+
 ## [1.4.1] - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,21 +127,26 @@ is the stronger check and the one to run if you care:
 gh attestation verify --repo jchultarsky/mirador mirador-aarch64-apple-darwin.tar.gz
 ```
 
-They also install `mirador-update` beside it, so a later upgrade is:
+Whether you installed with Cargo or one of those installers, a later upgrade is:
 
 ```sh
-mirador-update
+mirador --update
 ```
 
-It asks GitHub what the newest release is and installs it if that is newer than
-what you have. It runs **only when you run it** — mirador itself never phones
-home and does not know this program exists, unless you set
+The flag hands an installer-managed copy to the `mirador-update` program placed
+beside it, and a crates.io copy back to Cargo. The separate `mirador-update`
+command remains available for compatibility. A binary installed directly from
+an archive has no installation record to follow, so update it manually or run
+an installer once.
+
+Updating runs **only when you ask for it** — the normal dashboard never phones
+home, unless you set
 `[general].check_for_updates = true`, which asks crates.io once a day whether a
 newer version exists and says so once in the status bar. That setting is off by
 default, sends no identifier, caches its answer, fails silently, and is
 overridden by `NO_UPDATE_CHECK=1` or `DO_NOT_TRACK=1` in your environment. If you
-installed with `cargo install` or from source, upgrade the same way you
-installed; the updater is only for the two installers above.
+installed from source or through another package manager, upgrade the same way
+you installed.
 
 From source:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1703,7 +1703,7 @@ impl App {
             Ok(guard) => guard.clone(),
             Err(poisoned) => poisoned.into_inner().clone(),
         }?;
-        Some(format!("mirador {latest} is out   mirador-update "))
+        Some(format!("mirador {latest} is out   mirador --update "))
     }
 
     fn render_help(&mut self, frame: &mut ratatui::Frame, area: Rect) {
@@ -2478,7 +2478,7 @@ mod tests {
         let hint = app.update_hint().expect("a found version should show");
         assert!(hint.contains("9.9.9"), "got `{hint}`");
         assert!(
-            hint.contains("mirador-update"),
+            hint.contains("mirador --update"),
             "the notice must say what to do about it: `{hint}`"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod theme;
 mod theme_picker;
 mod themes;
 mod update;
+mod upgrade;
 mod watch;
 mod widgets;
 mod zones;
@@ -69,6 +70,7 @@ OPTIONS:
         --reset-config     Replace the config with the defaults, keeping a copy
         --factory-reset    Start over: config, preferences, tasks, notes and
                            watchlist all set aside, nothing deleted
+        --update           Update through the installer or Cargo and exit
     -y, --yes              Do not ask for confirmation
     -h, --help             Print this help and exit
     -V, --version          Print the version and exit
@@ -100,13 +102,14 @@ struct Args {
     migrate_config: bool,
     reset_config: bool,
     factory_reset: bool,
+    update: bool,
     /// Skip the confirmation `--reset-config` would otherwise ask for.
     assume_yes: bool,
     help: bool,
     version: bool,
 }
 
-/// Parse arguments without pulling in a CLI framework for four flags.
+/// Parse arguments without pulling in a CLI framework for this small flag set.
 fn parse_args(raw: impl Iterator<Item = String>) -> Result<Args> {
     let mut args = Args::default();
     let mut iter = raw.into_iter();
@@ -120,6 +123,7 @@ fn parse_args(raw: impl Iterator<Item = String>) -> Result<Args> {
             "--migrate-config" => args.migrate_config = true,
             "--reset-config" => args.reset_config = true,
             "--factory-reset" => args.factory_reset = true,
+            "--update" => args.update = true,
             "-y" | "--yes" => args.assume_yes = true,
             "-c" | "--config" => {
                 let value = iter.next().ok_or_else(|| {
@@ -139,6 +143,7 @@ fn parse_args(raw: impl Iterator<Item = String>) -> Result<Args> {
 }
 
 fn main() -> ExitCode {
+    upgrade::cleanup_stale();
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
@@ -315,6 +320,8 @@ fn run() -> Result<()> {
     if args.version {
         println!("mirador {}", env!("CARGO_PKG_VERSION"));
         return Ok(());
+    } else if args.update {
+        return upgrade::run();
     }
     if args.print_config {
         print!("{}", config::DEFAULT_CONFIG);
@@ -468,6 +475,7 @@ mod tests {
         assert!(parse(&["--migrate-config"]).unwrap().migrate_config);
         assert!(parse(&["--reset-config"]).unwrap().reset_config);
         assert!(parse(&["--factory-reset"]).unwrap().factory_reset);
+        assert!(parse(&["--update"]).unwrap().update);
         // The two are separate commands, not degrees of one: a config reset
         // must never quietly take the tasks with it.
         assert!(!parse(&["--reset-config"]).unwrap().factory_reset);
@@ -528,6 +536,8 @@ mod tests {
             "--config-path",
             "--migrate-config",
             "--reset-config",
+            "--factory-reset",
+            "--update",
             "--yes",
             "--help",
             "--version",

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,365 @@
+//! An explicit upgrade, handed back to whichever installer owns this copy.
+//!
+//! cargo-dist installs `mirador-update` beside release binaries, while
+//! `cargo install mirador` installs only `mirador`. The dashboard cannot tell
+//! those apart when it prints an update notice, so the stable entry point is
+//! `mirador --update`: use the sibling updater when it exists, otherwise ask
+//! Cargo whether it owns this executable and hand the install back to it.
+//!
+//! Windows adds one constraint. Neither updater can replace an executable that
+//! is still running, so this process renames itself aside before waiting for
+//! the updater. The next launch removes that old image after Windows releases
+//! it. Unix permits replacing a running executable and needs no handoff.
+
+#[cfg(windows)]
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+#[derive(Debug, PartialEq, Eq)]
+enum Method {
+    Installer(PathBuf),
+    Cargo { root: PathBuf },
+}
+
+/// Update this installation and wait for the owning installer to finish.
+pub fn run() -> Result<()> {
+    let current = std::env::current_exe().context("finding the running mirador executable")?;
+    let method = method(&current)?;
+
+    #[cfg(windows)]
+    {
+        run_on_windows(&current, &method)
+    }
+
+    #[cfg(not(windows))]
+    execute(&method)
+}
+
+/// Remove the executable a successful Windows update left behind.
+///
+/// Best-effort on purpose: failing to clean yesterday's binary must not stop
+/// today's dashboard from opening. A later `--update` reports the failure
+/// before it moves anything.
+pub fn cleanup_stale() {
+    #[cfg(windows)]
+    if let Ok(current) = std::env::current_exe() {
+        let _ = std::fs::remove_file(backup_path(&current));
+    }
+}
+
+fn method(current: &Path) -> Result<Method> {
+    let updater = current.with_file_name(if cfg!(windows) {
+        "mirador-update.exe"
+    } else {
+        "mirador-update"
+    });
+    if updater
+        .try_exists()
+        .with_context(|| format!("checking for {}", updater.display()))?
+    {
+        return Ok(Method::Installer(updater));
+    }
+
+    let root = cargo_root(current).ok_or_else(|| {
+        anyhow::anyhow!(
+            "this copy has no installer updater beside it and is not in a Cargo bin directory.\n\n\
+             Re-run mirador's installer, or update it with the package manager that put {} here.",
+            current.display()
+        )
+    })?;
+    let output = Command::new("cargo")
+        .args(["install", "--list", "--root"])
+        .arg(&root)
+        .output()
+        .with_context(|| {
+            format!(
+                "this looks like a Cargo installation at {}, but `cargo` could not be started",
+                root.display()
+            )
+        })?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "Cargo could not inspect the installation at {} ({}).",
+            root.display(),
+            output.status
+        );
+    }
+    let installed = String::from_utf8_lossy(&output.stdout);
+    if !crates_io_owns_mirador(&installed) {
+        anyhow::bail!(
+            "this copy has no installer updater, and Cargo does not record it as a crates.io install.\n\n\
+             Update it with the package manager or source checkout that put {} here.",
+            current.display()
+        );
+    }
+
+    Ok(Method::Cargo { root })
+}
+
+fn cargo_root(current: &Path) -> Option<PathBuf> {
+    let bin = current.parent()?;
+    if !bin
+        .file_name()?
+        .to_string_lossy()
+        .eq_ignore_ascii_case("bin")
+    {
+        return None;
+    }
+    bin.parent().map(Path::to_path_buf)
+}
+
+/// A registry install has no source in parentheses; path and git installs do.
+fn crates_io_owns_mirador(installed: &str) -> bool {
+    installed.lines().any(|line| {
+        line.strip_prefix("mirador v")
+            .is_some_and(|rest| rest.ends_with(':') && !rest.contains(" ("))
+    })
+}
+
+fn execute(method: &Method) -> Result<()> {
+    let mut command = match method {
+        Method::Installer(updater) => {
+            println!("Updating this installer-managed copy.");
+            Command::new(updater)
+        }
+        Method::Cargo { root } => {
+            println!("Updating this Cargo installation.");
+            let mut cargo = Command::new("cargo");
+            cargo
+                .args(["install", "mirador", "--locked", "--root"])
+                .arg(root)
+                .args(["--bin", "mirador"]);
+            cargo
+        }
+    };
+
+    let status = command.status().context("starting the updater")?;
+    if !status.success() {
+        anyhow::bail!("the updater exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn run_on_windows(current: &Path, method: &Method) -> Result<()> {
+    let mut moved = MovedExecutable::new(current)?;
+    match execute(method) {
+        Ok(()) => {
+            if current
+                .try_exists()
+                .with_context(|| format!("checking for updated {}", current.display()))?
+            {
+                moved.keep();
+            } else {
+                // The installer updater returns success when this version is
+                // already current. In that case it writes nothing, so put the
+                // unchanged executable straight back.
+                moved.restore()?;
+            }
+            Ok(())
+        }
+        Err(update_error) => {
+            moved
+                .restore()
+                .with_context(|| format!("the update failed ({update_error:#})"))?;
+            Err(update_error)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn backup_path(current: &Path) -> PathBuf {
+    let mut name = current
+        .file_stem()
+        .map_or_else(|| OsString::from("mirador"), OsString::from);
+    name.push("-update-old");
+    if let Some(extension) = current.extension() {
+        name.push(".");
+        name.push(extension);
+    }
+    current.with_file_name(name)
+}
+
+/// A running Windows image can be renamed but not deleted or overwritten.
+#[cfg(windows)]
+struct MovedExecutable {
+    original: PathBuf,
+    backup: PathBuf,
+    settled: bool,
+}
+
+#[cfg(windows)]
+impl MovedExecutable {
+    fn new(current: &Path) -> Result<Self> {
+        let backup = backup_path(current);
+        match std::fs::remove_file(&backup) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("removing the previous update copy at {}", backup.display())
+                });
+            }
+        }
+        std::fs::rename(current, &backup).with_context(|| {
+            format!(
+                "moving the running executable aside from {} to {}",
+                current.display(),
+                backup.display()
+            )
+        })?;
+        Ok(Self {
+            original: current.to_path_buf(),
+            backup,
+            settled: false,
+        })
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        if self.original.try_exists()? {
+            self.settled = true;
+            anyhow::bail!(
+                "the updater wrote {}, so the previous executable was kept at {} instead of overwriting it",
+                self.original.display(),
+                self.backup.display()
+            );
+        }
+        std::fs::rename(&self.backup, &self.original).with_context(|| {
+            format!(
+                "restoring {} from {}",
+                self.original.display(),
+                self.backup.display()
+            )
+        })?;
+        self.settled = true;
+        Ok(())
+    }
+
+    fn keep(&mut self) {
+        self.settled = true;
+    }
+}
+
+#[cfg(windows)]
+impl Drop for MovedExecutable {
+    fn drop(&mut self) {
+        if !self.settled && !self.original.exists() {
+            let _ = std::fs::rename(&self.backup, &self.original);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_root_is_the_parent_of_a_bin_directory() {
+        assert_eq!(
+            cargo_root(Path::new("/opt/mirador/bin/mirador")),
+            Some(PathBuf::from("/opt/mirador"))
+        );
+        assert_eq!(cargo_root(Path::new("/opt/mirador/debug/mirador")), None);
+    }
+
+    #[test]
+    fn only_a_crates_io_install_is_claimed_by_cargo() {
+        assert!(crates_io_owns_mirador(
+            "other v1.0.0:\n    other\nmirador v1.4.1:\n    mirador.exe\n"
+        ));
+        assert!(!crates_io_owns_mirador(
+            "mirador v1.4.1 (C:\\src\\mirador):\n    mirador.exe\n"
+        ));
+        assert!(!crates_io_owns_mirador(
+            "mirador v1.4.1 (https://github.com/example/mirador):\n    mirador\n"
+        ));
+        assert!(!crates_io_owns_mirador("some-mirador v1.4.1:\n"));
+    }
+
+    #[test]
+    fn a_sibling_updater_wins_without_a_cargo_receipt() {
+        let dir =
+            std::env::temp_dir().join(format!("mirador-upgrade-method-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let current = dir.join(if cfg!(windows) {
+            "mirador.exe"
+        } else {
+            "mirador"
+        });
+        let updater = current.with_file_name(if cfg!(windows) {
+            "mirador-update.exe"
+        } else {
+            "mirador-update"
+        });
+        std::fs::write(&updater, b"updater").unwrap();
+
+        assert_eq!(method(&current).unwrap(), Method::Installer(updater));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(windows)]
+    mod windows {
+        use super::*;
+
+        struct TempDir(PathBuf);
+
+        impl Drop for TempDir {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        fn executable(name: &str) -> (PathBuf, TempDir) {
+            let dir =
+                std::env::temp_dir().join(format!("mirador-upgrade-{}-{name}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            let path = dir.join("mirador.exe");
+            std::fs::write(&path, b"old").unwrap();
+            (path, TempDir(dir))
+        }
+
+        #[test]
+        fn a_moved_executable_can_be_restored_after_failure() {
+            let (current, _guard) = executable("restore");
+            let backup = backup_path(&current);
+            let mut moved = MovedExecutable::new(&current).unwrap();
+            assert!(!current.exists());
+            assert!(backup.exists());
+
+            moved.restore().unwrap();
+            assert_eq!(std::fs::read(&current).unwrap(), b"old");
+            assert!(!backup.exists());
+        }
+
+        #[test]
+        fn a_failed_updater_restores_the_running_executable() {
+            let (current, guard) = executable("failed-command");
+            let method = Method::Installer(guard.0.join("missing-updater.exe"));
+
+            let error = run_on_windows(&current, &method).unwrap_err();
+            assert!(error.to_string().contains("starting the updater"));
+            assert_eq!(std::fs::read(&current).unwrap(), b"old");
+            assert!(!backup_path(&current).exists());
+        }
+
+        #[test]
+        fn a_successful_replacement_leaves_the_old_image_for_next_launch() {
+            let (current, _guard) = executable("replace");
+            let backup = backup_path(&current);
+            let mut moved = MovedExecutable::new(&current).unwrap();
+            std::fs::write(&current, b"new").unwrap();
+            moved.keep();
+            drop(moved);
+
+            assert_eq!(std::fs::read(&current).unwrap(), b"new");
+            assert_eq!(std::fs::read(&backup).unwrap(), b"old");
+            std::fs::remove_file(&backup).unwrap();
+            assert!(!backup.exists());
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Adds `mirador --update` as one user-facing upgrade command while retaining the existing cargo-dist `mirador-update` helper.

The immediate bug is reproducible on Windows: this machine has `mirador v1.3.2` from crates.io, `cargo install --list` records only `mirador.exe`, and `Get-Command mirador-update` finds nothing. That is expected from the packaging—`install-updater = true` applies to the shell and PowerShell installers, not `cargo install`—but the opt-in update notice currently advertises `mirador-update` to every installation.

## What changed

- Adds and documents `mirador --update`, and points the dashboard's update notice at it.
- Prefers the existing sibling `mirador-update` for installer-managed releases, preserving cargo-dist's receipt and update path.
- Otherwise asks Cargo for the install receipt and delegates only a crates.io-owned copy to `cargo install mirador --locked --root <same-root> --bin mirador`.
- Refuses manual archives, path/git installs, and other package-manager copies with an actionable message instead of silently changing who owns the installation.
- On Windows, moves the running `.exe` aside before waiting for either updater. A mapped executable cannot be replaced there; a failed/no-op update restores it, while a successful replacement removes the old image on the next launch.
- Keeps both update paths explicitly invoked. Normal dashboard startup still makes no update request unless the existing opt-in check is enabled.

## How it was tested

- Added focused tests for CLI parsing/help, installer precedence, Cargo receipt classification, Windows move/restore, successful replacement cleanup, and rollback after an updater launch failure.
- Reproduced the original machine state: Cargo owns `mirador v1.3.2`, but no `mirador-update` command exists.
- Confirmed a synchronous Cargo replacement fails on Windows with `Access is denied (os error 5)` while the installed executable is running.
- Confirmed the same Cargo v0.1 → v0.2 replacement succeeds without `--force` after moving the running executable aside.
- Ran the real cargo-dist updater in an isolated install root: a v1.4.0 receipt successfully installed v1.4.1 with the main executable moved aside.
- Exercised both `mirador --update` handoffs end to end in isolated Windows roots; each wrote a replacement and the next launch removed the old image.
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (760 passed, 7 ignored)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
- `cargo +1.95.0 check --all-targets`
- `cargo publish --dry-run`

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes
- [x] New behaviour has tests, or there is a note below explaining why not
- [x] `CHANGELOG.md` updated under `Unreleased` for any user-visible change
- [x] Documentation updated: README; no config option was added

## Notes for the reviewer

This deliberately does not remove or reimplement cargo-dist's updater. It gives mirador one stable entry point, then hands control back to the existing owner of the installation.

The Windows rename is necessary rather than defensive ceremony: Cargo's replacement was measured both ways, failing against the running path and succeeding once that same running image was renamed. The previous executable remains recoverable throughout the operation.