### PR TITLE
Record the plugin direction where the code contradicts it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,14 @@ makes it the one panel where a nagging design would do real damage, which is
 why the chime defaults off and a paused timer greys out instead of blinking.
 The filter still holds for anything not asked for by name.
 
+**The filter governs what mirador *ships*, which after discussion #191 is
+narrower than it used to be.** If external panels happen, "does this answer one
+of the four questions" decides what goes in the binary; it does not decide what
+a reader may put on their own dashboard. The two cases that forced the
+distinction are worth keeping: an audiobook client is welcome as a plugin and
+would never be a widget here, and a terminal is refused in **both** places. The
+filter and the plugin boundary are different rules and they do not always agree.
+
 **Identified gaps, agreed:** (1) calendar / next event is the biggest hole —
 tasks are self-paced, a meeting is externally imposed and time-critical;
 (2) nothing shows what *changed* since you last looked; (3) no single "is
@@ -818,6 +826,40 @@ which is the one key the project guarantees always gets you out; and that what
 the case actually wants is a panel that *watches* a process rather than hosts
 one. The filter in "Product decisions already settled" now has to hold against
 people who do not know it exists.
+
+**And the answer did not stay a no.** krflol took the counter-proposal — a panel
+that *watches* a process — and came back with something larger.
+[Discussion #191](https://github.com/jchultarsky/mirador/discussions/191)
+proposes external panels as separate processes exchanging bounded, versioned
+JSON-lines messages: a working prototype against 1.5.0, an optional Python SDK
+in a repository of their own, and three examples chosen to span the range — the
+conservative process-watch panel, the terminal as a deliberate boundary test,
+and an Audiobookshelf client picked *because* it is obviously not core.
+
+**The owner said yes, and the reason had never been written down anywhere.**
+External widgets were in the original vision — "Grafana for the terminal,
+personal rather than corporate" — and the reason they were never built is that
+every design considered either embedded Python or Lua, or a public Rust API, and
+both were worse than not having the feature. A process boundary costs neither,
+which is why `panel.rs` no longer declares itself not-a-plugin-API.
+
+Nothing is built and what was posted is a position rather than a contract, but
+these parts were stated firmly and are the ones to hold: `Ctrl+C` stays
+host-owned with **no** exception, not even the first press; plugins take input
+from the start, because a panel you can only watch is not much of a widget;
+**the host does the clipping**, since a plugin cannot be trusted with invariant
+19 and the terminal cuts silently either way; an external panel must be visibly
+external, because mirador promises it does not phone home and a plugin can; the
+host never sees, stores, forwards or logs a plugin's credentials; and **no
+PTY**.
+
+**The boundary is *a view with controls* versus *a host for another program*,**
+and the audiobook client is what settled it. Off-axis-ness is not the test —
+that plugin is as far from the four questions as anything could be and is
+entirely welcome, because it is still a view. A terminal is a different kind of
+thing however on-topic its contents happen to be. The line is not crisp and the
+reply said so rather than writing a rule that would not survive its third
+example.
 
 ## Recently settled, so it is not re-litigated
 
@@ -1530,13 +1572,21 @@ note weighed rather than what the pane showed. The task panel had the identical
 defect one panel over. Both are cached now, and the cost is flat in the size of
 the note.
 
-There is an open **discussion**, which is not the same as an open issue:
-[#188](https://github.com/jchultarsky/mirador/discussions/188) proposes a
-terminal widget. The answer given was that mirador is a pane *inside* tmux or
-zellij rather than a replacement for one, and that what the proposer actually
-wants — to be told when a long task finishes — is a panel that *watches* a
-process rather than one that hosts a shell. Recorded here because it is the
-first identity question the project has been asked from outside.
+The live work is a **discussion**, which is not the same as an open issue:
+[#191](https://github.com/jchultarsky/mirador/discussions/191), external panels
+over a process boundary. The owner has said yes to the direction and posted the
+invariants he wants it to hold to; krflol has a working prototype and has not
+yet replied. **The next step is agreeing the contract in text, before either
+side judges the implementation** — that ordering was proposed deliberately, so
+the prototype is reviewed against a written contract rather than against
+somebody's instincts.
+
+It grew out of [#188](https://github.com/jchultarsky/mirador/discussions/188),
+which asked for a terminal widget and was answered no — mirador is a pane
+*inside* tmux or zellij rather than a replacement for one. That answer still
+holds and is now part of the plugin contract rather than a one-off refusal: no
+PTY, in-tree or out. See "Contributions from outside" for what was committed to
+and why.
 
 This heading has now described the wrong issue as the last one three times —
 #132, then #153, now #153 again after #178 closed. The entry is written when

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -1,16 +1,28 @@
 //! The [`Panel`] trait: the seam every dashboard widget goes through.
 //!
-//! **This is an in-tree seam, not a plugin API.** mirador is a binary crate
-//! with no library target, so nothing outside it can name this trait; and even
-//! if it could, `widgets::build` dispatches on a fixed `match` over
-//! `WIDGET_NAMES` and each widget's settings are a field on `Config`. Adding a
-//! widget is a pull request, and `CONTRIBUTING.md` lists the five places to
-//! touch. A real plugin story needs three things this does not have: a runtime
-//! registry instead of that `match`, per-widget config carried as an
-//! unparsed `toml::Value` so a widget can own its own schema, and a library
-//! target with a deliberate public surface. Adding only the last of those
-//! would make the trait nameable without making it usable, which is worse than
-//! the honest version.
+//! **This is an in-tree seam.** mirador is a binary crate with no library
+//! target, so nothing outside it can name this trait; `widgets::build`
+//! dispatches on a fixed `match` over `WIDGET_NAMES`; and each widget's
+//! settings are a field on `Config`. Adding a widget is a pull request, and
+//! `CONTRIBUTING.md` lists the six places to touch.
+//!
+//! This paragraph used to go on to say it was *not a plugin API* and was not
+//! going to become one. That is no longer the project's position — external
+//! panels are being designed in
+//! [discussion #191](https://github.com/jchultarsky/mirador/discussions/191).
+//! Nothing above it has changed; what changed is that it is a description of
+//! the code rather than a decision about the code.
+//!
+//! Which obstacles a plugin story faces depends on where the boundary is, and
+//! that part is worth keeping. Someone implementing *this trait* out of tree
+//! would need three things mirador does not have: a runtime registry instead of
+//! that `match`, per-widget config carried as an unparsed `toml::Value` so a
+//! widget can own its own schema, and a library target with a deliberate public
+//! surface. A **process** boundary needs the first two and eliminates the
+//! third — which is the expensive one, because a public Rust API is a semver
+//! commitment on every type it touches. That asymmetry is why the process
+//! design is the one being explored, and adding only the library target would
+//! still make the trait nameable without making it usable.
 //!
 //! What the seam does buy, in-tree, is real: a panel owns its own state and
 //! refresh cadence. The application shell is


### PR DESCRIPTION
`src/panel.rs` opens with **"This is an in-tree seam, not a plugin API"** and explains why a plugin story is out of scope. A public position was taken on [discussion #191](https://github.com/jchultarsky/mirador/discussions/191) that external panels *are* wanted — so anyone reading the repo cold would find the source contradicting the maintainer.

## What changed

**`src/panel.rs`** — the factual half is untouched and still true: no library target, a fixed `match` over `WIDGET_NAMES`, config as fields on `Config`. What goes is the claim that this is settled.

The three-obstacle list is kept and sharpened rather than deleted, because it turns out to be the argument *for* the design being explored. An out-of-tree implementor of the trait needs a runtime registry, per-widget config as an unparsed `toml::Value`, and a library target with a public surface. A **process** boundary needs the first two and eliminates the third — the expensive one, since a public Rust API is a semver commitment on every type it touches.

**`CLAUDE.md`**, three places:

- *Contributions from outside* — how #188's no became #191's yes, the history that had never been written down (external widgets were in the original vision; embedded Python/Lua and a public Rust API were both worse than not having the feature), and the six commitments posted with the yes.
- *Product decisions already settled* — the filter decides what mirador **ships**, not what a reader may put on their own dashboard. An audiobook client is welcome as a plugin and would never be a widget here; a terminal is refused in both places. Two different rules that do not always agree.
- *Open work* — #188 replaced by #191, with the next step recorded: agree the contract in text before either side judges the prototype.

**One stale fact fixed in passing:** `panel.rs` said `CONTRIBUTING.md` lists *five* places to touch. #189 made it six.

## What this deliberately does not say

Nothing is built and nothing is agreed. The reply on #191 is a position; krflol has not answered it. The notes say so in as many words, so a future session does not read this as a decision already taken.

## Checks

All four gates clean — 771 tests, clippy, fmt, and `RUSTDOCFLAGS="-D warnings" cargo doc`.

Stacked on #192; GitHub will retarget to `main` as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)