### PR TITLE
Make the contributor docs true, and enforce the parts that can be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1618,7 +1618,14 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/jchultarsky/mirador/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/jchultarsky/mirador/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/jchultarsky/mirador/compare/v1.3.2...v1.4.0
+[1.3.2]: https://github.com/jchultarsky/mirador/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/jchultarsky/mirador/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/jchultarsky/mirador/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/jchultarsky/mirador/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/jchultarsky/mirador/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/jchultarsky/mirador/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/jchultarsky/mirador/compare/v1.1.0...v1.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
 store.rs     write_atomic — every file mirador owns goes through it
 state.rs     UI-changed preferences, remembered across restarts
 update.rs    the opt-in update check — off unless the config turns it on
+upgrade.rs   `--update`: hands an installer copy to `mirador-update` and a
+             crates.io copy back to Cargo, and refuses anything it does not own
 watch.rs     the watch log's events and the rule that decides what is one
 feed.rs      enough RSS for a headline; quick-xml, unlike ical.rs — see below
 task.rs      task model + TOML store
@@ -133,11 +135,15 @@ quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
 poll.rs      the sliced sleep the two fetch threads share
 samples.rs   the bounded history behind the cpu and network graphs
 selection.rs list cursor movement and click-to-row
+clipboard.rs OSC 52, with base64 hand-rolled rather than taken as a dependency
 textfield.rs single-line text editor used by task entry
-textarea.rs  multi-line text editor used by note bodies
+textarea.rs  multi-line text editor used by note bodies, with the
+             selection the notes clipboard acts on
 dateinput.rs due-date entry
 ical.rs      enough RFC 5545 to answer "what is next"; no new dependencies
 calc.rs      the calculator's parser: precedence, brackets, bounded depth
+docs.rs      the guard on *this file* — cited tests, version, paths, and that
+             every module below is listed
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
              pomodoro, watchlog, news, cpu, network, calculator
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 286 of them, including the ones mirador
+    trip through `toml` discards all 290 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,25 +23,35 @@ cargo run
 
 Requires Rust 1.95 or newer.
 
-Before pushing, run what CI runs. All six, not the first three — the last two
-catch things the others cannot, and both have reddened `main` before: a broken
-intra-doc link only `cargo doc` sees, and an `exclude` in `Cargo.toml` that
-dropped a file the build needed.
+Before pushing, run what CI runs. All six, not the first three — the last three
+catch things the others cannot, and each has reddened `main` before: a broken
+intra-doc link only `cargo doc` sees, an `exclude` in `Cargo.toml` that dropped
+a file the build needed, and a dependency `cargo deny` refused.
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
-cargo test --all-targets
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --all-targets
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+cargo deny check
 cargo publish --dry-run
 ```
 
-CI also builds and tests on macOS, and type-checks against the minimum
-supported Rust version:
+`--locked` matters and is not decoration: without it cargo will quietly rewrite
+`Cargo.lock` to satisfy a build, so a local run can pass against a dependency
+set the repository does not contain. CI passes it everywhere for that reason.
+
+CI also builds and tests on macOS **and Windows**, and type-checks against the
+minimum supported Rust version:
 
 ```sh
-cargo +1.95.0 check --all-targets
+cargo +1.95.0 check --locked --all-targets
 ```
+
+Windows is in that matrix because a Windows-only startup panic once sat in
+`main`, and more recently because a test spawned a command that does not exist
+there — found by a contributor running the suite on their own machine, not by
+CI, whose runner image happened to provide it.
 
 Note that `clippy` gates some lints on the `rust-version` field, so a newer
 toolchain locally can report warnings CI does not, and vice versa. When the two
@@ -58,19 +68,31 @@ cargo run -- --config /tmp/mirador.toml
 
 The `Panel` trait in `src/panel.rs` is the seam. It is in-tree — mirador has no
 library target and `widgets::build` dispatches on a fixed match — so adding a
-widget means a pull request rather than a separate crate. Five places to touch:
+widget means a pull request rather than a separate crate. Six places to touch:
 
 1. Create `src/widgets/<name>.rs` and implement `Panel`.
-2. Add a config struct to `src/config/widgets.rs` and a field on `Config` in
-   `src/config/mod.rs`, with a `Default` implementation for every value. Mark
-   the struct `#[serde(default, deny_unknown_fields)]` — a config key that is
-   silently ignored makes a stale config look like stale code.
+2. Add a config struct to `src/config/widgets.rs`, add the type to the
+   `pub use widgets::{…}` list in `src/config/mod.rs`, and add a field on
+   `Config` in the same file. All three: the field names the type unqualified,
+   so without the re-export it does not compile. Give every value a `Default`,
+   and mark the struct `#[serde(default, deny_unknown_fields)]` — a config key
+   that is silently ignored makes a stale config look like stale code.
 3. Add the name to `WIDGET_NAMES` and an arm to `build` in
    `src/widgets/mod.rs`.
-4. Document the widget in `assets/default_config.toml` and in the README's
+4. **If your widget draws through `crate::grid::Grid`**, add
+   `("<name>", crate::widgets::<name>::COLUMNS)` to `EVERY_GRID` in
+   `src/grid.rs`. A test walks the tree for `const COLUMNS` declarations and
+   fails if the registry disagrees, because a grid that is not listed is a grid
+   the overflow sweep never checks — and an unchecked grid draws rows wider than
+   its panel, which the terminal then cuts without saying so.
+5. Document the widget in `assets/default_config.toml` and in the README's
    widget table.
-5. Add tests for the logic that is not drawing — parsing, formatting,
+6. Add tests for the logic that is not drawing — parsing, formatting,
    thresholds, state transitions.
+
+Steps 2 and 4 are the ones that bite. The calculator is the proof: the pull
+request that added the panel touched no `src/grid.rs` at all, and a later one
+had to add the registry entry when the panel gained a grid.
 
 Widgets must not block. If your widget needs network or disk I/O, do it on a
 background thread and poll the result in `tick`, as `weather.rs` does. A panel
@@ -97,9 +119,12 @@ dashboard.
 ## Adding a theme
 
 Write `assets/themes/<name>.toml` and add it to `BUNDLED` in `src/themes.rs`.
-That is the whole change — the `t` picker lists whatever is in `BUNDLED`.
+The `t` picker then lists it — that part needs nothing else. Two prose counts
+do have to follow, though, and nothing pins them: "Ten ship inside the binary"
+in `assets/default_config.toml`, and the theme table in the README.
 
-Four things will catch you out, and each has a test rather than a convention:
+Four things will catch you out. The first three have tests rather than
+conventions behind them:
 
 1. **Colour keys go *before* `[palette]` and before the gradient tables.** TOML
    assigns every key after a table header to that table, so a colour written
@@ -107,9 +132,12 @@ Four things will catch you out, and each has a test rather than a convention:
 2. **Set every key in `Theme::KEYS`** unless the theme `inherits` another.
 3. **The filename must be `[A-Za-z0-9_-]+`.** A theme is looked up by name, not
    by path, so anything else cannot be loaded.
-4. **`text` stays `reset`.** Body text follows the reader's own terminal
-   foreground; pinning it to your palette breaks on the half of terminals not
-   configured the way yours is.
+4. **`text` stays `reset` in a ported palette.** Body text follows the reader's
+   own terminal foreground; pinning it to your palette breaks on the half of
+   terminals not configured the way yours is. This one is a convention rather
+   than a test, and `high-contrast` is the deliberate exception — it sets
+   `text = "white"`, because guaranteed contrast is the entire point of that
+   theme and deferring to the terminal would defeat it.
 
 Keep `border` and `muted` distinct, or secondary text ends up as dim as the
 chrome and reads as broken rather than de-emphasised.
@@ -144,8 +172,15 @@ on buffers and selections, and round-tripping data through disk. The task panel
 is tested by driving the same key events the terminal sends, which is usually
 the clearest way to test panel behaviour.
 
-Rendering itself is not unit tested. Keep drawing code thin so that the logic
-worth testing lives outside it.
+Drawing *is* tested, and some of the strongest guards here are render tests:
+`no_grid_in_the_program_ever_overflows_its_width`,
+`every_widget_renders_at_any_size_without_panicking`, and the sweeps that check
+no panel draws a value the terminal will cut in half. Render into ratatui's
+`TestBackend` and assert on what reached the cells rather than on internal
+state — a buffer is the only place some of these faults are visible.
+
+Keep drawing code thin anyway, so the logic worth testing can also be tested
+without a terminal.
 
 ## Commit messages
 
@@ -158,10 +193,22 @@ obvious. Reference the issue number when there is one.
 Maintainers only:
 
 1. Update `CHANGELOG.md`, moving items out of `Unreleased` into a new version
-   section with a date.
-2. Bump `version` in `Cargo.toml`.
+   section with a date — **and add the link definition at the foot of the file**
+   alongside the others, then repoint `[Unreleased]` at the new tag. Seven
+   releases in a row skipped this and rendered as plain text instead of compare
+   links; `every_released_version_has_a_changelog_link` now fails if you do.
+2. Bump `version` in `Cargo.toml`, and the released-version line in
+   `CLAUDE.md` — a test compares the two.
 3. `cargo publish --dry-run` to check the packaged crate.
-4. Tag `vX.Y.Z` and push the tag.
+4. **Open a pull request for the bump and merge it.** `main` is protected, so
+   the version commit arrives as a squash.
+5. **Tag the squashed commit on `main`**, not your local one. Tagging before the
+   merge appears to work — the tag pushes, the release workflow runs, the
+   artifacts are right — and then the squash orphans the commit underneath it,
+   so `git describe` on `main` cannot see the release.
+6. `cargo publish`. The release workflow builds and uploads the GitHub release
+   artifacts; it does **not** publish the crate. That step is manual and comes
+   after the tag.
 
 ## Code of conduct
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -16,7 +16,10 @@
 # Docs: https://github.com/jchultarsky/mirador#configuration
 
 [general]
-# Frame budget in milliseconds. Lower is smoother and uses more CPU.
+# How long mirador waits for a key or resize before looking around again,
+# in milliseconds. Not a frame budget: the screen is redrawn when something
+# actually changes, not on a clock, so lowering this does not make anything
+# smoother — it only wakes the process more often. Clamped to 16-5000.
 tick_rate_ms = 250
 show_borders = true
 show_status_bar = true
@@ -85,8 +88,9 @@ rows = [
     # The timer draws block numerals when it has the width for them and falls
     # back to plain text when it does not.
     { widget = "pomodoro", width = 24 },
-    # 30 keeps the change column at 120 columns; below a panel width of 33 the
-    # markets grid drops it rather than clipping a number.
+    # 30 keeps the change column at 120 columns; below a panel width of 35 the
+    # markets grid drops it rather than clipping a number. 35 because the grid
+    # needs 29, plus 2 for the selection marker and 4 for the frame.
     { widget = "stocks",   width = 30 },
     { widget = "cpu",      width = 20 },
     { widget = "network",  width = 26 },

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -56,7 +56,7 @@ impl Default for Layout {
                     &[
                         ("pomodoro", 24),
                         // 30 rather than 28 so the change column survives at
-                        // 120 columns. Below a panel width of 33 the grid drops
+                        // 120 columns. Below a panel width of 35 the grid drops
                         // it rather than clipping a number, which is right — but
                         // "what is the portfolio doing" is one of the four
                         // questions, and the answer is the change, not the last

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -87,7 +87,12 @@ pub struct Config {
 // relationship the settings do not have.
 #[allow(clippy::struct_excessive_bools)]
 pub struct General {
-    /// Frame budget in milliseconds. Lower is smoother and burns more CPU.
+    /// How long to wait for an event before looking around again, in
+    /// milliseconds.
+    ///
+    /// Not a frame budget, despite how it reads: the redraw follows visible
+    /// change rather than the tick, so lowering this wakes the process more
+    /// often without making anything smoother.
     pub tick_rate_ms: u64,
     /// Draw a border around each panel.
     pub show_borders: bool,

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -196,6 +196,62 @@ mod tests {
         );
     }
 
+    /// Every released version has a changelog link definition.
+    ///
+    /// `CHANGELOG.md` uses reference-style headings — `## [1.5.0]` — which
+    /// render as plain text unless a matching `[1.5.0]: <url>` sits at the foot
+    /// of the file. Seven consecutive releases shipped without one, so seven
+    /// version headings on GitHub read as literal brackets rather than as
+    /// compare links.
+    ///
+    /// Nothing noticed, because the file still parsed, the release still went
+    /// out, and the defect is only visible rendered. That is the shape of every
+    /// entry in this module: true-looking prose that no build step reads.
+    #[test]
+    fn every_released_version_has_a_changelog_link() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("CHANGELOG.md");
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()))
+            .replace("\r\n", "\n");
+
+        let versions: Vec<String> = text
+            .lines()
+            .filter_map(|line| line.strip_prefix("## ["))
+            .filter_map(|rest| rest.split(']').next())
+            .filter(|v| v.starts_with(|c: char| c.is_ascii_digit()))
+            .map(str::to_string)
+            .collect();
+        assert!(
+            versions.len() > 10,
+            "only {} version headings found — the format probably changed and \
+             this check has stopped looking at anything",
+            versions.len()
+        );
+
+        let missing: Vec<&String> = versions
+            .iter()
+            .filter(|v| !text.contains(&format!("\n[{v}]: http")))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "{} released version(s) have no link definition: {missing:?}\n\n\
+             Add `[X.Y.Z]: <compare url>` at the foot of CHANGELOG.md beside \
+             the others. Without it the heading renders as literal brackets.",
+            missing.len()
+        );
+
+        // The moving one, which is wrong rather than merely absent when stale.
+        let newest = versions.first().expect("at least one version");
+        assert!(
+            text.contains(&format!(
+                "[Unreleased]: https://github.com/jchultarsky/mirador/compare/v{newest}...HEAD"
+            )),
+            "[Unreleased] should compare against v{newest}, the newest release. \
+             A stale one presents shipped work as unreleased, which is worse \
+             than a missing link."
+        );
+    }
+
     /// Every module in `src/` appears in the architecture map.
     ///
     /// The map is the first thing a reader consults and the easiest thing to

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -196,6 +196,59 @@ mod tests {
         );
     }
 
+    /// Every module in `src/` appears in the architecture map.
+    ///
+    /// The map is the first thing a reader consults and the easiest thing to
+    /// forget: it was missing `docs.rs`, `upgrade.rs` and `clipboard.rs` at
+    /// once — one added by a maintainer, one by an outside contributor, one
+    /// mentioned in the prose below but never in the list. None of the other
+    /// checks here could see it, because a module that is absent cites no test
+    /// and no path.
+    ///
+    /// Absence is the failure mode this file exists to catch, and it is the
+    /// one that a citation-based check is structurally blind to. So this
+    /// compares the map against the tree instead.
+    #[test]
+    fn every_module_is_named_in_the_architecture_map() {
+        let notes = notes();
+        let map = notes
+            .split("## Architecture")
+            .nth(1)
+            .and_then(|rest| rest.split("```").nth(1))
+            .expect("CLAUDE.md must carry an ```-fenced map under `## Architecture`");
+
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut missing = Vec::new();
+        for entry in std::fs::read_dir(&root).expect("src/ must exist").flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "rs") {
+                let name = path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned();
+                // `main.rs` is the entry point rather than a component, and the
+                // map opens by describing it in prose instead of listing it.
+                if name == "main.rs" {
+                    continue;
+                }
+                if !map.contains(&name) {
+                    missing.push(name);
+                }
+            }
+        }
+        missing.sort();
+
+        assert!(
+            missing.is_empty(),
+            "the architecture map does not mention {}: {missing:?}\n\n\
+             Add a line for each. The map is what a reader consults first, and \
+             a module missing from it is a module they will not know exists — \
+             which is exactly how three of them went unlisted at once.",
+            missing.len()
+        );
+    }
+
     /// The discriminator is empirical, so it is worth knowing when it stops
     /// selecting anything — a filter that matches nothing passes every time
     /// and checks nothing, which is the shape of failure this whole module

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 286;
+        const CITED: usize = 290;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))


### PR DESCRIPTION
First of three cleanup PRs. Found by an adversarial audit of the docs against the code; every finding below was independently verified before acting on it.

CONTRIBUTING.md is what an outside contributor follows, and this project now has one — so it goes first.

## The widget recipe did not work

It said **"five places to touch"** and omitted two of them:

- A widget drawing through the shared `Grid` must be added to `EVERY_GRID` in `src/grid.rs`, or `every_grid_in_the_program_is_on_this_list` fails. **The calculator is the proof**: the PR that added the panel touched no `grid.rs`, and a later one had to add the entry.
- Step 2 said to add a `Config` field without mentioning the `pub use widgets::{…}` re-export that makes the type name resolve. Followed literally, it does not compile.

## "Rendering itself is not unit tested" was false

There are **37 `TestBackend` sites**, and several are the strongest guards in the repo — `no_grid_in_the_program_ever_overflows_its_width`, `every_widget_renders_at_any_size_without_panicking`. That sentence told newcomers not to write the exact tests that have caught the most real bugs here.

## "Run what CI runs. All six" listed five

The missing one was `cargo deny check`, so a contributor adding a dependency reddened CI with no local warning. (I ran it while writing this — it passes.) None of the commands used `--locked`, which CI does deliberately: without it cargo rewrites `Cargo.lock` to satisfy the build, and a local run can pass against a dependency set the repo does not contain. **Windows was missing** from the platforms CI covers — the one a macOS contributor most needs to know about.

## A theme rule claimed a test it does not have

Rule 4 — "`text` stays `reset`" — sits under a sentence promising each rule has a test rather than a convention. There is no sweep over `BUNDLED`, and `high-contrast.toml` ships `text = "white"`. The rule is now scoped to ported palettes with the exception named, and the promise narrowed to the three rules that keep it.

## The release recipe never published the crate

And it tagged the wrong commit. Both facts were recorded in CLAUDE.md; neither was where a maintainer following CONTRIBUTING would meet them.

## Two config comments were wrong about the code

- **`tick_rate_ms` is not a frame budget.** Drawing is dirty-flag driven, so lowering it wakes the process more often without making anything smoother. It was described that way in both the shipped config and `config/mod.rs`.
- **The markets width threshold is 35, not 33.** The 33 forgets the selection marker; `layout.rs` stated both numbers four lines apart.

## Enforced rather than asserted

`every_released_version_has_a_changelog_link`.

**Seven consecutive releases** shipped without their changelog link definitions — 1.2.0 through 1.5.0 — so seven headings render as literal `[1.5.0] - 2026-08-02` instead of compare links. `[Unreleased]` still compared against `v1.1.3`, presenting all seven as unreleased work, which is worse than a missing link because it is actively wrong.

Definitions added; the test fails on either fault. Both failure modes checked by reintroducing them.

Four gates silent plus `cargo deny check`. 771 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)