### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-08-02
+
+Both features in this release came from outside the project, contributed by
+[@krflol](https://github.com/krflol).
+
 ### Added
 
 - **Notes can select, copy and paste body text as a scratchpad.** Shift plus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1552,7 +1552,7 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.4.1` is released**, on crates.io and as a GitHub release with binaries
+- **`1.5.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and changelog for #177 and #182.

Minor: two new user-visible features.

- **Notes become a scratchpad** — visible selection, `Ctrl+C` / `Ctrl+V`, bracketed paste (#177)
- **`mirador --update`** — one upgrade command that works whether the copy came from an installer or from `cargo install` (#182)

The second fixes a real defect: the update notice was telling every installation to run `mirador-update`, which `cargo install` users do not have.

**Both features came from outside the project**, contributed by @krflol. That is a first for mirador and the changelog says so.

No config key added, removed or renamed; no data file changed shape, so the 1.0 compatibility promise holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)