### PR TITLE
Add a bounded external panel protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **External panels are an explicit, language-neutral process boundary.** A
+  configured command can publish styled frame snapshots and opt into bounded
+  key, paste and mouse events. Mirador embeds no interpreter,
+  performs no plugin discovery, and starts no process unless its id is placed
+  in the layout. Each process is isolated from the UI thread; startup, message
+  rate, retained output and input queues are bounded; Mirador owns cell-aware
+  wrapping and clipping; external tiles are labelled; and Ctrl+C remains an
+  unconditional host-owned exit even when a child is stuck. The protocol is
+  documented independently so SDKs do not link against Mirador's private Rust
+  `Panel` trait. External panels can also hand bounded, completed events to
+  Mirador's native Watch Log.
+
 ## [1.5.1] - 2026-08-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,10 @@ glyphs.rs    block numerals, bold-uppercase labels, weather art
 theme.rs     colours and gradient stops
 themes.rs    `theme = "name"`: bundled themes, inherits, palettes
 config/      mod.rs: paths, loading, validation; widgets.rs: one settings
-             struct per panel; layout.rs: the grid
+             struct per panel; layout.rs: the grid; plugins.rs: explicit
+             process declarations and plugin-owned opaque config
+plugin/      mod.rs: external Panel adapter, bounded input and rendering;
+             process.rs: JSON-lines workers, limits and child lifecycle
 picker.rs    the `w` dialog — owns its cursor, returns an Action to the shell
 theme_picker.rs the `t` dialog — same shape, but previews as the cursor moves
 arrange.rs   the `m` mode's arithmetic: where a panel goes when you move it
@@ -392,9 +395,9 @@ why the chime defaults off and a paused timer greys out instead of blinking.
 The filter still holds for anything not asked for by name.
 
 **The filter governs what mirador *ships*, which after discussion #191 is
-narrower than it used to be.** With external panels, "does this answer one of
-the four questions" decides what goes in the binary; it does not decide what a
-reader may put on their own dashboard. The two cases that forced the
+narrower than it used to be.** If external panels happen, "does this answer one
+of the four questions" decides what goes in the binary; it does not decide what
+a reader may put on their own dashboard. The two cases that forced the
 distinction are worth keeping: an audiobook client is welcome as a plugin and
 would never be a widget here, and a terminal is refused in **both** places. The
 filter and the plugin boundary are different rules and they do not always agree.
@@ -841,18 +844,17 @@ External widgets were in the original vision — "Grafana for the terminal,
 personal rather than corporate" — and the reason they were never built is that
 every design considered either embedded Python or Lua, or a public Rust API, and
 both were worse than not having the feature. A process boundary costs neither,
-which is why `panel.rs` now distinguishes the private in-tree trait from the
-public process protocol instead of trying to turn one into the other.
+which is why `panel.rs` no longer declares itself not-a-plugin-API.
 
-The contract is now written in `docs/plugin-protocol.md`, independently of any
-SDK, and these are the parts the host must keep: `Ctrl+C` stays host-owned with
-**no** plugin exception; plugins take input from the start, because a panel you
-can only watch is not much of a widget; **the host does the clipping and
-wrapping**, since a plugin cannot be trusted with invariant 19 and the terminal
-cuts silently either way; an external panel is visibly external, because
-mirador promises it does not phone home and a plugin can; credentials have no
-host configuration, persistence or logging channel; startup, messages, rates,
-retention and queues are bounded; and **no PTY**.
+Nothing is built and what was posted is a position rather than a contract, but
+these parts were stated firmly and are the ones to hold: `Ctrl+C` stays
+host-owned with **no** exception, not even the first press; plugins take input
+from the start, because a panel you can only watch is not much of a widget;
+**the host does the clipping**, since a plugin cannot be trusted with invariant
+19 and the terminal cuts silently either way; an external panel must be visibly
+external, because mirador promises it does not phone home and a plugin can; the
+host never sees, stores, forwards or logs a plugin's credentials; and **no
+PTY**.
 
 **The boundary is *a view with controls* versus *a host for another program*,**
 and the audiobook client is what settled it. Off-axis-ness is not the test —
@@ -1588,12 +1590,14 @@ note weighed rather than what the pane showed. The task panel had the identical
 defect one panel over. Both are cached now, and the cost is flat in the size of
 the note.
 
-[Discussion #191](https://github.com/jchultarsky/mirador/discussions/191) is the
-source of the external-panel direction and its invariants. The agreed contract
-is the language-neutral specification in `docs/plugin-protocol.md`; the Rust
-code is the bounded host for that contract, not the API plugin authors link
-against. Judge changes to either against the written host obligations before
-judging an individual SDK or example plugin.
+The live work is a **discussion**, which is not the same as an open issue:
+[#191](https://github.com/jchultarsky/mirador/discussions/191), external panels
+over a process boundary. The owner has said yes to the direction and posted the
+invariants he wants it to hold to; krflol has a working prototype and has not
+yet replied. **The next step is agreeing the contract in text, before either
+side judges the implementation** — that ordering was proposed deliberately, so
+the prototype is reviewed against a written contract rather than against
+somebody's instincts.
 
 It grew out of [#188](https://github.com/jchultarsky/mirador/discussions/188),
 which asked for a terminal widget and was answered no — mirador is a pane

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,9 +392,9 @@ why the chime defaults off and a paused timer greys out instead of blinking.
 The filter still holds for anything not asked for by name.
 
 **The filter governs what mirador *ships*, which after discussion #191 is
-narrower than it used to be.** If external panels happen, "does this answer one
-of the four questions" decides what goes in the binary; it does not decide what
-a reader may put on their own dashboard. The two cases that forced the
+narrower than it used to be.** With external panels, "does this answer one of
+the four questions" decides what goes in the binary; it does not decide what a
+reader may put on their own dashboard. The two cases that forced the
 distinction are worth keeping: an audiobook client is welcome as a plugin and
 would never be a widget here, and a terminal is refused in **both** places. The
 filter and the plugin boundary are different rules and they do not always agree.
@@ -841,17 +841,18 @@ External widgets were in the original vision — "Grafana for the terminal,
 personal rather than corporate" — and the reason they were never built is that
 every design considered either embedded Python or Lua, or a public Rust API, and
 both were worse than not having the feature. A process boundary costs neither,
-which is why `panel.rs` no longer declares itself not-a-plugin-API.
+which is why `panel.rs` now distinguishes the private in-tree trait from the
+public process protocol instead of trying to turn one into the other.
 
-Nothing is built and what was posted is a position rather than a contract, but
-these parts were stated firmly and are the ones to hold: `Ctrl+C` stays
-host-owned with **no** exception, not even the first press; plugins take input
-from the start, because a panel you can only watch is not much of a widget;
-**the host does the clipping**, since a plugin cannot be trusted with invariant
-19 and the terminal cuts silently either way; an external panel must be visibly
-external, because mirador promises it does not phone home and a plugin can; the
-host never sees, stores, forwards or logs a plugin's credentials; and **no
-PTY**.
+The contract is now written in `docs/plugin-protocol.md`, independently of any
+SDK, and these are the parts the host must keep: `Ctrl+C` stays host-owned with
+**no** plugin exception; plugins take input from the start, because a panel you
+can only watch is not much of a widget; **the host does the clipping and
+wrapping**, since a plugin cannot be trusted with invariant 19 and the terminal
+cuts silently either way; an external panel is visibly external, because
+mirador promises it does not phone home and a plugin can; credentials have no
+host configuration, persistence or logging channel; startup, messages, rates,
+retention and queues are bounded; and **no PTY**.
 
 **The boundary is *a view with controls* versus *a host for another program*,**
 and the audiobook client is what settled it. Off-axis-ness is not the test —
@@ -1587,14 +1588,12 @@ note weighed rather than what the pane showed. The task panel had the identical
 defect one panel over. Both are cached now, and the cost is flat in the size of
 the note.
 
-The live work is a **discussion**, which is not the same as an open issue:
-[#191](https://github.com/jchultarsky/mirador/discussions/191), external panels
-over a process boundary. The owner has said yes to the direction and posted the
-invariants he wants it to hold to; krflol has a working prototype and has not
-yet replied. **The next step is agreeing the contract in text, before either
-side judges the implementation** — that ordering was proposed deliberately, so
-the prototype is reviewed against a written contract rather than against
-somebody's instincts.
+[Discussion #191](https://github.com/jchultarsky/mirador/discussions/191) is the
+source of the external-panel direction and its invariants. The agreed contract
+is the language-neutral specification in `docs/plugin-protocol.md`; the Rust
+code is the bounded host for that contract, not the API plugin authors link
+against. Judge changes to either against the written host obligations before
+judging an individual SDK or example plugin.
 
 It grew out of [#188](https://github.com/jchultarsky/mirador/discussions/188),
 which asked for a terminal widget and was answered no — mirador is a pane

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,11 +64,11 @@ mirador --print-config > /tmp/mirador.toml
 cargo run -- --config /tmp/mirador.toml
 ```
 
-## Adding a widget
+## Adding a built-in widget
 
-The `Panel` trait in `src/panel.rs` is the seam. It is in-tree — mirador has no
-library target and `widgets::build` dispatches on a fixed match — so adding a
-widget means a pull request rather than a separate crate. Six places to touch:
+The `Panel` trait in `src/panel.rs` is mirador's private in-tree seam. A widget
+that belongs in every installation still means a pull request. Six places to
+touch:
 
 1. Create `src/widgets/<name>.rs` and implement `Panel`.
 2. Add a config struct to `src/config/widgets.rs`, add the type to the
@@ -97,6 +97,17 @@ had to add the registry entry when the panel gained a grid.
 Widgets must not block. If your widget needs network or disk I/O, do it on a
 background thread and poll the result in `tick`, as `weather.rs` does. A panel
 that blocks freezes the whole dashboard.
+
+Personal or experimental panels do not need to become core widgets. The
+[external panel protocol](docs/plugin-protocol.md) is a versioned process
+boundary: it has no Rust ABI, lets the plugin own an opaque config table, and
+keeps language runtimes out of the Mirador binary. External plugins are not
+sandboxed; their command is an explicit trust decision by the person editing
+the config. Core owns the small host-side contract—reserved keys, rendering,
+bounds, lifecycle and compatibility—while SDKs, language runtimes and plugin
+support remain outside this repository. Protocol changes therefore need tests
+against those invariants and an update to the canonical specification, not a
+language-specific SDK in this tree.
 
 If your widget needs a setting the user can change from the keyboard, two
 things already exist for it. A value that is free text — a path, a place, a

--- a/README.md
+++ b/README.md
@@ -931,6 +931,36 @@ rather than failing quietly.
 | `cpu` | Average utilisation, a moving chart, and per-core meters |
 | `network` | Receive and transmit rates as moving charts |
 
+### External panels (optional)
+
+Mirador can host an explicitly configured panel process through its
+[versioned JSON-lines protocol](docs/plugin-protocol.md). This is a constrained
+customization boundary, not a second built-in widget system: the release binary
+embeds no interpreter, discovers nothing, and starts no process unless both its
+command is declared and its id is placed in the layout.
+
+```toml
+[[plugins]]
+id = "example"
+command = ["example-mirador-plugin"]
+
+[plugins.config]
+plugin_owned_setting = true
+```
+
+The host keeps `Ctrl+C`, rendering, clipping, wrapping, input arbitration and
+resource bounds on Mirador's side of the pipe. Every such tile is visibly
+marked `EXTERNAL`; it may accept focused input, but it cannot draw into the
+terminal or block the UI thread. The protocol deliberately offers no PTY or raw
+terminal capability.
+
+Plugin commands are trusted code with your permissions, not sandboxed
+extensions. Do not put credentials in Mirador's config or command arguments;
+a plugin that needs a login collects and owns it inside its panel. Optional
+language SDKs remain separate—the experimental Python SDK and example widgets
+at [krflol/mirador-plugins](https://github.com/krflol/mirador-plugins) are not a
+Python dependency or a Mirador support commitment.
+
 ### Market data
 
 The watchlist reads `query1.finance.yahoo.com`, the endpoint Yahoo's own charts
@@ -1141,9 +1171,10 @@ Bug reports, feature requests and pull requests are welcome. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the ground rules.
 
-Adding a widget means implementing the `Panel` trait, registering the name in
-`src/widgets/mod.rs`, and documenting it here. Nothing else in the codebase
-needs to know it exists.
+Adding a built-in widget means implementing the `Panel` trait, registering the
+name in `src/widgets/mod.rs`, and documenting it here. A personal or
+language-independent extension can instead implement the
+[external panel protocol](docs/plugin-protocol.md) without linking to Mirador.
 
 ## Acknowledgements
 

--- a/docs/plugin-protocol.md
+++ b/docs/plugin-protocol.md
@@ -83,7 +83,9 @@ Watch Log event or stderr diagnostic.
 Each placement owns one child process. Stdin and stdout carry UTF-8 JSON Lines;
 stderr is a diagnostic stream. On removal or normal application exit, Mirador
 sends `shutdown`, allows 300 ms for cleanup, then terminates a child that
-remains. A failed panel can be restarted with `r`.
+remains. The exit path waits, for at most one second, for the process supervisor
+to finish that grace-then-terminate sequence before terminal restoration. A
+failed panel can be restarted with `r`.
 
 ## Bounds
 
@@ -103,14 +105,16 @@ The host applies these v1 limits independently to every panel:
 | Undrained Watch Log events | 64, each at most 1,024 UTF-8 bytes |
 | Host-to-child input queue | 256 messages |
 | Child stderr accepted / retained | 64 KiB per second / latest 8 KiB |
+| Passive-key frame acknowledgement | 3 x `refresh_ms`, clamped to 100 ms through 1 second |
 
 Only the newest complete frame is retained. A newer frame replaces the prior
 one rather than entering a render queue. `refresh_ms` is clamped to 16 through
 60,000 ms, so a focused interactive panel cannot turn the shell into a busy
 loop.
 
-Crossing a protocol, startup, output-rate or retained-data limit fails that
-panel and terminates its child. A full host-to-child queue drops new input and
+Crossing a child protocol, startup, output-rate, retained-data or input-
+acknowledgement limit fails that panel and terminates its child. A full host-to-
+child queue or a host input message too large to encode drops the new input and
 shows a panel warning; input already claimed by a capturing panel never falls
 through as a Mirador global action.
 
@@ -280,8 +284,9 @@ drag, release and horizontal-wheel traffic is deliberately not part of v1.
 
 ## Input ownership
 
-Input policy is evaluated synchronously from the newest frame. Mirador never
-waits for a child to decide whether a global key is safe.
+Input policy is evaluated synchronously from the newest frame, plus the bounded
+host-owned race barrier described below. Mirador never waits for a child to
+decide whether a global key is safe.
 
 - `capture: true` is the same explicit text-entry or modal state used by an
   in-tree panel. While focused, it receives ordinary keys and suspends ordinary
@@ -299,7 +304,17 @@ explicit capture state the ordinary keys are suspended just as they are for a
 built-in editor; `Ctrl+C` remains reserved without exception.
 
 After Mirador accepts a named key from a passive panel, it conservatively
-captures subsequent input until a newer frame acknowledges the action. This
-closes the asynchronous transition where, for example, `Enter` opens a login
-form but a rapidly typed `q` arrives before the form's capture frame. Plugins
-publish a new frame after handling a named passive key.
+captures subsequent keyboard input for three of that panel's refresh intervals,
+clamped to at least 100 ms and at most one second. This closes the asynchronous
+transition where, for example, `Enter` opens a login form but a rapidly typed
+`q` arrives before the form's capture frame. Paste and mouse remain independent
+capabilities during this barrier: an event not opted into by the latest frame
+is not sent to the plugin or converted into fallback key events.
+
+Any valid frame accepted during the barrier acknowledges the action and
+releases it, even when its revision is equal to or older than the retained
+frame. This makes acknowledgement possible after `revision: u64::MAX` and keeps
+revision ordering separate from input ownership. If no frame arrives before
+the bound, Mirador fails the panel, terminates its child and returns input to
+the shell. Plugins therefore publish a frame after handling a named passive
+key; they cannot create an unbounded modal state by stalling.

--- a/docs/plugin-protocol.md
+++ b/docs/plugin-protocol.md
@@ -1,0 +1,305 @@
+# External panel protocol v1
+
+Mirador can adapt an explicitly configured child process into one dashboard
+tile. The process sends text and controls; Mirador remains the only renderer
+and the only owner of the real terminal.
+
+This is a language-neutral process protocol, not a public Rust API. Mirador
+owns the host and this specification. Plugin authors own everything on the
+other side of the pipe: language, runtime, dependencies, packaging, network
+access, plugin-specific configuration and support.
+
+## The contract
+
+When Mirador hosts an external panel, it keeps these permanent obligations:
+
+- `Ctrl+C` exits Mirador in every plugin state. It is never sent to a plugin.
+- Mirador fits, wraps and clips plugin text to the panel rectangle in terminal
+  cells. A wide line cannot overwrite a neighbouring panel.
+- Mirador enforces startup, message, rate, queue and retention bounds. A child
+  that blocks, floods, crashes or sends malformed data becomes a failed panel,
+  not a blocked dashboard or damaged terminal session.
+- Keyboard input follows the same focus and capture arbitration as an in-tree
+  panel. Mouse input goes to the panel under the pointer.
+- Every external tile is labelled `EXTERNAL` in its frame. Configuration names
+  the executable explicitly; Mirador never scans or discovers plugins.
+- The protocol remains compatible on Mirador's side of its version.
+- Mirador has no credential store or credential configuration channel. Input
+  sent to a focused plugin is not persisted, logged or forwarded elsewhere by
+  the host.
+
+With no external panel both declared and placed, Mirador starts no child,
+searches for no runtime and loads no additional code. Python, Lua and every
+other SDK remain optional projects outside the Mirador binary.
+
+## Scope and non-goals
+
+An external panel is still a widget: a bounded view with bounded controls. The
+protocol does not provide a PTY, raw terminal access, signal forwarding,
+scrollback, terminal copy mode, arbitrary cursor addressing or drawing outside
+the panel rectangle. It is not a terminal-multiplexer API, and Mirador will not
+grow those capabilities to support a shell-hosting plugin.
+
+A plugin may run ordinary background work, but it owns that work and any child
+processes it creates. Mirador sends shutdown to and, when necessary, terminates
+the configured plugin process; descendants are the plugin's responsibility.
+
+Plugin commands are arbitrary code running with the user's permissions. Pipes
+provide failure and rendering isolation, not a security sandbox. Configure
+only commands you trust.
+
+## Configuration and credentials
+
+Commands are argv arrays launched directly, without a platform shell. Paths
+and quoting therefore have the same meaning on Windows, Linux and macOS.
+
+```toml
+[[plugins]]
+id = "example"
+command = ["example-mirador-plugin", "--optional-argument"]
+
+[plugins.config]
+answer = 42
+
+[layout]
+rows = [
+  { height = 100, panels = [{ widget = "example", width = 100 }] },
+]
+```
+
+The id is a lowercase ASCII letter followed by lowercase letters, digits,
+hyphens or underscores. It cannot duplicate another plugin or a built-in
+widget id. `plugins.config` is plugin-owned TOML and reaches the child as JSON;
+Mirador does not interpret its schema.
+
+That table is configuration, not secret storage. Passwords, access tokens and
+other credentials must not appear in Mirador's config, command arguments or
+protocol diagnostics. A plugin that needs a login collects it through its own
+panel UI, masks it itself, and owns any persistence it offers. Mirador forwards
+focused key or paste input only to that plugin process and never writes it to a
+Mirador file. A plugin must likewise never echo a credential in a frame, error,
+Watch Log event or stderr diagnostic.
+
+Each placement owns one child process. Stdin and stdout carry UTF-8 JSON Lines;
+stderr is a diagnostic stream. On removal or normal application exit, Mirador
+sends `shutdown`, allows 300 ms for cleanup, then terminates a child that
+remains. A failed panel can be restarted with `r`.
+
+## Bounds
+
+The host applies these v1 limits independently to every panel:
+
+| Resource | Limit |
+| --- | ---: |
+| One stdin or stdout JSON-line message, including newline | 8 MiB |
+| Child stdout rate | 120 messages and 16 MiB per rolling second |
+| Time from process spawn to `ready` | 5 seconds |
+| Retained frame text | 1 MiB |
+| Lines / spans in one retained frame | 4,096 / 16,384 |
+| Bindings / passive input keys in one frame | 64 / 128 |
+| Ready or frame title / counter | 256 / 128 UTF-8 bytes |
+| Binding key / action | 64 / 256 UTF-8 bytes |
+| Non-fatal or fatal error text | 1,024 UTF-8 bytes |
+| Undrained Watch Log events | 64, each at most 1,024 UTF-8 bytes |
+| Host-to-child input queue | 256 messages |
+| Child stderr accepted / retained | 64 KiB per second / latest 8 KiB |
+
+Only the newest complete frame is retained. A newer frame replaces the prior
+one rather than entering a render queue. `refresh_ms` is clamped to 16 through
+60,000 ms, so a focused interactive panel cannot turn the shell into a busy
+loop.
+
+Crossing a protocol, startup, output-rate or retained-data limit fails that
+panel and terminates its child. A full host-to-child queue drops new input and
+shows a panel warning; input already claimed by a capturing panel never falls
+through as a Mirador global action.
+
+## Framing and version negotiation
+
+Each protocol message is one JSON object followed by `\n`; an unterminated
+final object is malformed rather than an implicit last line. The first host
+message is:
+
+```json
+{
+  "type": "hello",
+  "protocol": 1,
+  "host_version": "1.5.0",
+  "plugin": "example",
+  "config": {"answer": 42},
+  "cwd": "/current/working/directory"
+}
+```
+
+The first child message must arrive within five seconds and be:
+
+```json
+{
+  "type": "ready",
+  "protocol": 1,
+  "title": "Example",
+  "refresh_ms": 100
+}
+```
+
+The version must match exactly and `ready` is sent once. A frame or Watch Log
+event before `ready`, a second `ready`, an unknown field or message type, or
+malformed JSON ends the panel session.
+
+Version 1 is a compatibility commitment. A release that advertises v1 will
+not remove or redefine its fields, weaken host-owned keys, or lower its bounds.
+A future incompatible shape uses a new protocol number rather than silently
+changing this one.
+
+## Frames and host-owned rendering
+
+Frames are complete immutable snapshots, not patches. Revisions increase;
+late or duplicate revisions are ignored. Omitting a frame title uses the title
+negotiated by `ready` (or the configured plugin id when `ready` had none); it
+does not retain an override from an older frame.
+
+```json
+{
+  "type": "frame",
+  "revision": 7,
+  "title": "Example",
+  "counter": "ready",
+  "lines": [
+    {"spans": [
+      {"text": "hello ", "fg": "theme:text"},
+      {"text": "world", "fg": "ansi:10", "bold": true}
+    ]}
+  ],
+  "bindings": [
+    {"key": "Enter", "action": "open", "primary": true}
+  ],
+  "input": {
+    "capture": false,
+    "keys": ["Enter"],
+    "paste": false,
+    "mouse": false
+  },
+  "cursor": {"column": 3, "row": 0, "visible": true}
+}
+```
+
+Each `WireLine` is one logical line; line breaks are represented by another
+entry. Text, titles, counters, bindings and errors may not contain terminal
+control characters. Mirador rejects them rather than allowing an escape
+sequence to reach the real terminal. The host word-wraps logical lines by
+terminal display width, preserves span styles, clips to the available height,
+and replaces a glyph that cannot fit even one whole cell-width with an
+ellipsis. Ratatui is never asked to wrap plugin text.
+
+Cursor coordinates are zero-based viewport coordinates relative to the panel
+interior. They are clipped to that rectangle and are not remapped when the
+host wraps an over-wide logical line.
+
+Every span requires `text`. Optional `fg` and `bg` values accept:
+
+- `default` or `reset`;
+- `theme:border`, `theme:border_focused`, `theme:rule`, `theme:title`,
+  `theme:text`, `theme:muted`, `theme:label`, `theme:accent`, `theme:key`,
+  `theme:success`, `theme:warning`, `theme:error` or `theme:track`;
+- `ansi:0` through `ansi:255`;
+- a ratatui colour name or `#rrggbb`.
+
+The optional style flags are `bold`, `dim`, `italic`, `underlined` and
+`reversed`. Unknown colours fail the panel rather than changing meaning with a
+fallback.
+
+A child may report a visible error:
+
+```json
+{"type":"error","message":"connection lost","fatal":false}
+```
+
+A fatal error ends the process. A non-fatal error remains as a bounded panel
+notice until a later frame replaces it.
+
+## Watch Log events
+
+A plugin can hand a notable, completed event to Mirador's native Watch Log:
+
+```json
+{"type":"watch","text":"tests finished successfully in 42 seconds"}
+```
+
+Mirador supplies the timestamp and configured plugin id as the source. Text is
+one non-empty line. When the bounded queue is full, the oldest undrained event
+is discarded and the panel says so. This hook carries outcomes, not progress
+updates; the Watch Log's existing high bar for what counts still applies.
+
+## Host-to-child messages
+
+After negotiation the host may send the following messages. `shutdown` is the
+one exception to that ordering: it may follow `hello` immediately when Mirador
+exits or removes a panel during startup.
+
+```json
+{"type":"resize","columns":80,"rows":24}
+{"type":"focus","focused":true}
+{"type":"tick"}
+{"type":"paste","text":"one\ntwo"}
+{"type":"shutdown"}
+```
+
+Keys include both a stable code and the canonical chord used by `input.keys`:
+
+```json
+{
+  "type":"key",
+  "key":"Ctrl+x",
+  "code":"char",
+  "text":"x",
+  "modifiers":["Ctrl"]
+}
+```
+
+Named canonical keys include `Enter`, `Backspace`, `Tab`, `BackTab`, `Esc`,
+`Left`, `Right`, `Up`, `Down`, `Home`, `End`, `PageUp`, `PageDown`, `Delete`,
+`Insert`, and `F1` through `F12`. Modifier order is `Ctrl`, `Alt`, `Shift`,
+`Super`, `Hyper`, `Meta`. Character case is preserved.
+
+Mouse coordinates are panel-relative:
+
+```json
+{
+  "type":"mouse",
+  "kind":"down",
+  "button":"left",
+  "column":4,
+  "row":2,
+  "modifiers":[]
+}
+```
+
+Version 1 sends `down`, `scroll_up` and `scroll_down`. A `down` message names
+its `left`, `middle` or `right` button; wheel messages have no button. Motion,
+drag, release and horizontal-wheel traffic is deliberately not part of v1.
+
+## Input ownership
+
+Input policy is evaluated synchronously from the newest frame. Mirador never
+waits for a child to decide whether a global key is safe.
+
+- `capture: true` is the same explicit text-entry or modal state used by an
+  in-tree panel. While focused, it receives ordinary keys and suspends ordinary
+  global bindings.
+- `keys` names the canonical chords a passive panel consumes. Other keys fall
+  through to the shell.
+- `paste` and `mouse` opt into those event classes.
+- `Ctrl+C` is always consumed by the shell and exits Mirador. It is not a
+  protocol capability. A plugin uses an ordinary declared chord such as
+  `Ctrl+x` for its own cancel or interrupt action.
+
+A passive plugin cannot claim or advertise the shell's `q`, `Tab`, `BackTab`,
+`?`, `w`, `m`, `t`, `1` through `9`, `Ctrl+arrows`, or `Ctrl+C` bindings. In an
+explicit capture state the ordinary keys are suspended just as they are for a
+built-in editor; `Ctrl+C` remains reserved without exception.
+
+After Mirador accepts a named key from a passive panel, it conservatively
+captures subsequent input until a newer frame acknowledges the action. This
+closes the asynchronous transition where, for example, `Enter` opens a login
+form but a rapidly typed `q` arrives before the form's capture frame. Plugins
+publish a new frame after handling a named passive key.

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use ratatui::crossterm::event::{
 use ratatui::layout::{Constraint, Layout, Position, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
 
 use crate::config::Config;
 use crate::frame::{Binding, FrameSpec};
@@ -53,24 +53,6 @@ const GLOBAL: &[Binding] = &[
     Binding::extra("1-9", "jump to panel"),
     Binding::extra("Ctrl+C", "quit"),
 ];
-
-/// The text of `lines` with the styling dropped, for measuring.
-///
-/// Only the characters decide how text wraps, so a measurement does not need
-/// the spans — but it does need them concatenated in order, which is why this
-/// is not simply the first span of each line.
-fn plain_text(lines: &[Line<'_>]) -> String {
-    lines
-        .iter()
-        .map(|line| {
-            line.spans
-                .iter()
-                .map(|span| span.content.as_ref())
-                .collect::<String>()
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
 
 /// How long a run of resize keystrokes must be quiet before the layout is
 /// written back.
@@ -552,7 +534,7 @@ impl App {
                 dirty = false;
             }
 
-            if event::poll(tick_rate)? {
+            if event::poll(self.poll_wait(tick_rate))? {
                 match event::read()? {
                     // Only react to presses; on Windows every key also emits a
                     // release event, which would otherwise double every action.
@@ -757,6 +739,18 @@ impl App {
             .is_some_and(|slot| slot.panel.captures_input())
     }
 
+    /// Let a focused interactive panel request responsive asynchronous echo
+    /// without changing the dashboard-wide polling budget. The floor prevents
+    /// an external process from turning the shell into a busy loop.
+    fn poll_wait(&self, configured: Duration) -> Duration {
+        self.slots
+            .get(self.focus)
+            .filter(|slot| slot.panel.captures_input())
+            .map_or(configured, |slot| {
+                configured.min(slot.panel.refresh_interval().max(Duration::from_millis(16)))
+            })
+    }
+
     fn handle_key(&mut self, key: KeyEvent) {
         // Any key at all retires the startup hint. It has been read or it has
         // been ignored; either way it has had its turn.
@@ -768,15 +762,14 @@ impl App {
 
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
-        // Ctrl+C remains the terminal's quit key unless the focused editor has
-        // an actual text selection to copy. Merely being inside a form is not
-        // enough to steal the interrupt: with no selection, it still quits as
-        // it always has.
+        // Editors get first refusal only for a real selection. No modal panel,
+        // child process or external protocol can veto the escape hatch: after
+        // the selection collapses, Ctrl+C exits from every state.
         if ctrl && matches!(key.code, KeyCode::Char('c')) {
-            let copied = self.slots.get_mut(self.focus).is_some_and(|slot| {
+            let consumed = self.slots.get_mut(self.focus).is_some_and(|slot| {
                 slot.panel.copy_selection() == crate::panel::KeyOutcome::Consumed
             });
-            if copied {
+            if consumed {
                 return;
             }
             self.should_quit = true;
@@ -1047,7 +1040,7 @@ impl App {
         };
         match picker.handle_key(key) {
             crate::picker::Action::None => {}
-            crate::picker::Action::Toggle(name) => self.toggle_widget(name),
+            crate::picker::Action::Toggle(name) => self.toggle_widget(&name),
             crate::picker::Action::Close => {
                 self.picker = None;
                 // Written on close rather than on every toggle: someone trying
@@ -1224,7 +1217,9 @@ impl App {
                 // panel you just focused are the reason you pressed `?`.
                 self.help_scroll = 0;
             }
-            KeyCode::Char('w') => self.picker = Some(crate::picker::Picker::new()),
+            KeyCode::Char('w') => {
+                self.picker = Some(crate::picker::Picker::new(self.config.widget_names()));
+            }
             KeyCode::Char('t') => self.open_theme_picker(),
             KeyCode::Char('m') => self.enter_arrange(),
             KeyCode::Char(c @ '1'..='9') => {
@@ -1651,7 +1646,7 @@ impl App {
         for binding in GLOBAL.iter().filter(|b| b.primary) {
             parts.push(vec![
                 Span::styled("   ", muted),
-                Span::styled(binding.key, key_style),
+                Span::styled(binding.key.clone(), key_style),
                 Span::styled(format!(" {}", binding.action), muted),
             ]);
         }
@@ -1777,8 +1772,10 @@ impl App {
             ))
         };
         let entry = |binding: &Binding| {
+            let key = crate::grid::truncate(&binding.key, 12);
+            let padding = " ".repeat(12usize.saturating_sub(crate::grid::display_width(&key)));
             Line::from(vec![
-                Span::styled(format!("  {:<12}", binding.key), key_style),
+                Span::styled(format!("  {key}{padding}"), key_style),
                 Span::styled(binding.action.to_string(), muted),
             ])
         };
@@ -1802,12 +1799,16 @@ impl App {
         // close the overlay is no use once it has scrolled out of the overlay.
         let width = 46.min(area.width);
         let text_width = width.saturating_sub(crate::frame::FRAME_WIDTH).max(1);
-        // Measured after wrapping, not from `lines.len()`. The two differ
-        // whenever a line is longer than the popup, which the list of unused
-        // widgets routinely is — sizing from the unwrapped count is how the
-        // overlay came to be shorter than its own contents.
-        let text_height = crate::grid::wrapped_height(&plain_text(&lines), text_width);
-        let body = Paragraph::new(lines).wrap(Wrap { trim: false });
+        // Pre-wrap with Mirador's cell-aware rules. The focused panel may be an
+        // external process, so handing its binding text to ratatui's wrapper
+        // would give plugin-controlled emoji and combining marks a known panic
+        // path in the host renderer.
+        let lines: Vec<Line<'static>> = lines
+            .iter()
+            .flat_map(|line| crate::grid::wrap_line(line, usize::from(text_width)))
+            .collect();
+        let text_height = u16::try_from(lines.len()).unwrap_or(u16::MAX);
+        let body = Paragraph::new(lines);
 
         // Borders, the blank line, and the footer.
         let chrome = 4;
@@ -2153,9 +2154,9 @@ mod tests {
         whole.push(acc.clone());
         for binding in GLOBAL.iter().filter(|b| b.primary) {
             acc.push_str("   ");
-            acc.push_str(binding.key);
+            acc.push_str(&binding.key);
             acc.push(' ');
-            acc.push_str(binding.action);
+            acc.push_str(&binding.action);
             whole.push(acc.clone());
         }
 
@@ -3225,6 +3226,54 @@ mod tests {
         assert!(
             !app.should_quit,
             "Esc means back out of something, not quit"
+        );
+    }
+
+    #[test]
+    fn only_a_focused_capturing_panel_can_shorten_the_event_wait() {
+        struct ResponsivePanel {
+            capturing: bool,
+        }
+
+        impl crate::panel::Panel for ResponsivePanel {
+            fn title(&self) -> String {
+                "responsive test".into()
+            }
+
+            fn refresh_interval(&self) -> Duration {
+                Duration::from_millis(8)
+            }
+
+            fn captures_input(&self) -> bool {
+                self.capturing
+            }
+
+            fn render(
+                &mut self,
+                _frame: &mut ratatui::Frame,
+                _area: Rect,
+                _ctx: crate::panel::RenderContext<'_>,
+            ) {
+            }
+        }
+
+        let configured = Duration::from_millis(250);
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        app.slots[0].panel = Box::new(ResponsivePanel { capturing: false });
+        assert_eq!(app.poll_wait(configured), configured);
+
+        app.slots[0].panel = Box::new(ResponsivePanel { capturing: true });
+        assert_eq!(app.poll_wait(configured), Duration::from_millis(16));
+        assert_eq!(
+            app.poll_wait(Duration::from_millis(10)),
+            Duration::from_millis(10),
+            "a panel may ask for responsiveness but never slow the configured loop"
+        );
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(
+            app.should_quit,
+            "even a capturing panel cannot intercept Ctrl+C"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,7 @@ const A_YEAR_IN_MINUTES: u64 = 365 * 24 * 60;
 pub const DEFAULT_CONFIG: &str = include_str!("../../assets/default_config.toml");
 
 mod layout;
+mod plugins;
 mod widgets;
 
 // One flat namespace: the split into files is for readability, not a claim
@@ -43,6 +44,7 @@ mod widgets;
 // about who *names* the type, not about whether it is part of the surface.
 #[allow(unused_imports)]
 pub use layout::{Layout, LayoutPanel, LayoutRow};
+pub use plugins::PluginConfig;
 #[allow(unused_imports)]
 pub use widgets::{
     AgendaConfig, CalculatorConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig,
@@ -55,6 +57,9 @@ pub use widgets::{
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub general: General,
+    /// External panels are opt-in and named explicitly. An empty list performs
+    /// no discovery, imports no runtime and starts no process.
+    pub plugins: Vec<PluginConfig>,
     /// The resolved theme.
     ///
     /// Holds whatever `[theme]` said, or — when the config named one with
@@ -131,6 +136,25 @@ impl Default for General {
 }
 
 impl Config {
+    /// Built-in and explicitly declared widget ids, in picker order.
+    pub fn widget_names(&self) -> Vec<String> {
+        crate::widgets::WIDGET_NAMES
+            .iter()
+            .map(|name| (*name).to_string())
+            .chain(self.plugins.iter().map(|plugin| plugin.id.clone()))
+            .collect()
+    }
+
+    /// The declaration for an external widget, if one was explicitly named.
+    pub fn plugin(&self, id: &str) -> Option<&PluginConfig> {
+        self.plugins.iter().find(|plugin| plugin.id == id)
+    }
+
+    /// Whether a layout name resolves to a built-in or declared plugin.
+    pub fn knows_widget(&self, id: &str) -> bool {
+        crate::widgets::is_known_widget(id) || self.plugin(id).is_some()
+    }
+
     /// Load the config, creating a commented default if none exists.
     pub fn load(explicit: Option<PathBuf>) -> Result<(Self, PathBuf)> {
         let path = match explicit {
@@ -230,6 +254,20 @@ impl Config {
     /// however mangled, can produce a config that would have been rejected had
     /// it come from the file.
     pub(crate) fn validate(&self) -> Result<()> {
+        let mut plugin_ids = std::collections::HashSet::new();
+        for plugin in &self.plugins {
+            plugin.validate()?;
+            if crate::widgets::is_known_widget(&plugin.id) {
+                anyhow::bail!(
+                    "plugin id `{}` conflicts with a built-in widget.",
+                    plugin.id
+                );
+            }
+            if !plugin_ids.insert(plugin.id.as_str()) {
+                anyhow::bail!("plugin id `{}` is declared more than once.", plugin.id);
+            }
+        }
+
         if self.layout.rows.is_empty() {
             anyhow::bail!(
                 "`[layout]` has no rows, so there is nothing to draw. \
@@ -245,11 +283,11 @@ impl Config {
                 );
             }
             for panel in &row.panels {
-                if !crate::widgets::is_known_widget(&panel.widget) {
+                if !self.knows_widget(&panel.widget) {
                     anyhow::bail!(
                         "unknown widget `{}`. Available widgets: {}.",
                         panel.widget,
-                        crate::widgets::WIDGET_NAMES.join(", ")
+                        self.widget_names().join(", ")
                     );
                 }
             }
@@ -824,6 +862,73 @@ mod tests {
         assert!(
             msg.contains("todo"),
             "should list valid widgets, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn an_explicit_plugin_can_supply_a_layout_name_and_opaque_settings() {
+        let source = r#"
+plugins = [{
+    id = "example",
+    command = ["mirador-example", "--compact"],
+    config = { label = "local" }
+}]
+
+[layout]
+rows = [{ height = 1, panels = [{ widget = "example" }] }]
+"#;
+        let config: Config = toml::from_str(source).expect("plugin declaration parses");
+        config
+            .validate()
+            .expect("declared plugin is a known widget");
+        assert_eq!(
+            config.widget_names().last().map(String::as_str),
+            Some("example")
+        );
+        assert_eq!(config.plugins[0].config["label"].as_str(), Some("local"));
+    }
+
+    #[test]
+    fn plugin_ids_cannot_shadow_core_widgets_or_each_other() {
+        let collision: Config =
+            toml::from_str("plugins = [{ id = \"notes\", command = [\"anything\"] }]").unwrap();
+        assert!(
+            collision
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("conflicts with a built-in")
+        );
+
+        let duplicate: Config = toml::from_str(
+            "plugins = [\n  { id = \"sample\", command = [\"one\"] },\n  { id = \"sample\", command = [\"two\"] }\n]",
+        )
+        .unwrap();
+        assert!(
+            duplicate
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("more than once")
+        );
+    }
+
+    #[test]
+    fn plugin_commands_are_argv_not_platform_shell_strings() {
+        let config: Config = toml::from_str(
+            "plugins = [{ id = \"sample\", command = [\"python\", \"-m\", \"sample\"] }]",
+        )
+        .unwrap();
+        assert_eq!(config.plugins[0].command, ["python", "-m", "sample"]);
+
+        let missing: Config =
+            toml::from_str("plugins = [{ id = \"sample\", command = [] }]").unwrap();
+        assert!(
+            missing
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("no executable")
         );
     }
 

--- a/src/config/plugins.rs
+++ b/src/config/plugins.rs
@@ -1,0 +1,49 @@
+//! Explicit declarations for out-of-process panels.
+//!
+//! Nothing in this module discovers or starts a plugin. A declaration only
+//! gives the layout registry a name and a command; the process is started if
+//! and when that name is actually placed in the layout.
+
+use serde::Deserialize;
+
+/// One external panel command and the settings passed to it unchanged.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PluginConfig {
+    /// Stable widget id used by `[layout]` and the panel picker.
+    pub id: String,
+    /// Executable followed by arguments. It is launched directly, never
+    /// through a platform shell, so quoting behaves the same on every OS.
+    pub command: Vec<String>,
+    /// Plugin-owned, non-secret TOML. Mirador deliberately does not interpret
+    /// its schema; credentials are collected by plugin UI, never stored here.
+    #[serde(default)]
+    pub config: toml::Table,
+}
+
+impl PluginConfig {
+    pub(super) fn validate(&self) -> anyhow::Result<()> {
+        let valid_id = self.id.chars().enumerate().all(|(index, character)| {
+            if index == 0 {
+                character.is_ascii_lowercase()
+            } else {
+                character.is_ascii_lowercase()
+                    || character.is_ascii_digit()
+                    || matches!(character, '-' | '_')
+            }
+        });
+        if self.id.is_empty() || !valid_id {
+            anyhow::bail!(
+                "plugin id `{}` is invalid; use a lowercase letter followed by lowercase letters, digits, `-` or `_`.",
+                self.id
+            );
+        }
+        if self.command.is_empty() || self.command[0].trim().is_empty() {
+            anyhow::bail!(
+                "plugin `{}` has no executable; `command` must be a non-empty array.",
+                self.id
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -266,6 +266,76 @@ mod tests {
     /// compares the map against the tree instead.
     #[test]
     fn every_module_is_named_in_the_architecture_map() {
+        fn directory_entry(map: &str, directory: &str) -> String {
+            let heading = format!("{directory}/");
+            let mut entry = String::new();
+            let mut found = false;
+            for line in map.lines() {
+                if line.starts_with(&heading) {
+                    found = true;
+                    entry.push_str(line);
+                } else if found && line.starts_with(' ') {
+                    entry.push(' ');
+                    entry.push_str(line.trim());
+                } else if found {
+                    break;
+                }
+            }
+            entry
+        }
+
+        fn names_module(entry: &str, file: &str) -> bool {
+            let stem = file.strip_suffix(".rs").unwrap_or(file);
+            entry
+                .split(|character: char| {
+                    !(character.is_ascii_alphanumeric() || matches!(character, '_' | '.'))
+                })
+                .any(|word| word == file || word == stem)
+        }
+
+        fn walk(
+            root: &Path,
+            dir: &Path,
+            map: &str,
+            inspected: &mut usize,
+            missing: &mut Vec<String>,
+        ) {
+            for entry in std::fs::read_dir(dir)
+                .expect("source directory must be readable")
+                .flatten()
+            {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(root, &path, map, inspected, missing);
+                    continue;
+                }
+                if path.extension().is_none_or(|extension| extension != "rs") {
+                    continue;
+                }
+
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("walked source stays below src")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                if relative == "main.rs" {
+                    continue;
+                }
+                *inspected += 1;
+
+                let Some((directory, file)) = relative.split_once('/') else {
+                    if !map.contains(&relative) {
+                        missing.push(relative);
+                    }
+                    continue;
+                };
+                let entry = directory_entry(map, directory);
+                if entry.is_empty() || (file != "mod.rs" && !names_module(&entry, file)) {
+                    missing.push(relative);
+                }
+            }
+        }
+
         let notes = notes();
         let map = notes
             .split("## Architecture")
@@ -275,25 +345,15 @@ mod tests {
 
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut missing = Vec::new();
-        for entry in std::fs::read_dir(&root).expect("src/ must exist").flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|e| e == "rs") {
-                let name = path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .into_owned();
-                // `main.rs` is the entry point rather than a component, and the
-                // map opens by describing it in prose instead of listing it.
-                if name == "main.rs" {
-                    continue;
-                }
-                if !map.contains(&name) {
-                    missing.push(name);
-                }
-            }
-        }
+        let mut inspected = 0usize;
+        walk(&root, &root, map, &mut inspected, &mut missing);
         missing.sort();
+
+        assert!(
+            inspected > 40,
+            "the architecture sweep saw only {inspected} modules; it must recurse into \
+             config/, plugin/ and widgets/ rather than pass on top-level files alone"
+        );
 
         assert!(
             missing.is_empty(),

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -15,6 +15,8 @@
 //! Focus is signalled by *recession* rather than by brightening — unfocused
 //! frames dim, so exactly one thing on screen is at normal brightness.
 
+use std::borrow::Cow;
+
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -57,12 +59,12 @@ pub fn centred(area: Rect, width: u16, height: u16) -> Rect {
 ///
 /// One declaration feeds the border hint, the status bar and the help overlay,
 /// so a binding can never drift out of sync with the text describing it.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
     /// The key as typed, e.g. `a`, `space`, `Tab`.
-    pub key: &'static str,
+    pub key: Cow<'static, str>,
     /// What it does, in the imperative.
-    pub action: &'static str,
+    pub action: Cow<'static, str>,
     /// Whether it is important enough for the border hint. Bindings that are
     /// aliases (`j` for `down`) or expert-only set this false so they do not
     /// spend the small hint budget.
@@ -73,8 +75,8 @@ impl Binding {
     /// A binding shown in the border hint.
     pub const fn primary(key: &'static str, action: &'static str) -> Self {
         Self {
-            key,
-            action,
+            key: Cow::Borrowed(key),
+            action: Cow::Borrowed(action),
             primary: true,
         }
     }
@@ -82,9 +84,18 @@ impl Binding {
     /// A binding that appears only in the help overlay.
     pub const fn extra(key: &'static str, action: &'static str) -> Self {
         Self {
-            key,
-            action,
+            key: Cow::Borrowed(key),
+            action: Cow::Borrowed(action),
             primary: false,
+        }
+    }
+
+    /// A binding supplied at runtime, for example by an external plugin.
+    pub fn owned(key: impl Into<String>, action: impl Into<String>, primary: bool) -> Self {
+        Self {
+            key: Cow::Owned(key.into()),
+            action: Cow::Owned(action.into()),
+            primary,
         }
     }
 }
@@ -106,10 +117,10 @@ pub fn hint_line(bindings: &[Binding], theme: &Theme, budget: u16) -> Option<Lin
 
     for binding in bindings.iter().filter(|b| b.primary) {
         let separator = if spans.len() > 1 { " · " } else { "" };
-        let width = separator.chars().count()
-            + binding.key.chars().count()
+        let width = crate::grid::display_width(separator)
+            + crate::grid::display_width(&binding.key)
             + 1
-            + binding.action.chars().count();
+            + crate::grid::display_width(&binding.action);
         let Ok(width) = u16::try_from(width) else {
             continue;
         };
@@ -119,7 +130,7 @@ pub fn hint_line(bindings: &[Binding], theme: &Theme, budget: u16) -> Option<Lin
         if !separator.is_empty() {
             spans.push(Span::styled(separator, action_style));
         }
-        spans.push(Span::styled(binding.key, key_style));
+        spans.push(Span::styled(binding.key.clone(), key_style));
         spans.push(Span::styled(format!(" {}", binding.action), action_style));
         used += width;
     }
@@ -369,7 +380,11 @@ mod tests {
         let theme = Theme::default();
         for budget in 0..80u16 {
             if let Some(line) = hint_line(&bindings(), &theme, budget) {
-                let width: usize = line.spans.iter().map(|s| s.content.chars().count()).sum();
+                let width: usize = line
+                    .spans
+                    .iter()
+                    .map(|span| crate::grid::display_width(&span.content))
+                    .sum();
                 assert!(
                     width <= budget as usize,
                     "hint of {width} exceeded budget {budget}"
@@ -383,6 +398,18 @@ mod tests {
         // Better a clean border than a clipped fragment.
         assert!(hint_line(&bindings(), &Theme::default(), 4).is_none());
         assert!(hint_line(&bindings(), &Theme::default(), 0).is_none());
+    }
+
+    #[test]
+    fn runtime_binding_hints_budget_terminal_cells() {
+        let binding = Binding::owned("界", "open", true);
+        let line = hint_line(&[binding], &Theme::default(), 9).expect("exactly fits");
+        let width: usize = line
+            .spans
+            .iter()
+            .map(|span| crate::grid::display_width(&span.content))
+            .sum();
+        assert_eq!(width, 9);
     }
 
     #[test]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -154,7 +154,7 @@ fn break_lines<'a>(text: &'a str, width: usize, mut emit: impl FnMut(&'a str)) {
 
     // An empty string has no lines at all, and still occupies one row.
     if !any {
-        emit("");
+        emit(&text[..0]);
     }
 }
 
@@ -178,6 +178,12 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
 /// emoji sequence can occupy fewer cells as one string than it does when a
 /// style boundary splits it. In that exceptional case the row is collapsed
 /// and truncated as one span so it still cannot cross the requested edge.
+/// Embedded `\n` and `\r\n` are accepted as hard line boundaries. Their bytes
+/// are skipped by mapping each wrapped row back to its absolute source range,
+/// so a delimiter can never drift the styled-byte cursor or become a slice
+/// panic. If an internal range ever stops landing on UTF-8 boundaries, the row
+/// falls back to the line style instead of trusting an assertion in release
+/// code.
 pub fn wrap_line(line: &Line<'_>, width: usize) -> Vec<Line<'static>> {
     if width == 0 {
         return Vec::new();
@@ -187,51 +193,50 @@ pub fn wrap_line(line: &Line<'_>, width: usize) -> Vec<Line<'static>> {
         .iter()
         .map(|span| span.content.as_ref())
         .collect();
-    let mut span_index = 0usize;
-    let mut span_offset = 0usize;
-    wrap(&text, width)
-        .into_iter()
-        .map(|row| {
-            let spans =
-                take_styled_bytes(&line.spans, &mut span_index, &mut span_offset, row.len());
-            let rendered_width: usize = spans.iter().map(|span| display_width(&span.content)).sum();
-            if rendered_width > width {
-                let style = spans.first().map_or(line.style, |span| span.style);
-                Line::from(Span::styled(truncate(&row, width), style))
-            } else {
-                Line::from(spans).style(line.style)
-            }
-        })
-        .collect()
+    let base = text.as_ptr() as usize;
+    let mut output = Vec::new();
+    break_lines(&text, width, |row| {
+        let spans = (row.as_ptr() as usize)
+            .checked_sub(base)
+            .filter(|start| start.saturating_add(row.len()) <= text.len())
+            .and_then(|start| styled_byte_range(&line.spans, start, start + row.len()));
+        let style = spans
+            .as_ref()
+            .and_then(|spans| spans.first())
+            .map_or(line.style, |span| span.style);
+        let spans = spans.unwrap_or_else(|| vec![Span::styled(row.to_string(), style)]);
+        let rendered_width: usize = spans.iter().map(|span| display_width(&span.content)).sum();
+        if rendered_width > width {
+            output.push(Line::from(Span::styled(truncate(row, width), style)));
+        } else {
+            output.push(Line::from(spans).style(line.style));
+        }
+    });
+    output
 }
 
-fn take_styled_bytes(
-    source: &[Span<'_>],
-    span_index: &mut usize,
-    span_offset: &mut usize,
-    mut remaining: usize,
-) -> Vec<Span<'static>> {
+fn styled_byte_range(source: &[Span<'_>], start: usize, end: usize) -> Option<Vec<Span<'static>>> {
+    let expected = end.checked_sub(start)?;
     let mut output = Vec::new();
-    while remaining > 0 && *span_index < source.len() {
-        let span = &source[*span_index];
-        let available = &span.content[*span_offset..];
-        if available.is_empty() {
-            *span_index += 1;
-            *span_offset = 0;
-            continue;
+    let mut offset = 0usize;
+    let mut copied = 0usize;
+    for span in source {
+        let span_end = offset.checked_add(span.content.len())?;
+        if start < span_end && end > offset {
+            let local_start = start.saturating_sub(offset);
+            let local_end = end.min(span_end).checked_sub(offset)?;
+            let content = span.content.get(local_start..local_end)?;
+            if !content.is_empty() {
+                copied = copied.checked_add(content.len())?;
+                output.push(Span::styled(content.to_string(), span.style));
+            }
         }
-        let take = remaining.min(available.len());
-        debug_assert!(available.is_char_boundary(take));
-        output.push(Span::styled(available[..take].to_string(), span.style));
-        remaining -= take;
-        *span_offset += take;
-        if *span_offset == span.content.len() {
-            *span_index += 1;
-            *span_offset = 0;
+        offset = span_end;
+        if offset >= end {
+            break;
         }
     }
-    debug_assert_eq!(remaining, 0);
-    output
+    (copied == expected).then_some(output)
 }
 
 /// `text` wrapped to `width` and rejoined, ready for a `Paragraph` that must
@@ -923,10 +928,14 @@ mod tests {
 
         // Split so this test's own source is not a match.
         let needle = concat!("Line::fr", "om(vec![");
-        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/widgets");
-
         let mut found = Vec::new();
-        walk(&root, needle, &mut found);
+        let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        // External panel output is bounded by the same invariant as an in-tree
+        // widget. Sweep both implementation trees so moving composition behind
+        // the process boundary cannot make this guard pass vacuously.
+        for directory in ["widgets", "plugin"] {
+            walk(&source.join(directory), needle, &mut found);
+        }
 
         for name in &found {
             let allowed = ALLOWED
@@ -1024,6 +1033,28 @@ mod tests {
             .map(|span| display_width(&span.content))
             .sum();
         assert!(rendered_width <= 2, "rendered width was {rendered_width}");
+    }
+
+    #[test]
+    fn styled_wrapping_treats_embedded_line_endings_as_guarded_hard_breaks() {
+        let first = Style::default().add_modifier(Modifier::BOLD);
+        let second = Style::default().add_modifier(Modifier::ITALIC);
+        let third = Style::default().add_modifier(Modifier::UNDERLINED);
+        let line = Line::from(vec![
+            Span::styled("ab\r", first),
+            Span::styled("\né\n", second),
+            Span::styled("界", third),
+        ]);
+
+        let wrapped = wrap_line(&line, 10);
+        let text: Vec<String> = wrapped
+            .iter()
+            .map(|row| row.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect();
+        assert_eq!(text, ["ab", "é", "界"]);
+        assert_eq!(wrapped[0].spans[0].style, first);
+        assert_eq!(wrapped[1].spans[0].style, second);
+        assert_eq!(wrapped[2].spans[0].style, third);
     }
 
     /// The one exception, and it is deliberate: a single glyph that cannot fit

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -170,6 +170,70 @@ pub fn wrap(text: &str, width: usize) -> Vec<String> {
     out
 }
 
+/// Wrap one already-styled logical line without handing untrusted text to
+/// ratatui's wrapper.
+///
+/// Span styles follow their source bytes across row boundaries. The final
+/// width check deliberately sums the spans the way ratatui does: a joined
+/// emoji sequence can occupy fewer cells as one string than it does when a
+/// style boundary splits it. In that exceptional case the row is collapsed
+/// and truncated as one span so it still cannot cross the requested edge.
+pub fn wrap_line(line: &Line<'_>, width: usize) -> Vec<Line<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+    let text: String = line
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect();
+    let mut span_index = 0usize;
+    let mut span_offset = 0usize;
+    wrap(&text, width)
+        .into_iter()
+        .map(|row| {
+            let spans =
+                take_styled_bytes(&line.spans, &mut span_index, &mut span_offset, row.len());
+            let rendered_width: usize = spans.iter().map(|span| display_width(&span.content)).sum();
+            if rendered_width > width {
+                let style = spans.first().map_or(line.style, |span| span.style);
+                Line::from(Span::styled(truncate(&row, width), style))
+            } else {
+                Line::from(spans).style(line.style)
+            }
+        })
+        .collect()
+}
+
+fn take_styled_bytes(
+    source: &[Span<'_>],
+    span_index: &mut usize,
+    span_offset: &mut usize,
+    mut remaining: usize,
+) -> Vec<Span<'static>> {
+    let mut output = Vec::new();
+    while remaining > 0 && *span_index < source.len() {
+        let span = &source[*span_index];
+        let available = &span.content[*span_offset..];
+        if available.is_empty() {
+            *span_index += 1;
+            *span_offset = 0;
+            continue;
+        }
+        let take = remaining.min(available.len());
+        debug_assert!(available.is_char_boundary(take));
+        output.push(Span::styled(available[..take].to_string(), span.style));
+        remaining -= take;
+        *span_offset += take;
+        if *span_offset == span.content.len() {
+            *span_index += 1;
+            *span_offset = 0;
+        }
+    }
+    debug_assert_eq!(remaining, 0);
+    output
+}
+
 /// `text` wrapped to `width` and rejoined, ready for a `Paragraph` that must
 /// **not** be given `Wrap`.
 ///
@@ -714,11 +778,12 @@ mod tests {
     /// the sweep passed cheerfully with the defect reintroduced. Counting the
     /// call sites cannot miss.
     ///
-    /// Two are allowed, and both are text this program wrote itself: the help
-    /// overlay and the delete confirmation, whose one variable line is
-    /// truncated to the width before it gets there.
+    /// One is allowed: the delete confirmation, whose one variable line is
+    /// truncated to the width before it gets there. The help overlay used to
+    /// be the second, but external panel bindings made its text plugin-owned;
+    /// it now comes through [`wrap_line`] instead.
     #[test]
-    fn only_the_two_known_places_use_ratatuis_own_wrapper() {
+    fn only_the_known_delete_confirmation_uses_ratatuis_own_wrapper() {
         fn walk(dir: &std::path::Path, needle: &str, found: &mut Vec<String>) {
             let Ok(entries) = std::fs::read_dir(dir) else {
                 return;
@@ -762,9 +827,9 @@ mod tests {
 
         assert_eq!(
             found.len(),
-            2,
-            "expected exactly two uses of ratatui's wrapper — the help overlay \
-             and the delete confirmation — and found {}:\n  {}\n\n\
+            1,
+            "expected exactly one use of ratatui's wrapper — the delete \
+             confirmation — and found {}:\n  {}\n\n\
              If this is a new site rendering text mirador did not write, wrap it \
              with `grid::wrapped` instead: ratatui's wrapper panics on a leading \
              combining mark, and on a double-width glyph in a word too long for \
@@ -772,10 +837,6 @@ mod tests {
              program wrote itself, widen this count and say why.",
             found.len(),
             found.join("\n  ")
-        );
-        assert!(
-            found.iter().any(|f| f.starts_with("app.rs:")),
-            "the help overlay's wrap went missing: {found:?}"
         );
         assert!(
             found.iter().any(|f| f.starts_with("todo.rs:")),
@@ -944,6 +1005,25 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn styled_wrapping_uses_the_width_ratatui_will_render() {
+        let line = Line::from(vec![
+            Span::styled("👩", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "\u{200d}💻",
+                Style::default().add_modifier(Modifier::ITALIC),
+            ),
+        ]);
+        let wrapped = wrap_line(&line, 2);
+        assert_eq!(wrapped.len(), 1);
+        let rendered_width: usize = wrapped[0]
+            .spans
+            .iter()
+            .map(|span| display_width(&span.content))
+            .sum();
+        assert!(rendered_width <= 2, "rendered width was {rendered_width}");
     }
 
     /// The one exception, and it is deliberate: a single glyph that cannot fit

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod migrate;
 mod note;
 mod panel;
 mod picker;
+mod plugin;
 mod poll;
 mod prompt;
 mod quote;

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -1,28 +1,16 @@
 //! The [`Panel`] trait: the seam every dashboard widget goes through.
 //!
-//! **This is an in-tree seam.** mirador is a binary crate with no library
-//! target, so nothing outside it can name this trait; `widgets::build`
-//! dispatches on a fixed `match` over `WIDGET_NAMES`; and each widget's
-//! settings are a field on `Config`. Adding a widget is a pull request, and
-//! `CONTRIBUTING.md` lists the six places to touch.
+//! **This remains an in-tree seam, not the public plugin API.** Built-in
+//! widgets implement this trait and are compiled into the binary. External
+//! panels instead run out of process and speak the versioned protocol in
+//! [`crate::plugin`], whose host adapter implements this private trait for
+//! them.
 //!
-//! This paragraph used to go on to say it was *not a plugin API* and was not
-//! going to become one. That is no longer the project's position — external
-//! panels are being designed in
-//! [discussion #191](https://github.com/jchultarsky/mirador/discussions/191).
-//! Nothing above it has changed; what changed is that it is a description of
-//! the code rather than a decision about the code.
-//!
-//! Which obstacles a plugin story faces depends on where the boundary is, and
-//! that part is worth keeping. Someone implementing *this trait* out of tree
-//! would need three things mirador does not have: a runtime registry instead of
-//! that `match`, per-widget config carried as an unparsed `toml::Value` so a
-//! widget can own its own schema, and a library target with a deliberate public
-//! surface. A **process** boundary needs the first two and eliminates the
-//! third — which is the expensive one, because a public Rust API is a semver
-//! commitment on every type it touches. That asymmetry is why the process
-//! design is the one being explored, and adding only the library target would
-//! still make the trait nameable without making it usable.
+//! The process boundary supplies the two things external panels need — a
+//! runtime registry and plugin-owned opaque configuration — without exposing
+//! this trait through a library target. That avoids coupling plugins to
+//! ratatui, Mirador's private Rust types or its release cadence, and avoids a
+//! permanent Rust semver promise on every type the trait touches.
 //!
 //! What the seam does buy, in-tree, is real: a panel owns its own state and
 //! refresh cadence. The application shell is
@@ -157,7 +145,7 @@ pub trait Panel {
     /// Key bindings, declared once and reused for the border hint, the status
     /// bar and the help overlay. Order matters: the border shows as many
     /// `primary` bindings as fit, in order.
-    fn bindings(&self) -> &'static [Binding] {
+    fn bindings(&self) -> &[Binding] {
         &[]
     }
 
@@ -190,6 +178,8 @@ pub trait Panel {
     /// how often it expects to have something new to show — a clock with
     /// seconds ticks four times a second and changes once. Say how often you
     /// need to check, and answer the second question from [`Panel::tick`].
+    /// A focused panel that captures input may also shorten the application's
+    /// event wait to this interval for asynchronous interactive feedback.
     fn refresh_interval(&self) -> Duration {
         Duration::from_secs(1)
     }
@@ -318,8 +308,10 @@ pub trait Panel {
     }
 
     /// When true, the panel is in a text-entry or modal state and the app
-    /// suppresses *all* global bindings, including quit, so that typing a `q`
-    /// into a form does not exit the dashboard.
+    /// suppresses ordinary global bindings, including `q`, so that typing a
+    /// title does not exit the dashboard. `Ctrl+C` remains shell-owned in every
+    /// state; an active selection may consume one press to copy and collapse,
+    /// after which the next press exits.
     ///
     /// This looks like it should be a variant of [`KeyOutcome`] — a panel that
     /// swallowed the key could say so on the way out, and the trait would lose

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -22,12 +22,12 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use crate::theme::Theme;
 
 /// What a keypress asked the shell to do.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     /// Nothing the shell needs to act on; the cursor may have moved.
     None,
     /// Turn this widget on if it is off, and off if it is on.
-    Toggle(&'static str),
+    Toggle(String),
     /// Close the dialog and commit whatever changed.
     Close,
 }
@@ -36,12 +36,13 @@ pub enum Action {
 #[derive(Debug)]
 pub struct Picker {
     selected: usize,
+    names: Vec<String>,
 }
 
 impl Picker {
     /// Open on the first widget.
-    pub fn new() -> Self {
-        Self { selected: 0 }
+    pub fn new(names: Vec<String>) -> Self {
+        Self { selected: 0, names }
     }
 
     /// Which row the cursor is on. Exposed for tests.
@@ -56,8 +57,7 @@ impl Picker {
     /// than dismissing on any of them — a stray keystroke must not close it and
     /// leave the user wondering whether the toggle took.
     pub fn handle_key(&mut self, key: KeyEvent) -> Action {
-        let names = crate::widgets::WIDGET_NAMES;
-        let last = names.len().saturating_sub(1);
+        let last = self.names.len().saturating_sub(1);
 
         match key.code {
             KeyCode::Esc | KeyCode::Char('q' | 'w') | KeyCode::Enter => Action::Close,
@@ -77,9 +77,10 @@ impl Picker {
                 self.selected = last;
                 Action::None
             }
-            KeyCode::Char(' ') => names
+            KeyCode::Char(' ') => self
+                .names
                 .get(self.selected)
-                .copied()
+                .cloned()
                 .map_or(Action::None, Action::Toggle),
             _ => Action::None,
         }
@@ -98,10 +99,8 @@ impl Picker {
         placed: impl Fn(&str) -> bool,
         error: Option<&str>,
     ) {
-        let names = crate::widgets::WIDGET_NAMES;
-
         let mut lines: Vec<Line> = Vec::new();
-        for (index, name) in names.iter().enumerate() {
+        for (index, name) in self.names.iter().enumerate() {
             let on = placed(name);
             let here = index == self.selected;
             // A filled mark and an empty one in the track colour, the same
@@ -185,10 +184,19 @@ mod tests {
         picker.handle_key(KeyEvent::from(code))
     }
 
+    fn picker() -> Picker {
+        Picker::new(
+            crate::widgets::WIDGET_NAMES
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+        )
+    }
+
     #[test]
     fn the_cursor_clamps_at_both_ends() {
         let last = crate::widgets::WIDGET_NAMES.len() - 1;
-        let mut picker = Picker::new();
+        let mut picker = picker();
 
         assert_eq!(picker.selected(), 0, "opens on the first widget");
         press(&mut picker, KeyCode::Up);
@@ -202,16 +210,16 @@ mod tests {
 
     #[test]
     fn space_names_the_widget_under_the_cursor() {
-        let mut picker = Picker::new();
+        let mut picker = picker();
         assert_eq!(
             press(&mut picker, KeyCode::Char(' ')),
-            Action::Toggle(crate::widgets::WIDGET_NAMES[0])
+            Action::Toggle(crate::widgets::WIDGET_NAMES[0].to_string())
         );
 
         press(&mut picker, KeyCode::Down);
         assert_eq!(
             press(&mut picker, KeyCode::Char(' ')),
-            Action::Toggle(crate::widgets::WIDGET_NAMES[1])
+            Action::Toggle(crate::widgets::WIDGET_NAMES[1].to_string())
         );
     }
 
@@ -223,12 +231,22 @@ mod tests {
             KeyCode::Char('w'),
             KeyCode::Enter,
         ] {
-            assert_eq!(press(&mut Picker::new(), code), Action::Close, "{code:?}");
+            assert_eq!(press(&mut picker(), code), Action::Close, "{code:?}");
         }
         // A dialog that closed on any key would leave the user unsure whether
         // their last toggle was taken.
         for code in [KeyCode::Char('x'), KeyCode::Tab, KeyCode::Backspace] {
-            assert_eq!(press(&mut Picker::new(), code), Action::None, "{code:?}");
+            assert_eq!(press(&mut picker(), code), Action::None, "{code:?}");
         }
+    }
+
+    #[test]
+    fn runtime_plugin_names_are_selectable() {
+        let mut picker = Picker::new(vec!["clocks".into(), "terminal".into()]);
+        press(&mut picker, KeyCode::End);
+        assert_eq!(
+            press(&mut picker, KeyCode::Char(' ')),
+            Action::Toggle("terminal".into())
+        );
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,0 +1,1523 @@
+//! Out-of-process panels over a small, versioned JSON-lines protocol.
+//!
+//! Mirador does not discover plugins, embed an interpreter, or load dynamic
+//! libraries. A process exists only when the config explicitly declares its
+//! command *and* the layout places its id. The process publishes complete
+//! render snapshots; Mirador remains the only owner of the real terminal and
+//! the only renderer touching ratatui.
+
+use std::sync::mpsc::TrySendError;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{
+    KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Clear, Paragraph};
+use serde::{Deserialize, Serialize};
+
+use crate::config::PluginConfig;
+use crate::frame::Binding;
+use crate::panel::{KeyOutcome, Panel, RenderContext};
+
+mod process;
+
+use process::{Phase, Runtime, Shared, spawn_process};
+
+pub const PROTOCOL_VERSION: u16 = 1;
+const MAX_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_WATCH_TEXT_BYTES: usize = 1024;
+const MAX_RETAINED_FRAME_TEXT_BYTES: usize = 1024 * 1024;
+const MAX_FRAME_LINES: usize = 4096;
+const MAX_FRAME_SPANS: usize = 16_384;
+const MAX_BINDINGS: usize = 64;
+const MAX_INPUT_KEYS: usize = 128;
+const MAX_TITLE_BYTES: usize = 256;
+const MAX_COUNTER_BYTES: usize = 128;
+const MAX_BINDING_KEY_BYTES: usize = 64;
+const MAX_BINDING_ACTION_BYTES: usize = 256;
+const MAX_ERROR_BYTES: usize = 1024;
+const MAX_COLOR_BYTES: usize = 64;
+/// A visible cell may carry combining marks, but an unbounded run of them must
+/// not make drawing one row proportional to an entire retained frame.
+const RENDER_BYTES_PER_CELL: usize = 16;
+const DEFAULT_REFRESH: Duration = Duration::from_millis(33);
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum HostMessage {
+    Hello {
+        protocol: u16,
+        host_version: &'static str,
+        plugin: String,
+        config: serde_json::Value,
+        cwd: String,
+    },
+    Resize {
+        columns: u16,
+        rows: u16,
+    },
+    Focus {
+        focused: bool,
+    },
+    Key {
+        key: String,
+        code: String,
+        text: Option<String>,
+        modifiers: Vec<String>,
+    },
+    Paste {
+        text: String,
+    },
+    Mouse {
+        kind: String,
+        button: Option<String>,
+        column: u16,
+        row: u16,
+        modifiers: Vec<String>,
+    },
+    Tick,
+    Shutdown,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum PluginMessage {
+    Ready {
+        protocol: u16,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        refresh_ms: Option<u64>,
+    },
+    Frame {
+        revision: u64,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        counter: Option<String>,
+        #[serde(default)]
+        lines: Vec<WireLine>,
+        #[serde(default)]
+        bindings: Vec<WireBinding>,
+        #[serde(default)]
+        input: InputPolicy,
+        #[serde(default)]
+        cursor: Option<WireCursor>,
+    },
+    Error {
+        message: String,
+        #[serde(default)]
+        fatal: bool,
+    },
+    Watch {
+        text: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct WireLine {
+    #[serde(default)]
+    spans: Vec<WireSpan>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+// These are independent terminal style attributes on the wire, not states of
+// one machine; combining them would make the protocol less direct.
+#[allow(clippy::struct_excessive_bools)]
+struct WireSpan {
+    text: String,
+    #[serde(default)]
+    fg: Option<String>,
+    #[serde(default)]
+    bg: Option<String>,
+    #[serde(default)]
+    bold: bool,
+    #[serde(default)]
+    dim: bool,
+    #[serde(default)]
+    italic: bool,
+    #[serde(default)]
+    underlined: bool,
+    #[serde(default)]
+    reversed: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireBinding {
+    key: String,
+    action: String,
+    #[serde(default)]
+    primary: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+// Each flag grants a distinct input class. A bitset would leak a Rust encoding
+// into a language-neutral JSON protocol.
+#[allow(clippy::struct_excessive_bools)]
+struct InputPolicy {
+    /// Consume every key while focused.
+    capture: bool,
+    /// Canonical keys to consume while not capturing, e.g. `Enter` or `r`.
+    keys: Vec<String>,
+    paste: bool,
+    mouse: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireCursor {
+    column: u16,
+    row: u16,
+    #[serde(default = "yes")]
+    visible: bool,
+}
+
+const fn yes() -> bool {
+    true
+}
+
+#[derive(Debug, Clone)]
+struct WireFrame {
+    revision: u64,
+    title: Option<String>,
+    counter: Option<String>,
+    lines: Vec<WireLine>,
+    bindings: Vec<WireBinding>,
+    input: InputPolicy,
+    cursor: Option<WireCursor>,
+}
+
+/// Adapter from one explicitly configured process to Mirador's private panel
+/// trait. Process failures are panel state, never application failures.
+pub struct PluginPanel {
+    spec: PluginConfig,
+    runtime: Option<Runtime>,
+    shared: Arc<Mutex<Shared>>,
+    seen_generation: u64,
+    phase: Phase,
+    title: String,
+    refresh: Duration,
+    frame: Option<Arc<WireFrame>>,
+    bindings: Vec<Binding>,
+    policy: InputPolicy,
+    notice: Option<String>,
+    /// Revision whose passive key action is awaiting a new frame. Until that
+    /// acknowledgement arrives, subsequent input is conservatively captured
+    /// so a rapid `Enter`, `q` cannot cross an asynchronous mode transition.
+    input_barrier: Option<u64>,
+    last_size: Option<(u16, u16)>,
+    last_focus: Option<bool>,
+}
+
+impl PluginPanel {
+    pub fn new(spec: PluginConfig) -> Self {
+        let id = spec.id.clone();
+        let mut panel = Self {
+            spec,
+            runtime: None,
+            shared: Arc::new(Mutex::new(Shared::starting())),
+            seen_generation: u64::MAX,
+            phase: Phase::Starting,
+            title: id,
+            refresh: DEFAULT_REFRESH,
+            frame: None,
+            bindings: Vec::new(),
+            policy: InputPolicy::default(),
+            notice: None,
+            input_barrier: None,
+            last_size: None,
+            last_focus: None,
+        };
+        panel.start();
+        panel.sync();
+        panel
+    }
+
+    fn start(&mut self) {
+        self.stop();
+        self.shared = Arc::new(Mutex::new(Shared::starting()));
+        self.seen_generation = u64::MAX;
+        self.phase = Phase::Starting;
+        self.frame = None;
+        self.bindings.clear();
+        self.policy = InputPolicy::default();
+        self.notice = None;
+        self.input_barrier = None;
+        self.last_size = None;
+        self.last_focus = None;
+
+        match spawn_process(&self.spec, &self.shared) {
+            Ok(runtime) => self.runtime = Some(runtime),
+            Err(error) => self
+                .shared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .fail(format!("could not start plugin: {error}")),
+        }
+    }
+
+    fn stop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown();
+        }
+    }
+
+    fn sync(&mut self) -> bool {
+        let shared = self
+            .shared
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if shared.generation == self.seen_generation {
+            return false;
+        }
+
+        self.seen_generation = shared.generation;
+        self.phase = shared.phase.clone();
+        self.refresh = shared.refresh;
+        self.notice.clone_from(&shared.notice);
+        let negotiated_title = shared.title.clone().unwrap_or_else(|| self.spec.id.clone());
+        let next = if matches!(self.phase, Phase::Exited(_) | Phase::Failed(_)) {
+            None
+        } else {
+            shared.frame.clone()
+        };
+        drop(shared);
+
+        self.title = next
+            .as_ref()
+            .and_then(|frame| frame.title.clone())
+            .unwrap_or(negotiated_title);
+
+        if let Some(frame) = &next {
+            self.policy = frame.input.clone();
+            if self
+                .input_barrier
+                .is_some_and(|revision| frame.revision > revision)
+            {
+                self.input_barrier = None;
+            }
+            if matches!(self.phase, Phase::Exited(_) | Phase::Failed(_)) {
+                self.input_barrier = None;
+            }
+            self.bindings = frame
+                .bindings
+                .iter()
+                .map(|binding| {
+                    Binding::owned(binding.key.clone(), binding.action.clone(), binding.primary)
+                })
+                .collect();
+        } else {
+            self.policy = InputPolicy::default();
+            self.input_barrier = None;
+            self.bindings.clear();
+        }
+        if matches!(self.phase, Phase::Exited(_) | Phase::Failed(_)) {
+            self.bindings.push(Binding::primary("r", "restart"));
+            // Closing the last host sender lets the stdin worker leave too.
+            // A completed child must not leave one parked thread behind until
+            // the panel is restarted or the whole application exits.
+            self.runtime = None;
+        }
+        self.frame = next;
+        true
+    }
+
+    fn send(&mut self, message: HostMessage) -> bool {
+        if !matches!(self.phase, Phase::Running) {
+            return false;
+        }
+        let Some(runtime) = &self.runtime else {
+            return false;
+        };
+        match runtime.events.try_send(message) {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) => {
+                let mut shared = self
+                    .shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if shared.notice.as_deref() != Some("plugin input queue is full") {
+                    shared.notice = Some("plugin input queue is full".into());
+                    shared.changed();
+                }
+                false
+            }
+            Err(TrySendError::Disconnected(_)) => false,
+        }
+    }
+
+    fn begin_input_barrier(&mut self) {
+        if self.policy.capture || self.input_barrier.is_some() {
+            return;
+        }
+        if let Some(revision) = self.frame.as_ref().map(|frame| frame.revision) {
+            self.input_barrier = Some(revision);
+        }
+    }
+
+    fn status_lines(
+        &self,
+        theme: &crate::theme::Theme,
+        width: u16,
+        height: u16,
+    ) -> Vec<Line<'static>> {
+        if width == 0 || height == 0 {
+            return Vec::new();
+        }
+        let (headline, detail) = match &self.phase {
+            Phase::Starting => ("starting plugin".to_string(), None),
+            Phase::Running => ("waiting for first frame".to_string(), None),
+            Phase::Stopping => ("stopping plugin".to_string(), None),
+            Phase::Exited(status) => (
+                "plugin exited".to_string(),
+                Some(format!("{status}; press r to restart")),
+            ),
+            Phase::Failed(error) => (
+                "plugin failed".to_string(),
+                Some(format!("{error}; press r to retry")),
+            ),
+        };
+        let mut lines = Vec::new();
+        push_status_text(
+            &mut lines,
+            &headline,
+            Style::default().fg(theme.muted),
+            width,
+            height,
+        );
+        if let Some(detail) = detail {
+            push_status_text(
+                &mut lines,
+                &detail,
+                Style::default().fg(theme.error),
+                width,
+                height,
+            );
+        }
+        let shared = self
+            .shared
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(notice) = &shared.notice {
+            push_status_text(
+                &mut lines,
+                notice,
+                Style::default().fg(theme.warning),
+                width,
+                height,
+            );
+        }
+        if !shared.stderr.trim().is_empty() && lines.len() < usize::from(height) {
+            lines.push(Line::from(""));
+            for line in shared.stderr.lines().take(3) {
+                push_status_text(
+                    &mut lines,
+                    line,
+                    Style::default().fg(theme.muted),
+                    width,
+                    height,
+                );
+            }
+        }
+        lines.truncate(usize::from(height));
+        lines
+    }
+}
+
+impl Panel for PluginPanel {
+    fn title(&self) -> String {
+        format!("{} · {}", crate::glyphs::utility("external"), self.title)
+    }
+
+    fn counter(&self) -> Option<String> {
+        match &self.phase {
+            Phase::Starting => Some("starting".into()),
+            Phase::Exited(_) => Some("exited".into()),
+            Phase::Failed(_) => Some("failed".into()),
+            Phase::Running | Phase::Stopping => {
+                self.frame.as_ref().and_then(|frame| frame.counter.clone())
+            }
+        }
+    }
+
+    fn bindings(&self) -> &[Binding] {
+        &self.bindings
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        self.refresh
+    }
+
+    fn tick(&mut self) -> bool {
+        let changed = self.sync();
+        let _ = self.send(HostMessage::Tick);
+        changed
+    }
+
+    fn events(&mut self) -> Vec<crate::watch::Event> {
+        let mut shared = self
+            .shared
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        shared
+            .watch
+            .drain(..)
+            .map(|text| crate::watch::Event::new(self.spec.id.clone(), text))
+            .collect()
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        self.sync();
+        let size = (area.width.max(1), area.height.max(1));
+        if self.last_size != Some(size)
+            && self.send(HostMessage::Resize {
+                columns: size.0,
+                rows: size.1,
+            })
+        {
+            self.last_size = Some(size);
+        }
+        if self.last_focus != Some(ctx.focused)
+            && self.send(HostMessage::Focus {
+                focused: ctx.focused,
+            })
+        {
+            self.last_focus = Some(ctx.focused);
+        }
+
+        let Some(snapshot) = &self.frame else {
+            frame.render_widget(
+                Paragraph::new(self.status_lines(ctx.theme, area.width, area.height)),
+                area,
+            );
+            return;
+        };
+
+        let lines = wrapped_wire_lines(&snapshot.lines, area.width, area.height, ctx.theme);
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().fg(ctx.theme.text)),
+            area,
+        );
+
+        let (notice, notice_color) = if let Some(notice) = self.notice.as_deref() {
+            (Some(notice), ctx.theme.warning)
+        } else {
+            (
+                match &self.phase {
+                    Phase::Exited(status) => Some(status.as_str()),
+                    Phase::Failed(error) => Some(error.as_str()),
+                    Phase::Starting | Phase::Running | Phase::Stopping => None,
+                },
+                ctx.theme.error,
+            )
+        };
+        if let Some(notice) = notice
+            && area.height > 0
+        {
+            let status = Rect::new(
+                area.x,
+                area.y + area.height.saturating_sub(1),
+                area.width,
+                1,
+            );
+            frame.render_widget(Clear, status);
+            frame.render_widget(
+                Paragraph::new(Span::styled(
+                    crate::grid::truncate(notice, usize::from(area.width)),
+                    Style::default().fg(notice_color),
+                )),
+                status,
+            );
+        }
+
+        if ctx.focused
+            && let Some(cursor) = snapshot.cursor
+            && cursor.visible
+            && cursor.column < area.width
+            && cursor.row < area.height
+        {
+            frame.set_cursor_position((area.x + cursor.column, area.y + cursor.row));
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        let canonical = canonical_key(key);
+        if matches!(self.phase, Phase::Exited(_) | Phase::Failed(_)) && canonical == "r" {
+            self.start();
+            return KeyOutcome::Consumed;
+        }
+        // A passive panel can add local actions, but it cannot redefine the
+        // shell's navigation. Capturing is the same explicit modal state used
+        // by in-tree editors, where ordinary globals are suspended; Ctrl+C is
+        // intercepted by App before either state reaches this method.
+        if !self.policy.capture && self.input_barrier.is_none() && host_owns_key_while_passive(key)
+        {
+            return KeyOutcome::Ignored;
+        }
+        if !self.policy.capture
+            && self.input_barrier.is_none()
+            && !self.policy.keys.iter().any(|item| item == &canonical)
+        {
+            return KeyOutcome::Ignored;
+        }
+
+        let accepted = self.send(HostMessage::Key {
+            key: canonical,
+            code: key_code(key.code),
+            text: match key.code {
+                KeyCode::Char(character) => Some(character.to_string()),
+                _ => None,
+            },
+            modifiers: key_modifiers(key.modifiers),
+        });
+        if accepted {
+            self.begin_input_barrier();
+        }
+        // Once a plugin declares capture, a stalled process must not turn its
+        // queued `q` into Mirador's global quit key.
+        KeyOutcome::Consumed
+    }
+
+    fn handle_paste(&mut self, text: &str) -> KeyOutcome {
+        if !self.policy.paste && self.input_barrier.is_none() {
+            return KeyOutcome::Ignored;
+        }
+        let _ = self.send(HostMessage::Paste {
+            text: text.to_string(),
+        });
+        KeyOutcome::Consumed
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, area: Rect) -> KeyOutcome {
+        if !self.policy.mouse && self.input_barrier.is_none() {
+            return KeyOutcome::Ignored;
+        }
+        let Some((kind, button)) = mouse_kind(event.kind) else {
+            return KeyOutcome::Ignored;
+        };
+        let _ = self.send(HostMessage::Mouse {
+            kind,
+            button,
+            column: event.column.saturating_sub(area.x),
+            row: event.row.saturating_sub(area.y),
+            modifiers: key_modifiers(event.modifiers),
+        });
+        KeyOutcome::Consumed
+    }
+
+    fn captures_input(&self) -> bool {
+        self.policy.capture || self.input_barrier.is_some()
+    }
+
+    fn shutdown(&mut self) {
+        self.stop();
+        self.phase = Phase::Stopping;
+    }
+}
+
+impl Drop for PluginPanel {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn push_status_text(
+    lines: &mut Vec<Line<'static>>,
+    text: &str,
+    style: Style,
+    width: u16,
+    height: u16,
+) {
+    let remaining = usize::from(height).saturating_sub(lines.len());
+    if remaining == 0 {
+        return;
+    }
+    for row in crate::grid::wrap(text, usize::from(width))
+        .into_iter()
+        .take(remaining)
+    {
+        lines.push(Line::from(Span::styled(
+            crate::grid::truncate(&row, usize::from(width)),
+            style,
+        )));
+    }
+}
+
+/// Wrap a plugin snapshot using Mirador's own cell-aware rules while keeping
+/// the styles attached to the bytes that supplied each row.
+///
+/// Only enough source for the visible rows plus one row of word look-ahead is
+/// inspected. A legal 1 MiB snapshot therefore cannot make a ten-row panel
+/// reprocess 1 MiB on every draw, and pathological runs of zero-width marks are
+/// bounded by a per-cell byte budget as well.
+fn wrapped_wire_lines(
+    source: &[WireLine],
+    width: u16,
+    height: u16,
+    theme: &crate::theme::Theme,
+) -> Vec<Line<'static>> {
+    if width == 0 || height == 0 {
+        return Vec::new();
+    }
+
+    let mut output = Vec::with_capacity(usize::from(height));
+    for line in source {
+        let remaining = usize::from(height).saturating_sub(output.len());
+        if remaining == 0 {
+            break;
+        }
+        let prefix = visible_wire_prefix(line, usize::from(width), remaining);
+        let mut span_index = 0usize;
+        let mut span_offset = 0usize;
+        for row in crate::grid::wrap(&prefix, usize::from(width))
+            .into_iter()
+            .take(remaining)
+        {
+            let spans = take_styled_bytes(
+                &line.spans,
+                &mut span_index,
+                &mut span_offset,
+                row.len(),
+                theme,
+            );
+            // Ratatui measures each styled span independently. A joined emoji
+            // sequence can be two cells as one string but wider when a style
+            // boundary splits it, so the postcondition must use the widths the
+            // renderer will actually add.
+            let rendered_width: usize = spans
+                .iter()
+                .map(|span| crate::grid::display_width(&span.content))
+                .sum();
+            if rendered_width > usize::from(width) {
+                let style = spans.first().map_or(Style::default(), |span| span.style);
+                output.push(Line::from(Span::styled(
+                    crate::grid::truncate(&row, usize::from(width)),
+                    style,
+                )));
+            } else {
+                output.push(Line::from(spans));
+            }
+        }
+    }
+    output
+}
+
+fn visible_wire_prefix(line: &WireLine, width: usize, rows: usize) -> String {
+    // A two-cell glyph in a one-cell panel is replaced by one ellipsis. Count
+    // enough source width to produce every requested replacement row.
+    let cell_budget = width.max(2).saturating_mul(rows.saturating_add(1));
+    let byte_budget = cell_budget
+        .saturating_mul(RENDER_BYTES_PER_CELL)
+        .clamp(256, MAX_RETAINED_FRAME_TEXT_BYTES);
+    let mut output = String::new();
+    let mut cells = 0usize;
+
+    'spans: for span in &line.spans {
+        for character in span.text.chars() {
+            let bytes = character.len_utf8();
+            let character_width = crate::grid::char_width(character);
+            if output.len().saturating_add(bytes) > byte_budget
+                || (character_width > 0 && cells.saturating_add(character_width) > cell_budget)
+            {
+                break 'spans;
+            }
+            output.push(character);
+            cells = cells.saturating_add(character_width);
+        }
+    }
+    output
+}
+
+fn take_styled_bytes(
+    source: &[WireSpan],
+    span_index: &mut usize,
+    span_offset: &mut usize,
+    mut remaining: usize,
+    theme: &crate::theme::Theme,
+) -> Vec<Span<'static>> {
+    let mut output = Vec::new();
+    while remaining > 0 && *span_index < source.len() {
+        let span = &source[*span_index];
+        let available = &span.text[*span_offset..];
+        if available.is_empty() {
+            *span_index += 1;
+            *span_offset = 0;
+            continue;
+        }
+        let take = remaining.min(available.len());
+        debug_assert!(available.is_char_boundary(take));
+        output.push(Span::styled(
+            available[..take].to_string(),
+            span_style(span, theme),
+        ));
+        remaining -= take;
+        *span_offset += take;
+        if *span_offset == span.text.len() {
+            *span_index += 1;
+            *span_offset = 0;
+        }
+    }
+    debug_assert_eq!(remaining, 0);
+    output
+}
+
+fn canonical_key(key: KeyEvent) -> String {
+    let base = match key.code {
+        KeyCode::Char(' ') => "Space".into(),
+        KeyCode::Char(character) => character.to_string(),
+        KeyCode::Enter => "Enter".into(),
+        KeyCode::Backspace => "Backspace".into(),
+        KeyCode::Tab => "Tab".into(),
+        KeyCode::BackTab => "BackTab".into(),
+        KeyCode::Esc => "Esc".into(),
+        KeyCode::Left => "Left".into(),
+        KeyCode::Right => "Right".into(),
+        KeyCode::Up => "Up".into(),
+        KeyCode::Down => "Down".into(),
+        KeyCode::Home => "Home".into(),
+        KeyCode::End => "End".into(),
+        KeyCode::PageUp => "PageUp".into(),
+        KeyCode::PageDown => "PageDown".into(),
+        KeyCode::Delete => "Delete".into(),
+        KeyCode::Insert => "Insert".into(),
+        KeyCode::F(number) => format!("F{number}"),
+        other => format!("{other:?}"),
+    };
+    let mut prefixes = key_modifiers(key.modifiers);
+    if prefixes.is_empty() {
+        base
+    } else {
+        prefixes.push(base);
+        prefixes.join("+")
+    }
+}
+
+/// Keys whose passive meaning belongs to the dashboard shell.
+///
+/// This mirrors `app::dispatch_key` rather than the text printed in a help
+/// overlay. Matching the event code is important: Mirador's existing globals
+/// act on `Alt+q` as well as bare `q`, so a plugin must not be able to claim the
+/// modified spelling and silently get ahead of the shell.
+fn host_owns_key_while_passive(key: KeyEvent) -> bool {
+    if key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(
+            key.code,
+            KeyCode::Char('c') | KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down
+        )
+    {
+        return true;
+    }
+    matches!(
+        key.code,
+        KeyCode::Char('q' | '?' | 'w' | 'm' | 't' | '1'..='9') | KeyCode::Tab | KeyCode::BackTab
+    )
+}
+
+/// String-side equivalent used to reject a frame that advertises a passive
+/// claim the host will never honour.
+fn host_owned_chord(raw: &str) -> bool {
+    let (control, base) = chord_parts(raw);
+    let jump = base.len() == 1 && matches!(base.as_bytes()[0], b'1'..=b'9');
+    (control
+        && matches!(
+            base.to_ascii_lowercase().as_str(),
+            "c" | "left" | "right" | "up" | "down"
+        ))
+        || matches!(base, "q" | "?" | "w" | "m" | "t" | "Tab" | "BackTab")
+        || jump
+}
+
+fn is_ctrl_c_chord(raw: &str) -> bool {
+    let (control, base) = chord_parts(raw);
+    control && base.eq_ignore_ascii_case("c")
+}
+
+fn binding_mentions_host_key(raw: &str, capture: bool) -> bool {
+    raw.split(|character: char| {
+        character.is_whitespace() || matches!(character, '/' | ',' | '·' | '(' | ')')
+    })
+    .filter(|part| !part.is_empty())
+    .any(|part| {
+        is_ctrl_c_chord(part)
+            || part.eq_ignore_ascii_case("ctrl+c")
+            || (!capture
+                && (host_owned_chord(part)
+                    || part == "1-9"
+                    || part.eq_ignore_ascii_case("ctrl+arrows")))
+    })
+}
+
+fn chord_parts(raw: &str) -> (bool, &str) {
+    let mut pieces = raw.split('+').peekable();
+    let mut control = false;
+    let mut base = "";
+    while let Some(piece) = pieces.next() {
+        if pieces.peek().is_none() {
+            base = piece;
+        } else if piece.eq_ignore_ascii_case("ctrl") {
+            control = true;
+        }
+    }
+    (control, base)
+}
+
+fn key_code(code: KeyCode) -> String {
+    match code {
+        KeyCode::Char(_) => "char".into(),
+        KeyCode::F(number) => format!("f{number}"),
+        other => format!("{other:?}").to_ascii_lowercase(),
+    }
+}
+
+fn key_modifiers(modifiers: KeyModifiers) -> Vec<String> {
+    [
+        (KeyModifiers::CONTROL, "Ctrl"),
+        (KeyModifiers::ALT, "Alt"),
+        (KeyModifiers::SHIFT, "Shift"),
+        (KeyModifiers::SUPER, "Super"),
+        (KeyModifiers::HYPER, "Hyper"),
+        (KeyModifiers::META, "Meta"),
+    ]
+    .into_iter()
+    .filter(|(flag, _)| modifiers.contains(*flag))
+    .map(|(_, name)| name.to_string())
+    .collect()
+}
+
+fn mouse_kind(kind: MouseEventKind) -> Option<(String, Option<String>)> {
+    match kind {
+        MouseEventKind::Down(button) => Some(("down".into(), Some(mouse_button(button)))),
+        MouseEventKind::ScrollDown => Some(("scroll_down".into(), None)),
+        MouseEventKind::ScrollUp => Some(("scroll_up".into(), None)),
+        MouseEventKind::Up(_)
+        | MouseEventKind::Drag(_)
+        | MouseEventKind::Moved
+        | MouseEventKind::ScrollLeft
+        | MouseEventKind::ScrollRight => None,
+    }
+}
+
+fn mouse_button(button: MouseButton) -> String {
+    match button {
+        MouseButton::Left => "left",
+        MouseButton::Right => "right",
+        MouseButton::Middle => "middle",
+    }
+    .into()
+}
+
+fn span_style(span: &WireSpan, theme: &crate::theme::Theme) -> Style {
+    let mut style = Style::default();
+    if let Some(color) = span.fg.as_deref().and_then(|raw| wire_color(raw, theme)) {
+        style = style.fg(color);
+    }
+    if let Some(color) = span.bg.as_deref().and_then(|raw| wire_color(raw, theme)) {
+        style = style.bg(color);
+    }
+    for (enabled, modifier) in [
+        (span.bold, Modifier::BOLD),
+        (span.dim, Modifier::DIM),
+        (span.italic, Modifier::ITALIC),
+        (span.underlined, Modifier::UNDERLINED),
+        (span.reversed, Modifier::REVERSED),
+    ] {
+        if enabled {
+            style = style.add_modifier(modifier);
+        }
+    }
+    style
+}
+
+fn wire_color(raw: &str, theme: &crate::theme::Theme) -> Option<Color> {
+    match raw {
+        "default" | "reset" => Some(Color::Reset),
+        "theme:border" => Some(theme.border),
+        "theme:border_focused" => Some(theme.border_focused),
+        "theme:rule" => Some(theme.rule),
+        "theme:title" => Some(theme.title),
+        "theme:text" => Some(theme.text),
+        "theme:muted" => Some(theme.muted),
+        "theme:label" => Some(theme.label),
+        "theme:accent" => Some(theme.accent),
+        "theme:key" => Some(theme.key),
+        "theme:success" => Some(theme.success),
+        "theme:warning" => Some(theme.warning),
+        "theme:error" => Some(theme.error),
+        "theme:track" => Some(theme.track),
+        _ => raw
+            .strip_prefix("ansi:")
+            .and_then(|index| index.parse::<u8>().ok())
+            .map(Color::Indexed)
+            .or_else(|| raw.parse().ok()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, BufReader};
+
+    use super::process::{apply_message, read_limited_line};
+    use super::*;
+
+    fn detached_panel(policy: InputPolicy) -> PluginPanel {
+        PluginPanel {
+            spec: PluginConfig {
+                id: "test".into(),
+                command: vec!["unused".into()],
+                config: toml::Table::new(),
+            },
+            runtime: None,
+            shared: Arc::new(Mutex::new(Shared::starting())),
+            seen_generation: 0,
+            phase: Phase::Running,
+            title: "test".into(),
+            refresh: DEFAULT_REFRESH,
+            frame: None,
+            bindings: Vec::new(),
+            policy,
+            notice: None,
+            input_barrier: None,
+            last_size: None,
+            last_focus: None,
+        }
+    }
+
+    #[test]
+    fn ready_must_match_the_host_protocol() {
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        assert!(!apply_message(
+            PluginMessage::Ready {
+                protocol: PROTOCOL_VERSION + 1,
+                title: None,
+                refresh_ms: None,
+            },
+            &shared,
+        ));
+        assert!(matches!(
+            shared.lock().unwrap().phase,
+            Phase::Failed(ref message) if message.contains("incompatible")
+        ));
+    }
+
+    #[test]
+    fn frames_are_full_snapshots_and_old_revisions_are_ignored() {
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        assert!(apply_message(
+            PluginMessage::Ready {
+                protocol: PROTOCOL_VERSION,
+                title: Some("test".into()),
+                refresh_ms: Some(1),
+            },
+            &shared,
+        ));
+        let frame = |revision, text: &str| PluginMessage::Frame {
+            revision,
+            title: None,
+            counter: None,
+            lines: vec![WireLine {
+                spans: vec![WireSpan {
+                    text: text.into(),
+                    fg: None,
+                    bg: None,
+                    bold: false,
+                    dim: false,
+                    italic: false,
+                    underlined: false,
+                    reversed: false,
+                }],
+            }],
+            bindings: Vec::new(),
+            input: InputPolicy::default(),
+            cursor: None,
+        };
+        assert!(apply_message(frame(2, "new"), &shared));
+        assert!(apply_message(frame(1, "old"), &shared));
+        let shared = shared.lock().unwrap();
+        assert_eq!(shared.refresh, Duration::from_millis(16));
+        assert_eq!(shared.frame.as_ref().unwrap().lines[0].spans[0].text, "new");
+    }
+
+    #[test]
+    fn an_omitted_frame_title_restores_the_negotiated_title() {
+        let mut panel = detached_panel(InputPolicy::default());
+        assert!(apply_message(
+            PluginMessage::Ready {
+                protocol: PROTOCOL_VERSION,
+                title: Some("negotiated".into()),
+                refresh_ms: None,
+            },
+            &panel.shared,
+        ));
+        let frame = |revision, title| PluginMessage::Frame {
+            revision,
+            title,
+            counter: None,
+            lines: Vec::new(),
+            bindings: Vec::new(),
+            input: InputPolicy::default(),
+            cursor: None,
+        };
+
+        assert!(apply_message(
+            frame(1, Some("temporary".into())),
+            &panel.shared
+        ));
+        assert!(panel.sync());
+        assert_eq!(panel.title, "temporary");
+
+        assert!(apply_message(frame(2, None), &panel.shared));
+        assert!(panel.sync());
+        assert_eq!(panel.title, "negotiated");
+    }
+
+    #[test]
+    fn canonical_keys_are_stable_across_platforms() {
+        assert_eq!(
+            canonical_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            "Ctrl+c"
+        );
+        assert_eq!(
+            canonical_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::SHIFT)),
+            "Shift+PageUp"
+        );
+        assert_eq!(canonical_key(KeyEvent::from(KeyCode::Enter)), "Enter");
+    }
+
+    #[test]
+    fn semantic_and_terminal_colours_share_the_wire_format() {
+        let theme = crate::theme::Theme::default();
+        assert_eq!(wire_color("theme:accent", &theme), Some(theme.accent));
+        assert_eq!(wire_color("ansi:203", &theme), Some(Color::Indexed(203)));
+        assert_eq!(wire_color("#112233", &theme), Some(Color::Rgb(17, 34, 51)));
+    }
+
+    #[test]
+    fn host_wraps_styled_output_to_cells_and_visible_rows() {
+        let theme = crate::theme::Theme::default();
+        let source = [WireLine {
+            spans: vec![
+                WireSpan {
+                    text: "one ".into(),
+                    fg: Some("theme:accent".into()),
+                    bg: None,
+                    bold: true,
+                    dim: false,
+                    italic: false,
+                    underlined: false,
+                    reversed: false,
+                },
+                WireSpan {
+                    text: "two three".into(),
+                    fg: None,
+                    bg: None,
+                    bold: false,
+                    dim: false,
+                    italic: true,
+                    underlined: false,
+                    reversed: false,
+                },
+            ],
+        }];
+        let lines = wrapped_wire_lines(&source, 7, 2, &theme);
+        assert_eq!(lines.len(), 2);
+        for line in &lines {
+            let text: String = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect();
+            assert!(crate::grid::display_width(&text) <= 7, "{text:?}");
+        }
+        assert!(
+            lines[0]
+                .spans
+                .first()
+                .unwrap()
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn a_glyph_wider_than_the_panel_is_replaced_not_spilled() {
+        let theme = crate::theme::Theme::default();
+        let source = [WireLine {
+            spans: vec![WireSpan {
+                text: "界界".into(),
+                fg: None,
+                bg: None,
+                bold: false,
+                dim: false,
+                italic: false,
+                underlined: false,
+                reversed: false,
+            }],
+        }];
+        let lines = wrapped_wire_lines(&source, 1, 2, &theme);
+        assert_eq!(lines.len(), 2);
+        for line in lines {
+            let text: String = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect();
+            assert_eq!(text, "…");
+            assert_eq!(crate::grid::display_width(&text), 1);
+        }
+    }
+
+    #[test]
+    fn a_style_boundary_cannot_make_a_joined_glyph_overrun() {
+        let theme = crate::theme::Theme::default();
+        let source = [WireLine {
+            spans: vec![
+                WireSpan {
+                    text: "👩".into(),
+                    fg: Some("theme:accent".into()),
+                    bg: None,
+                    bold: false,
+                    dim: false,
+                    italic: false,
+                    underlined: false,
+                    reversed: false,
+                },
+                WireSpan {
+                    text: "\u{200d}💻".into(),
+                    fg: Some("theme:text".into()),
+                    bg: None,
+                    bold: false,
+                    dim: false,
+                    italic: false,
+                    underlined: false,
+                    reversed: false,
+                },
+            ],
+        }];
+        let lines = wrapped_wire_lines(&source, 2, 1, &theme);
+        let rendered_width: usize = lines[0]
+            .spans
+            .iter()
+            .map(|span| crate::grid::display_width(&span.content))
+            .sum();
+        assert!(rendered_width <= 2, "rendered width was {rendered_width}");
+    }
+
+    #[test]
+    fn external_panels_disclose_their_origin_in_the_frame_title() {
+        let panel = detached_panel(InputPolicy::default());
+        assert_eq!(panel.title(), "EXTERNAL · test");
+    }
+
+    #[test]
+    fn passive_policy_claims_only_named_keys_and_capture_never_falls_through() {
+        let mut passive = detached_panel(InputPolicy {
+            keys: vec!["Enter".into()],
+            ..InputPolicy::default()
+        });
+        assert_eq!(
+            passive.handle_key(KeyEvent::from(KeyCode::Enter)),
+            KeyOutcome::Consumed
+        );
+        assert_eq!(
+            passive.handle_key(KeyEvent::from(KeyCode::Char('q'))),
+            KeyOutcome::Ignored
+        );
+
+        let mut capturing = detached_panel(InputPolicy {
+            capture: true,
+            ..InputPolicy::default()
+        });
+        assert_eq!(
+            capturing.handle_key(KeyEvent::from(KeyCode::Char('q'))),
+            KeyOutcome::Consumed,
+            "a stalled plugin must not turn its q into a global quit"
+        );
+    }
+
+    #[test]
+    fn passive_plugins_cannot_claim_shell_keys_but_capture_can_suspend_them() {
+        let shell_keys = [
+            KeyEvent::from(KeyCode::Char('q')),
+            KeyEvent::from(KeyCode::Tab),
+            KeyEvent::from(KeyCode::Char('?')),
+            KeyEvent::from(KeyCode::Char('w')),
+            KeyEvent::from(KeyCode::Char('m')),
+            KeyEvent::from(KeyCode::Char('t')),
+            KeyEvent::from(KeyCode::Char('3')),
+            KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL),
+        ];
+        let mut passive = detached_panel(InputPolicy {
+            keys: shell_keys.iter().copied().map(canonical_key).collect(),
+            ..InputPolicy::default()
+        });
+        for key in shell_keys {
+            assert_eq!(passive.handle_key(key), KeyOutcome::Ignored, "{key:?}");
+        }
+
+        let mut capturing = detached_panel(InputPolicy {
+            capture: true,
+            ..InputPolicy::default()
+        });
+        assert_eq!(
+            capturing.handle_key(KeyEvent::from(KeyCode::Char('q'))),
+            KeyOutcome::Consumed
+        );
+    }
+
+    #[test]
+    fn protocol_spellings_identify_every_reserved_chord() {
+        for chord in [
+            "q",
+            "Alt+q",
+            "?",
+            "w",
+            "m",
+            "t",
+            "Tab",
+            "BackTab",
+            "Shift+BackTab",
+            "1",
+            "9",
+            "Ctrl+c",
+            "Ctrl+Shift+c",
+            "Ctrl+Left",
+        ] {
+            assert!(host_owned_chord(chord), "{chord}");
+        }
+        for chord in ["Q", "Enter", "r", "Alt+Left", "Ctrl+x"] {
+            assert!(!host_owned_chord(chord), "{chord}");
+        }
+    }
+
+    #[test]
+    fn a_passive_action_captures_until_a_new_frame_acknowledges_it() {
+        let passive = InputPolicy {
+            keys: vec!["Enter".into()],
+            ..InputPolicy::default()
+        };
+        let frame = |revision, input| WireFrame {
+            revision,
+            title: None,
+            counter: None,
+            lines: Vec::new(),
+            bindings: Vec::new(),
+            input,
+            cursor: None,
+        };
+        let mut panel = detached_panel(passive.clone());
+        panel.frame = Some(Arc::new(frame(4, passive)));
+
+        // Simulate a successfully queued named key. Until revision 5 arrives,
+        // rapid follow-up input belongs to the pending plugin transition.
+        panel.begin_input_barrier();
+        assert!(panel.captures_input());
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Char('q'))),
+            KeyOutcome::Consumed
+        );
+        {
+            let mut shared = panel.shared.lock().unwrap();
+            shared.frame = Some(Arc::new(frame(5, InputPolicy::default())));
+            shared.generation += 1;
+        }
+        assert!(panel.sync());
+        assert!(!panel.captures_input());
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Char('q'))),
+            KeyOutcome::Ignored
+        );
+    }
+
+    #[test]
+    fn watch_messages_enter_the_native_panel_event_drain() {
+        let mut panel = detached_panel(InputPolicy::default());
+        assert!(apply_message(
+            PluginMessage::Ready {
+                protocol: PROTOCOL_VERSION,
+                title: None,
+                refresh_ms: None,
+            },
+            &panel.shared,
+        ));
+        assert!(apply_message(
+            PluginMessage::Watch {
+                text: "the build finished".into(),
+            },
+            &panel.shared,
+        ));
+
+        let events = panel.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source, "test");
+        assert_eq!(events[0].text, "the build finished");
+        assert!(panel.events().is_empty(), "the native hook is a drain");
+    }
+
+    #[test]
+    fn watch_messages_are_single_lines_and_their_queue_is_bounded() {
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        assert!(apply_message(
+            PluginMessage::Ready {
+                protocol: PROTOCOL_VERSION,
+                title: None,
+                refresh_ms: None,
+            },
+            &shared,
+        ));
+        for index in 0..65 {
+            assert!(apply_message(
+                PluginMessage::Watch {
+                    text: format!("event {index}"),
+                },
+                &shared,
+            ));
+        }
+        let guard = shared.lock().unwrap();
+        assert_eq!(guard.watch.len(), 64);
+        assert_eq!(guard.watch.front().map(String::as_str), Some("event 1"));
+        drop(guard);
+
+        assert!(!apply_message(
+            PluginMessage::Watch {
+                text: "not\none line".into(),
+            },
+            &shared,
+        ));
+        assert!(matches!(
+            shared.lock().unwrap().phase,
+            Phase::Failed(ref error) if error.contains("one non-empty line")
+        ));
+    }
+
+    #[test]
+    fn oversized_messages_are_rejected_before_unbounded_allocation() {
+        let input = vec![b'x'; MAX_MESSAGE_BYTES + 1];
+        let mut reader = BufReader::new(input.as_slice());
+        let error = read_limited_line(&mut reader, &mut Vec::new()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn the_last_json_object_still_requires_a_newline() {
+        let mut reader = BufReader::new(br#"{"type":"ready","protocol":1}"#.as_slice());
+        let error = read_limited_line(&mut reader, &mut Vec::new()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("newline"));
+    }
+
+    /// Cross-repository smoke test. Point `MIRADOR_TEST_PLUGIN` at any protocol
+    /// command; language SDKs can use this in their own release checks.
+    #[test]
+    #[ignore = "requires an explicitly installed external plugin command"]
+    fn an_external_process_negotiates_and_publishes_a_frame() {
+        use std::time::Instant;
+
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let command = std::env::var("MIRADOR_TEST_PLUGIN")
+            .expect("set MIRADOR_TEST_PLUGIN to an external plugin executable");
+        let mut panel = PluginPanel::new(PluginConfig {
+            id: "integration".into(),
+            command: vec![command],
+            config: toml::Table::new(),
+        });
+        let theme = crate::theme::Theme::default();
+        let gradients = theme.gradients();
+        let watch = crate::watch::WatchLog::default();
+        let mut terminal = Terminal::new(TestBackend::new(60, 12)).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        while Instant::now() < deadline {
+            panel.tick();
+            terminal
+                .draw(|frame| {
+                    let area = frame.area();
+                    panel.render(
+                        frame,
+                        area,
+                        RenderContext {
+                            theme: &theme,
+                            gradients: &gradients,
+                            focused: true,
+                            watch: &watch,
+                        },
+                    );
+                })
+                .unwrap();
+            if matches!(panel.phase, Phase::Running) && panel.frame.is_some() {
+                panel.shutdown();
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let phase = panel.phase.clone();
+        panel.shutdown();
+        panic!("plugin did not publish a frame within five seconds: {phase:?}");
+    }
+
+    /// Full proof for the dashboard-native example: Rust host -> Python SDK ->
+    /// process watcher -> child process -> protocol watch message -> native
+    /// `Panel::events` drain.
+    #[test]
+    #[ignore = "requires an explicitly installed mirador-process-watch command"]
+    fn an_external_process_watcher_reports_a_native_watch_event() {
+        use std::time::Instant;
+
+        let watcher = std::env::var("MIRADOR_TEST_WATCH_PLUGIN")
+            .expect("set MIRADOR_TEST_WATCH_PLUGIN to mirador-process-watch");
+        let child = std::env::current_exe()
+            .expect("test executable has a path")
+            .to_string_lossy()
+            .into_owned();
+        let mut config = toml::Table::new();
+        config.insert("name".into(), toml::Value::String("Host tests".into()));
+        config.insert(
+            "command".into(),
+            toml::Value::Array(
+                [child, "--list".into()]
+                    .into_iter()
+                    .map(toml::Value::String)
+                    .collect(),
+            ),
+        );
+        config.insert("autostart".into(), toml::Value::Boolean(true));
+        config.insert("output_lines".into(), toml::Value::Integer(50));
+        let mut panel = PluginPanel::new(PluginConfig {
+            id: "process-watch-test".into(),
+            command: vec![watcher],
+            config,
+        });
+        let deadline = Instant::now() + Duration::from_secs(15);
+
+        while Instant::now() < deadline {
+            panel.tick();
+            if let Some(event) = panel.events().into_iter().next() {
+                panel.shutdown();
+                assert_eq!(event.source, "process-watch-test");
+                assert!(
+                    event.text.contains("finished successfully"),
+                    "unexpected Watch Log event: {}",
+                    event.text
+                );
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let phase = panel.phase.clone();
+        panel.shutdown();
+        panic!("process watcher did not report completion within fifteen seconds: {phase:?}");
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -8,7 +8,7 @@
 
 use std::sync::mpsc::TrySendError;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ratatui::Frame;
 use ratatui::crossterm::event::{
@@ -46,6 +46,10 @@ const MAX_COLOR_BYTES: usize = 64;
 /// not make drawing one row proportional to an entire retained frame.
 const RENDER_BYTES_PER_CELL: usize = 16;
 const DEFAULT_REFRESH: Duration = Duration::from_millis(33);
+const INPUT_BARRIER_REFRESHES: u32 = 3;
+const MIN_INPUT_BARRIER: Duration = Duration::from_millis(100);
+const MAX_INPUT_BARRIER: Duration = Duration::from_secs(1);
+const INPUT_BARRIER_POLL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -196,6 +200,12 @@ struct WireFrame {
     cursor: Option<WireCursor>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct InputBarrier {
+    frame_sequence: u64,
+    expires_at: Instant,
+}
+
 /// Adapter from one explicitly configured process to Mirador's private panel
 /// trait. Process failures are panel state, never application failures.
 pub struct PluginPanel {
@@ -203,6 +213,7 @@ pub struct PluginPanel {
     runtime: Option<Runtime>,
     shared: Arc<Mutex<Shared>>,
     seen_generation: u64,
+    seen_frame_sequence: u64,
     phase: Phase,
     title: String,
     refresh: Duration,
@@ -210,10 +221,9 @@ pub struct PluginPanel {
     bindings: Vec<Binding>,
     policy: InputPolicy,
     notice: Option<String>,
-    /// Revision whose passive key action is awaiting a new frame. Until that
-    /// acknowledgement arrives, subsequent input is conservatively captured
-    /// so a rapid `Enter`, `q` cannot cross an asynchronous mode transition.
-    input_barrier: Option<u64>,
+    /// A passive key action awaiting any accepted frame. The short deadline is
+    /// what makes this a race barrier rather than an unbounded modal state.
+    input_barrier: Option<InputBarrier>,
     last_size: Option<(u16, u16)>,
     last_focus: Option<bool>,
 }
@@ -226,6 +236,7 @@ impl PluginPanel {
             runtime: None,
             shared: Arc::new(Mutex::new(Shared::starting())),
             seen_generation: u64::MAX,
+            seen_frame_sequence: 0,
             phase: Phase::Starting,
             title: id,
             refresh: DEFAULT_REFRESH,
@@ -246,6 +257,7 @@ impl PluginPanel {
         self.stop();
         self.shared = Arc::new(Mutex::new(Shared::starting()));
         self.seen_generation = u64::MAX;
+        self.seen_frame_sequence = 0;
         self.phase = Phase::Starting;
         self.frame = None;
         self.bindings.clear();
@@ -266,8 +278,8 @@ impl PluginPanel {
     }
 
     fn stop(&mut self) {
-        if let Some(runtime) = self.runtime.take() {
-            runtime.shutdown();
+        if let Some(mut runtime) = self.runtime.take() {
+            let _ = runtime.shutdown();
         }
     }
 
@@ -276,7 +288,20 @@ impl PluginPanel {
             .shared
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let frame_sequence = shared.frame_sequence;
+        if shared.generation == self.seen_generation && frame_sequence == self.seen_frame_sequence {
+            return false;
+        }
+
         if shared.generation == self.seen_generation {
+            drop(shared);
+            if self
+                .input_barrier
+                .is_some_and(|barrier| barrier.frame_sequence != frame_sequence)
+            {
+                self.input_barrier = None;
+            }
+            self.seen_frame_sequence = frame_sequence;
             return false;
         }
 
@@ -292,6 +317,14 @@ impl PluginPanel {
         };
         drop(shared);
 
+        if self
+            .input_barrier
+            .is_some_and(|barrier| barrier.frame_sequence != frame_sequence)
+        {
+            self.input_barrier = None;
+        }
+        self.seen_frame_sequence = frame_sequence;
+
         self.title = next
             .as_ref()
             .and_then(|frame| frame.title.clone())
@@ -299,12 +332,6 @@ impl PluginPanel {
 
         if let Some(frame) = &next {
             self.policy = frame.input.clone();
-            if self
-                .input_barrier
-                .is_some_and(|revision| frame.revision > revision)
-            {
-                self.input_barrier = None;
-            }
             if matches!(self.phase, Phase::Exited(_) | Phase::Failed(_)) {
                 self.input_barrier = None;
             }
@@ -338,7 +365,7 @@ impl PluginPanel {
         let Some(runtime) = &self.runtime else {
             return false;
         };
-        match runtime.events.try_send(message) {
+        match runtime.send(message) {
             Ok(()) => true,
             Err(TrySendError::Full(_)) => {
                 let mut shared = self
@@ -359,9 +386,40 @@ impl PluginPanel {
         if self.policy.capture || self.input_barrier.is_some() {
             return;
         }
-        if let Some(revision) = self.frame.as_ref().map(|frame| frame.revision) {
-            self.input_barrier = Some(revision);
+        let timeout = input_barrier_timeout(self.refresh);
+        self.input_barrier = Some(InputBarrier {
+            frame_sequence: self.seen_frame_sequence,
+            expires_at: Instant::now() + timeout,
+        });
+    }
+
+    fn input_barrier_active(&self) -> bool {
+        self.input_barrier
+            .is_some_and(|barrier| Instant::now() < barrier.expires_at)
+    }
+
+    fn expire_input_barrier(&mut self) -> bool {
+        let Some(barrier) = self.input_barrier else {
+            return false;
+        };
+        if Instant::now() < barrier.expires_at {
+            return false;
         }
+
+        self.input_barrier = None;
+        let timeout = input_barrier_timeout(self.refresh);
+        let message = format!(
+            "plugin did not acknowledge input with a frame within {} ms",
+            timeout.as_millis()
+        );
+        self.shared
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .fail(message);
+        if let Some(runtime) = &self.runtime {
+            runtime.abort();
+        }
+        self.sync()
     }
 
     fn status_lines(
@@ -454,11 +512,17 @@ impl Panel for PluginPanel {
     }
 
     fn refresh_interval(&self) -> Duration {
-        self.refresh
+        self.input_barrier.map_or(self.refresh, |barrier| {
+            let until_deadline = barrier
+                .expires_at
+                .saturating_duration_since(Instant::now())
+                .max(Duration::from_millis(1));
+            self.refresh.min(INPUT_BARRIER_POLL).min(until_deadline)
+        })
     }
 
     fn tick(&mut self) -> bool {
-        let changed = self.sync();
+        let changed = self.expire_input_barrier() || self.sync();
         let _ = self.send(HostMessage::Tick);
         changed
     }
@@ -476,6 +540,7 @@ impl Panel for PluginPanel {
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        self.expire_input_barrier();
         self.sync();
         let size = (area.width.max(1), area.height.max(1));
         if self.last_size != Some(size)
@@ -550,6 +615,7 @@ impl Panel for PluginPanel {
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        self.expire_input_barrier();
         let canonical = canonical_key(key);
         if matches!(self.phase, Phase::Exited(_) | Phase::Failed(_)) && canonical == "r" {
             self.start();
@@ -588,18 +654,44 @@ impl Panel for PluginPanel {
     }
 
     fn handle_paste(&mut self, text: &str) -> KeyOutcome {
-        if !self.policy.paste && self.input_barrier.is_none() {
-            return KeyOutcome::Ignored;
+        self.expire_input_barrier();
+        if !self.policy.paste {
+            // Capture and the race barrier own the event, but paste is a
+            // separate capability. Consume it without converting its contents
+            // into key messages or forwarding it to a process that opted out.
+            return if self.policy.capture || self.input_barrier_active() {
+                KeyOutcome::Consumed
+            } else {
+                KeyOutcome::Ignored
+            };
         }
-        let _ = self.send(HostMessage::Paste {
+        let message = HostMessage::Paste {
             text: text.to_string(),
-        });
+        };
+        if !host_message_fits(&message) {
+            let mut shared = self
+                .shared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            shared.notice =
+                Some("paste is too large for external panel input (8 MiB message limit)".into());
+            shared.changed();
+            drop(shared);
+            self.sync();
+            return KeyOutcome::Consumed;
+        }
+        let _ = self.send(message);
         KeyOutcome::Consumed
     }
 
     fn handle_mouse(&mut self, event: MouseEvent, area: Rect) -> KeyOutcome {
-        if !self.policy.mouse && self.input_barrier.is_none() {
-            return KeyOutcome::Ignored;
+        self.expire_input_barrier();
+        if !self.policy.mouse {
+            return if self.policy.capture || self.input_barrier_active() {
+                KeyOutcome::Consumed
+            } else {
+                KeyOutcome::Ignored
+            };
         }
         let Some((kind, button)) = mouse_kind(event.kind) else {
             return KeyOutcome::Ignored;
@@ -615,7 +707,7 @@ impl Panel for PluginPanel {
     }
 
     fn captures_input(&self) -> bool {
-        self.policy.capture || self.input_barrier.is_some()
+        self.policy.capture || self.input_barrier_active()
     }
 
     fn shutdown(&mut self) {
@@ -675,99 +767,68 @@ fn wrapped_wire_lines(
         if remaining == 0 {
             break;
         }
-        let prefix = visible_wire_prefix(line, usize::from(width), remaining);
-        let mut span_index = 0usize;
-        let mut span_offset = 0usize;
-        for row in crate::grid::wrap(&prefix, usize::from(width))
+        let prefix = visible_wire_line(line, usize::from(width), remaining, theme);
+        for row in crate::grid::wrap_line(&prefix, usize::from(width))
             .into_iter()
             .take(remaining)
         {
-            let spans = take_styled_bytes(
-                &line.spans,
-                &mut span_index,
-                &mut span_offset,
-                row.len(),
-                theme,
-            );
-            // Ratatui measures each styled span independently. A joined emoji
-            // sequence can be two cells as one string but wider when a style
-            // boundary splits it, so the postcondition must use the widths the
-            // renderer will actually add.
-            let rendered_width: usize = spans
-                .iter()
-                .map(|span| crate::grid::display_width(&span.content))
-                .sum();
-            if rendered_width > usize::from(width) {
-                let style = spans.first().map_or(Style::default(), |span| span.style);
-                output.push(Line::from(Span::styled(
-                    crate::grid::truncate(&row, usize::from(width)),
-                    style,
-                )));
-            } else {
-                output.push(Line::from(spans));
-            }
+            output.push(row);
         }
     }
     output
 }
 
-fn visible_wire_prefix(line: &WireLine, width: usize, rows: usize) -> String {
+fn visible_wire_line(
+    line: &WireLine,
+    width: usize,
+    rows: usize,
+    theme: &crate::theme::Theme,
+) -> Line<'static> {
     // A two-cell glyph in a one-cell panel is replaced by one ellipsis. Count
     // enough source width to produce every requested replacement row.
     let cell_budget = width.max(2).saturating_mul(rows.saturating_add(1));
     let byte_budget = cell_budget
         .saturating_mul(RENDER_BYTES_PER_CELL)
         .clamp(256, MAX_RETAINED_FRAME_TEXT_BYTES);
-    let mut output = String::new();
+    let mut output = Vec::new();
+    let mut bytes = 0usize;
     let mut cells = 0usize;
+    let mut complete = true;
 
-    'spans: for span in &line.spans {
+    for span in &line.spans {
+        let mut text = String::new();
         for character in span.text.chars() {
-            let bytes = character.len_utf8();
+            let character_bytes = character.len_utf8();
             let character_width = crate::grid::char_width(character);
-            if output.len().saturating_add(bytes) > byte_budget
+            if bytes.saturating_add(character_bytes) > byte_budget
                 || (character_width > 0 && cells.saturating_add(character_width) > cell_budget)
             {
-                break 'spans;
+                complete = false;
+                break;
             }
-            output.push(character);
+            text.push(character);
+            bytes = bytes.saturating_add(character_bytes);
             cells = cells.saturating_add(character_width);
         }
+        if !text.is_empty() {
+            output.push(Span::styled(text, span_style(span, theme)));
+        }
+        if !complete {
+            break;
+        }
     }
-    output
+    Line::from(output)
 }
 
-fn take_styled_bytes(
-    source: &[WireSpan],
-    span_index: &mut usize,
-    span_offset: &mut usize,
-    mut remaining: usize,
-    theme: &crate::theme::Theme,
-) -> Vec<Span<'static>> {
-    let mut output = Vec::new();
-    while remaining > 0 && *span_index < source.len() {
-        let span = &source[*span_index];
-        let available = &span.text[*span_offset..];
-        if available.is_empty() {
-            *span_index += 1;
-            *span_offset = 0;
-            continue;
-        }
-        let take = remaining.min(available.len());
-        debug_assert!(available.is_char_boundary(take));
-        output.push(Span::styled(
-            available[..take].to_string(),
-            span_style(span, theme),
-        ));
-        remaining -= take;
-        *span_offset += take;
-        if *span_offset == span.text.len() {
-            *span_index += 1;
-            *span_offset = 0;
-        }
-    }
-    debug_assert_eq!(remaining, 0);
-    output
+fn input_barrier_timeout(refresh: Duration) -> Duration {
+    refresh
+        .saturating_mul(INPUT_BARRIER_REFRESHES)
+        .clamp(MIN_INPUT_BARRIER, MAX_INPUT_BARRIER)
+}
+
+fn host_message_fits(message: &HostMessage) -> bool {
+    serde_json::to_vec(message)
+        .is_ok_and(|encoded| encoded.len().saturating_add(1) <= MAX_MESSAGE_BYTES)
 }
 
 fn canonical_key(key: KeyEvent) -> String {
@@ -978,6 +1039,7 @@ mod tests {
             runtime: None,
             shared: Arc::new(Mutex::new(Shared::starting())),
             seen_generation: 0,
+            seen_frame_sequence: 0,
             phase: Phase::Running,
             title: "test".into(),
             refresh: DEFAULT_REFRESH,
@@ -1005,6 +1067,34 @@ mod tests {
         assert!(matches!(
             shared.lock().unwrap().phase,
             Phase::Failed(ref message) if message.contains("incompatible")
+        ));
+    }
+
+    #[test]
+    fn spawn_failure_is_panel_state_and_restart_retries_the_process() {
+        let mut panel = PluginPanel::new(PluginConfig {
+            id: "missing-test-plugin".into(),
+            command: vec!["mirador-plugin-test-command-that-does-not-exist-7f09".into()],
+            config: toml::Table::new(),
+        });
+        assert!(matches!(
+            panel.phase,
+            Phase::Failed(ref error) if error.contains("could not start plugin")
+        ));
+        let first_attempt = Arc::clone(&panel.shared);
+
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Char('r'))),
+            KeyOutcome::Consumed
+        );
+        assert!(
+            !Arc::ptr_eq(&first_attempt, &panel.shared),
+            "restart did not create a new process session"
+        );
+        assert!(panel.sync());
+        assert!(matches!(
+            panel.phase,
+            Phase::Failed(ref error) if error.contains("could not start plugin")
         ));
     }
 
@@ -1300,42 +1390,154 @@ mod tests {
     }
 
     #[test]
-    fn a_passive_action_captures_until_a_new_frame_acknowledges_it() {
+    fn any_accepted_frame_releases_a_passive_input_barrier() {
         let passive = InputPolicy {
             keys: vec!["Enter".into()],
             ..InputPolicy::default()
         };
-        let frame = |revision, input| WireFrame {
-            revision,
-            title: None,
-            counter: None,
-            lines: Vec::new(),
-            bindings: Vec::new(),
-            input,
-            cursor: None,
-        };
         let mut panel = detached_panel(passive.clone());
-        panel.frame = Some(Arc::new(frame(4, passive)));
+        assert!(apply_message(
+            PluginMessage::Ready {
+                protocol: PROTOCOL_VERSION,
+                title: None,
+                refresh_ms: None,
+            },
+            &panel.shared,
+        ));
+        assert!(apply_message(
+            PluginMessage::Frame {
+                revision: u64::MAX,
+                title: None,
+                counter: None,
+                lines: Vec::new(),
+                bindings: Vec::new(),
+                input: passive,
+                cursor: None,
+            },
+            &panel.shared,
+        ));
+        assert!(panel.sync());
 
-        // Simulate a successfully queued named key. Until revision 5 arrives,
-        // rapid follow-up input belongs to the pending plugin transition.
+        // The maximum revision cannot be exceeded. A second valid frame with
+        // that revision is still an acknowledgement even though it cannot
+        // replace the retained snapshot.
         panel.begin_input_barrier();
         assert!(panel.captures_input());
         assert_eq!(
             panel.handle_key(KeyEvent::from(KeyCode::Char('q'))),
             KeyOutcome::Consumed
         );
-        {
-            let mut shared = panel.shared.lock().unwrap();
-            shared.frame = Some(Arc::new(frame(5, InputPolicy::default())));
-            shared.generation += 1;
-        }
-        assert!(panel.sync());
+        assert!(apply_message(
+            PluginMessage::Frame {
+                revision: u64::MAX,
+                title: None,
+                counter: None,
+                lines: Vec::new(),
+                bindings: Vec::new(),
+                input: InputPolicy::default(),
+                cursor: None,
+            },
+            &panel.shared,
+        ));
+        assert!(
+            !panel.sync(),
+            "an acknowledgement without a new snapshot must not force a redraw"
+        );
         assert!(!panel.captures_input());
         assert_eq!(
             panel.handle_key(KeyEvent::from(KeyCode::Char('q'))),
             KeyOutcome::Ignored
         );
+    }
+
+    #[test]
+    fn an_unacknowledged_input_barrier_expires_as_a_failed_panel() {
+        let mut panel = detached_panel(InputPolicy {
+            keys: vec!["Enter".into()],
+            ..InputPolicy::default()
+        });
+        panel.input_barrier = Some(InputBarrier {
+            frame_sequence: 0,
+            expires_at: Instant::now()
+                .checked_sub(Duration::from_millis(1))
+                .expect("one millisecond fits before now"),
+        });
+
+        assert_eq!(panel.refresh_interval(), Duration::from_millis(1));
+        assert!(panel.expire_input_barrier());
+        assert!(!panel.captures_input());
+        assert!(matches!(
+            panel.phase,
+            Phase::Failed(ref error) if error.contains("acknowledge input")
+        ));
+        assert_eq!(
+            panel.handle_key(KeyEvent::from(KeyCode::Char('q'))),
+            KeyOutcome::Ignored,
+            "a failed plugin must return ordinary shell keys to Mirador"
+        );
+    }
+
+    #[test]
+    fn a_barrier_never_grants_undeclared_paste_or_mouse_capabilities() {
+        let mut panel = detached_panel(InputPolicy::default());
+        let (runtime, received) = Runtime::stub();
+        panel.runtime = Some(runtime);
+        panel.input_barrier = Some(InputBarrier {
+            frame_sequence: 0,
+            expires_at: Instant::now() + Duration::from_secs(1),
+        });
+        let mouse = MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        };
+
+        assert_eq!(panel.handle_paste("private"), KeyOutcome::Consumed);
+        assert_eq!(
+            panel.handle_mouse(mouse, Rect::new(0, 0, 10, 10)),
+            KeyOutcome::Consumed
+        );
+        assert!(
+            matches!(
+                received.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ),
+            "undeclared input reached the plugin process"
+        );
+        panel.shutdown();
+    }
+
+    #[test]
+    fn oversized_user_paste_is_dropped_without_blame_or_process_failure() {
+        let mut panel = detached_panel(InputPolicy {
+            paste: true,
+            ..InputPolicy::default()
+        });
+        let (runtime, received) = Runtime::stub();
+        panel.runtime = Some(runtime);
+
+        assert_eq!(
+            panel.handle_paste(&"x".repeat(MAX_MESSAGE_BYTES)),
+            KeyOutcome::Consumed
+        );
+        let shared = panel.shared.lock().unwrap();
+        assert!(
+            !matches!(shared.phase, Phase::Failed(_)),
+            "host input size must not be reported as a plugin protocol failure"
+        );
+        assert!(
+            shared
+                .notice
+                .as_deref()
+                .is_some_and(|notice| notice.contains("paste is too large"))
+        );
+        drop(shared);
+        assert!(matches!(
+            received.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        panel.shutdown();
     }
 
     #[test]

--- a/src/plugin/process.rs
+++ b/src/plugin/process.rs
@@ -3,9 +3,9 @@
 use std::collections::VecDeque;
 use std::io::{self, BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use crate::config::PluginConfig;
@@ -24,6 +24,12 @@ const WATCH_QUEUE: usize = 64;
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(300);
 const OUTPUT_CLOSE_GRACE: Duration = Duration::from_millis(100);
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+// Pipe closure and lifecycle commands wake the supervisor immediately. This is
+// only the fallback for a descendant that inherited stdout, so an idle plugin
+// does not need the old permanent 50 Hz process poll.
+const PROCESS_STATUS_POLL: Duration = Duration::from_secs(1);
+const SUPERVISOR_JOIN_GRACE: Duration = Duration::from_millis(750);
+const SUPERVISOR_ABORT_GRACE: Duration = Duration::from_millis(250);
 const MESSAGE_RATE_WINDOW: Duration = Duration::from_secs(1);
 const MAX_MESSAGES_PER_WINDOW: usize = 120;
 const MAX_STDOUT_BYTES_PER_WINDOW: usize = 16 * 1024 * 1024;
@@ -40,6 +46,9 @@ pub(super) enum Phase {
 
 pub(super) struct Shared {
     pub(super) generation: u64,
+    /// Number of valid frame messages accepted, including stale revisions.
+    /// Input acknowledgement is about receipt, not revision arithmetic.
+    pub(super) frame_sequence: u64,
     pub(super) ready: bool,
     pub(super) phase: Phase,
     pub(super) title: Option<String>,
@@ -54,6 +63,7 @@ impl Shared {
     pub(super) fn starting() -> Self {
         Self {
             generation: 0,
+            frame_sequence: 0,
             ready: false,
             phase: Phase::Starting,
             title: None,
@@ -92,15 +102,87 @@ enum SupervisorCommand {
 }
 
 pub(super) struct Runtime {
-    pub(super) events: SyncSender<HostMessage>,
+    events: Option<SyncSender<HostMessage>>,
     supervisor: mpsc::Sender<SupervisorCommand>,
+    supervisor_thread: Option<JoinHandle<()>>,
 }
 
 impl Runtime {
-    pub(super) fn shutdown(&self) {
-        let _ = self.events.try_send(HostMessage::Shutdown);
-        let _ = self.supervisor.send(SupervisorCommand::Shutdown);
+    pub(super) fn send(&self, message: HostMessage) -> Result<(), TrySendError<HostMessage>> {
+        let Some(events) = self.events.as_ref() else {
+            return Err(TrySendError::Disconnected(message));
+        };
+        events.try_send(message)
     }
+
+    pub(super) fn abort(&self) {
+        let _ = self.supervisor.send(SupervisorCommand::Abort);
+    }
+
+    /// Ask the child to stop, then remain alive long enough for the supervisor
+    /// to enforce the grace-then-kill contract. The wait itself is bounded so
+    /// a broken OS process primitive cannot trap Mirador on exit.
+    pub(super) fn shutdown(&mut self) -> bool {
+        if let Some(events) = self.events.take() {
+            let _ = events.try_send(HostMessage::Shutdown);
+            drop(events);
+            let _ = self.supervisor.send(SupervisorCommand::Shutdown);
+        }
+
+        let Some(thread) = self.supervisor_thread.take() else {
+            return true;
+        };
+        if wait_until_finished(&thread, SUPERVISOR_JOIN_GRACE) {
+            return thread.join().is_ok();
+        }
+
+        // The supervisor normally killed the process after 300 ms. Abort is a
+        // second, independent nudge before the bounded host wait runs out.
+        let _ = self.supervisor.send(SupervisorCommand::Abort);
+        if wait_until_finished(&thread, SUPERVISOR_ABORT_GRACE) {
+            thread.join().is_ok()
+        } else {
+            false
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn stub() -> (Self, Receiver<HostMessage>) {
+        let (events, received) = mpsc::sync_channel(EVENT_QUEUE);
+        let (supervisor, commands) = mpsc::channel();
+        let supervisor_thread = thread::spawn(move || {
+            while let Ok(command) = commands.recv() {
+                if matches!(
+                    command,
+                    SupervisorCommand::Shutdown | SupervisorCommand::Abort
+                ) {
+                    return;
+                }
+            }
+        });
+        (
+            Self {
+                events: Some(events),
+                supervisor,
+                supervisor_thread: Some(supervisor_thread),
+            },
+            received,
+        )
+    }
+}
+
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+fn wait_until_finished(thread: &JoinHandle<()>, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while !thread.is_finished() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(5));
+    }
+    thread.is_finished()
 }
 
 pub(super) fn spawn_process(
@@ -145,7 +227,7 @@ pub(super) fn spawn_process(
     thread::spawn(move || stderr_loop(stderr, &stderr_shared, &stderr_supervisor));
 
     let supervisor_shared = Arc::clone(shared);
-    thread::spawn(move || {
+    let supervisor_thread = thread::spawn(move || {
         supervisor_loop(
             &mut child,
             &supervisor_rx,
@@ -165,14 +247,15 @@ pub(super) fn spawn_process(
         config,
         cwd,
     };
-    event_tx
-        .try_send(hello)
-        .map_err(|error| io::Error::other(format!("sending hello: {error}")))?;
-
-    Ok(Runtime {
-        events: event_tx,
+    let runtime = Runtime {
+        events: Some(event_tx),
         supervisor: supervisor_tx,
-    })
+        supervisor_thread: Some(supervisor_thread),
+    };
+    runtime
+        .send(hello)
+        .map_err(|error| io::Error::other(format!("sending hello: {error}")))?;
+    Ok(runtime)
 }
 
 fn writer_loop(
@@ -318,15 +401,12 @@ pub(super) fn read_limited_line(
 }
 
 pub(super) fn apply_message(message: PluginMessage, shared: &Arc<Mutex<Shared>>) -> bool {
-    let mut shared = shared
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
     match message {
         PluginMessage::Ready {
             protocol,
             title,
             refresh_ms,
-        } => return apply_ready(protocol, title, refresh_ms, &mut shared),
+        } => apply_ready_message(protocol, title, refresh_ms, shared),
         PluginMessage::Frame {
             revision,
             title,
@@ -335,81 +415,139 @@ pub(super) fn apply_message(message: PluginMessage, shared: &Arc<Mutex<Shared>>)
             bindings,
             input,
             cursor,
-        } => {
-            return apply_frame(
-                WireFrame {
-                    revision,
-                    title,
-                    counter,
-                    lines,
-                    bindings,
-                    input,
-                    cursor,
-                },
-                &mut shared,
-            );
-        }
-        PluginMessage::Error { message, fatal } => {
-            if !shared.ready {
-                shared.fail("plugin sent an error before `ready`");
-                return false;
-            }
-            if let Err(error) = validate_text(&message, "error message", MAX_ERROR_BYTES) {
-                shared.fail(error);
-                return false;
-            }
-            if fatal {
-                shared.fail(message);
-                return false;
-            }
-            shared.notice = Some(message);
-            shared.changed();
-        }
-        PluginMessage::Watch { text } => {
-            if !shared.ready {
-                shared.fail("plugin sent a watch event before `ready`");
-                return false;
-            }
-            if text.trim().is_empty()
-                || text.len() > MAX_WATCH_TEXT_BYTES
-                || text.chars().any(char::is_control)
-            {
-                shared.fail(format!(
-                    "plugin watch text must be one non-empty line of at most {MAX_WATCH_TEXT_BYTES} UTF-8 bytes"
-                ));
-                return false;
-            }
-            if shared.watch.len() == WATCH_QUEUE {
-                shared.watch.pop_front();
-                shared.notice = Some("plugin watch queue overflowed; oldest event dropped".into());
-            }
-            shared.watch.push_back(text);
-            shared.changed();
-        }
+        } => apply_frame_message(
+            WireFrame {
+                revision,
+                title,
+                counter,
+                lines,
+                bindings,
+                input,
+                cursor,
+            },
+            shared,
+        ),
+        PluginMessage::Error { message, fatal } => apply_error_message(message, fatal, shared),
+        PluginMessage::Watch { text } => apply_watch_message(text, shared),
     }
-    true
 }
 
-fn apply_ready(
+fn apply_ready_message(
     protocol: u16,
     title: Option<String>,
     refresh_ms: Option<u64>,
-    shared: &mut Shared,
+    shared: &Arc<Mutex<Shared>>,
 ) -> bool {
     if protocol != PROTOCOL_VERSION {
-        shared.fail(format!(
-            "protocol {protocol} is incompatible with host protocol {PROTOCOL_VERSION}"
-        ));
-        return false;
-    }
-    if shared.ready {
-        shared.fail("plugin sent `ready` more than once");
-        return false;
+        return fail_shared(
+            shared,
+            format!("protocol {protocol} is incompatible with host protocol {PROTOCOL_VERSION}"),
+        );
     }
     if let Some(title) = title.as_deref()
         && let Err(error) = validate_text(title, "ready title", MAX_TITLE_BYTES)
     {
-        shared.fail(error);
+        return fail_shared(shared, error);
+    }
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    apply_ready(title, refresh_ms, &mut shared)
+}
+
+fn apply_frame_message(frame: WireFrame, shared: &Arc<Mutex<Shared>>) -> bool {
+    if let Err(error) = validate_frame(
+        frame.title.as_deref(),
+        frame.counter.as_deref(),
+        &frame.lines,
+        &frame.bindings,
+        &frame.input,
+    ) {
+        return fail_shared(shared, error);
+    }
+
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !shared.ready {
+        shared.fail("plugin sent a frame before `ready`");
+        return false;
+    }
+    if !matches!(shared.phase, Phase::Running) {
+        return false;
+    }
+    apply_frame(frame, &mut shared)
+}
+
+fn apply_error_message(message: String, fatal: bool, shared: &Arc<Mutex<Shared>>) -> bool {
+    if let Err(error) = validate_text(&message, "error message", MAX_ERROR_BYTES) {
+        return fail_shared(shared, error);
+    }
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !shared.ready {
+        shared.fail("plugin sent an error before `ready`");
+        return false;
+    }
+    if !matches!(shared.phase, Phase::Running) {
+        return false;
+    }
+    if fatal {
+        shared.fail(message);
+        return false;
+    }
+    shared.notice = Some(message);
+    shared.changed();
+    true
+}
+
+fn apply_watch_message(text: String, shared: &Arc<Mutex<Shared>>) -> bool {
+    if text.trim().is_empty()
+        || text.len() > MAX_WATCH_TEXT_BYTES
+        || text.chars().any(char::is_control)
+    {
+        return fail_shared(
+            shared,
+            format!(
+                "plugin watch text must be one non-empty line of at most \
+                 {MAX_WATCH_TEXT_BYTES} UTF-8 bytes"
+            ),
+        );
+    }
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !shared.ready {
+        shared.fail("plugin sent a watch event before `ready`");
+        return false;
+    }
+    if !matches!(shared.phase, Phase::Running) {
+        return false;
+    }
+    if shared.watch.len() == WATCH_QUEUE {
+        shared.watch.pop_front();
+        shared.notice = Some("plugin watch queue overflowed; oldest event dropped".into());
+    }
+    shared.watch.push_back(text);
+    shared.changed();
+    true
+}
+
+fn fail_shared(shared: &Arc<Mutex<Shared>>, error: impl Into<String>) -> bool {
+    shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .fail(error);
+    false
+}
+
+fn apply_ready(title: Option<String>, refresh_ms: Option<u64>, shared: &mut Shared) -> bool {
+    if shared.ready {
+        shared.fail("plugin sent `ready` more than once");
+        return false;
+    }
+    if !matches!(shared.phase, Phase::Starting) {
         return false;
     }
     shared.ready = true;
@@ -423,20 +561,7 @@ fn apply_ready(
 }
 
 fn apply_frame(frame: WireFrame, shared: &mut Shared) -> bool {
-    if !shared.ready {
-        shared.fail("plugin sent a frame before `ready`");
-        return false;
-    }
-    if let Err(error) = validate_frame(
-        frame.title.as_deref(),
-        frame.counter.as_deref(),
-        &frame.lines,
-        &frame.bindings,
-        &frame.input,
-    ) {
-        shared.fail(error);
-        return false;
-    }
+    shared.frame_sequence = shared.frame_sequence.wrapping_add(1);
     if shared
         .frame
         .as_ref()
@@ -562,11 +687,15 @@ fn stderr_loop(
     supervisor: &mpsc::Sender<SupervisorCommand>,
 ) {
     let mut buffer = [0u8; 1024];
+    let mut decoder = StderrDecoder::default();
     let mut window_started = Instant::now();
     let mut window_bytes = 0usize;
     loop {
         let read = match stderr.read(&mut buffer) {
-            Ok(0) => return,
+            Ok(0) => {
+                append_stderr(shared, &decoder.decode(&[], true));
+                return;
+            }
             Ok(read) => read,
             Err(error) => {
                 shared
@@ -594,27 +723,91 @@ fn stderr_loop(
             return;
         }
 
-        let text: String = String::from_utf8_lossy(&buffer[..read])
-            .chars()
-            .map(|character| match character {
-                '\n' | '\r' => '\n',
-                '\t' => ' ',
-                control if control.is_control() => '\u{fffd}',
-                printable => printable,
-            })
-            .collect();
-        let mut shared = shared
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        shared.stderr.push_str(&text);
-        if shared.stderr.len() > MAX_STDERR_BYTES {
-            let excess = shared.stderr.len() - MAX_STDERR_BYTES;
-            let mut boundary = excess;
-            while boundary < shared.stderr.len() && !shared.stderr.is_char_boundary(boundary) {
-                boundary += 1;
+        append_stderr(shared, &decoder.decode(&buffer[..read], false));
+    }
+}
+
+#[derive(Default)]
+struct StderrDecoder {
+    pending: Vec<u8>,
+}
+
+impl StderrDecoder {
+    /// Decode complete UTF-8 while retaining at most one incomplete code point
+    /// for the next fixed-size read. Invalid bytes still become replacement
+    /// characters; valid text split exactly at 1 KiB no longer does.
+    fn decode(&mut self, bytes: &[u8], eof: bool) -> String {
+        self.pending.extend_from_slice(bytes);
+        let mut output = String::new();
+        loop {
+            match std::str::from_utf8(&self.pending) {
+                Ok(valid) => {
+                    sanitise_stderr(valid, &mut output);
+                    self.pending.clear();
+                    break;
+                }
+                Err(error) => {
+                    let valid = error.valid_up_to();
+                    if valid > 0 {
+                        // `valid_up_to` is guaranteed to be a UTF-8 boundary.
+                        let prefix =
+                            std::str::from_utf8(&self.pending[..valid]).unwrap_or_default();
+                        sanitise_stderr(prefix, &mut output);
+                        self.pending.drain(..valid);
+                    }
+                    match error.error_len() {
+                        Some(length) => {
+                            output.push('\u{fffd}');
+                            self.pending.drain(..length);
+                        }
+                        None if eof => {
+                            output.push('\u{fffd}');
+                            self.pending.clear();
+                            break;
+                        }
+                        None => break,
+                    }
+                }
             }
-            shared.stderr.drain(..boundary);
         }
+        output
+    }
+}
+
+fn sanitise_stderr(text: &str, output: &mut String) {
+    output.extend(text.chars().map(|character| match character {
+        '\n' | '\r' => '\n',
+        '\t' => ' ',
+        control if control.is_control() => '\u{fffd}',
+        printable => printable,
+    }));
+}
+
+fn append_stderr(shared: &Arc<Mutex<Shared>>, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    shared.stderr.push_str(text);
+    if shared.stderr.len() > MAX_STDERR_BYTES {
+        let excess = shared.stderr.len() - MAX_STDERR_BYTES;
+        let mut boundary = excess;
+        while boundary < shared.stderr.len() && !shared.stderr.is_char_boundary(boundary) {
+            boundary += 1;
+        }
+        shared.stderr.drain(..boundary);
+    }
+    // Stderr is visible before the first frame and after a terminal failure.
+    // While a healthy frame is on screen, retaining diagnostics is enough; a
+    // generation bump per chunk would force redraws for text not being drawn.
+    if shared.frame.is_none()
+        || matches!(
+            shared.phase,
+            Phase::Exited(_) | Phase::Failed(_) | Phase::Stopping
+        )
+    {
         shared.changed();
     }
 }
@@ -627,32 +820,8 @@ fn supervisor_loop(
 ) {
     let mut deadline = None;
     let mut output_closed = None;
+    let mut disconnected = false;
     loop {
-        match commands.try_recv() {
-            Ok(SupervisorCommand::Abort) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return;
-            }
-            Ok(SupervisorCommand::Shutdown) => {
-                deadline = Some(Instant::now() + SHUTDOWN_GRACE);
-                let mut shared = shared
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                if !matches!(shared.phase, Phase::Exited(_) | Phase::Failed(_)) {
-                    shared.phase = Phase::Stopping;
-                    shared.changed();
-                }
-            }
-            Ok(SupervisorCommand::OutputClosed) => {
-                output_closed = Some(Instant::now() + OUTPUT_CLOSE_GRACE);
-            }
-            Err(TryRecvError::Disconnected) if deadline.is_none() => {
-                deadline = Some(Instant::now() + SHUTDOWN_GRACE);
-            }
-            Err(TryRecvError::Empty | TryRecvError::Disconnected) => {}
-        }
-
         match child.try_wait() {
             Ok(Some(status)) => {
                 let mut shared = shared
@@ -675,14 +844,14 @@ fn supervisor_loop(
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .fail(format!("checking plugin process: {error}"));
+                terminate_child(child);
                 return;
             }
         }
 
         let startup_timed_out = expire_startup(shared, Instant::now(), startup_deadline);
         if startup_timed_out {
-            let _ = child.kill();
-            let _ = child.wait();
+            terminate_child(child);
             return;
         }
 
@@ -699,20 +868,64 @@ fn supervisor_loop(
                 }
             };
             if should_fail {
-                let _ = child.kill();
-                let _ = child.wait();
+                terminate_child(child);
                 return;
             }
             output_closed = None;
         }
 
         if deadline.is_some_and(|when| Instant::now() >= when) {
-            let _ = child.kill();
-            let _ = child.wait();
+            terminate_child(child);
             return;
         }
-        thread::sleep(Duration::from_millis(20));
+
+        let now = Instant::now();
+        let startup = (!shared
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .ready)
+            .then_some(startup_deadline);
+        let until = [startup, deadline, output_closed]
+            .into_iter()
+            .flatten()
+            .map(|when| when.saturating_duration_since(now))
+            .min()
+            .unwrap_or(PROCESS_STATUS_POLL)
+            .min(PROCESS_STATUS_POLL);
+        if disconnected {
+            thread::sleep(until);
+            continue;
+        }
+        match commands.recv_timeout(until) {
+            Ok(SupervisorCommand::Abort) => {
+                terminate_child(child);
+                return;
+            }
+            Ok(SupervisorCommand::Shutdown) => {
+                deadline = Some(Instant::now() + SHUTDOWN_GRACE);
+                let mut shared = shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !matches!(shared.phase, Phase::Exited(_) | Phase::Failed(_)) {
+                    shared.phase = Phase::Stopping;
+                    shared.changed();
+                }
+            }
+            Ok(SupervisorCommand::OutputClosed) => {
+                output_closed = Some(Instant::now() + OUTPUT_CLOSE_GRACE);
+            }
+            Err(RecvTimeoutError::Disconnected) if !disconnected => {
+                disconnected = true;
+                deadline = Some(Instant::now() + SHUTDOWN_GRACE);
+            }
+            Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => {}
+        }
     }
+}
+
+fn terminate_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn expire_startup(shared: &Arc<Mutex<Shared>>, now: Instant, deadline: Instant) -> bool {
@@ -732,8 +945,55 @@ fn expire_startup(shared: &Arc<Mutex<Shared>>, now: Instant, deadline: Instant) 
 
 #[cfg(test)]
 mod tests {
+    use std::process::Stdio;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
-    use crate::plugin::{WireBinding, WireSpan};
+    use crate::panel::Panel;
+    use crate::plugin::{PluginPanel, WireBinding, WireSpan};
+
+    const WAITING_CHILD_TEST: &str =
+        "plugin::process::tests::child_waits_for_the_parent_to_terminate_it";
+
+    fn waiting_child() -> Child {
+        let executable = std::env::current_exe().expect("test executable has a path");
+        Command::new(executable)
+            .args(["--ignored", "--exact", WAITING_CHILD_TEST, "--quiet"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("waiting test child starts")
+    }
+
+    fn supervised_waiting_runtime(
+        shared: &Arc<Mutex<Shared>>,
+    ) -> (Runtime, Receiver<HostMessage>, Arc<AtomicBool>) {
+        let mut child = waiting_child();
+        let (events, received) = mpsc::sync_channel(EVENT_QUEUE);
+        let (supervisor, commands) = mpsc::channel();
+        let finished = Arc::new(AtomicBool::new(false));
+        let thread_finished = Arc::clone(&finished);
+        let supervisor_shared = Arc::clone(shared);
+        let supervisor_thread = thread::spawn(move || {
+            supervisor_loop(
+                &mut child,
+                &commands,
+                &supervisor_shared,
+                Instant::now() + STARTUP_TIMEOUT,
+            );
+            thread_finished.store(true, Ordering::Release);
+        });
+        (
+            Runtime {
+                events: Some(events),
+                supervisor,
+                supervisor_thread: Some(supervisor_thread),
+            },
+            received,
+            finished,
+        )
+    }
 
     fn span(text: impl Into<String>) -> WireSpan {
         WireSpan {
@@ -746,6 +1006,139 @@ mod tests {
             underlined: false,
             reversed: false,
         }
+    }
+
+    #[test]
+    #[ignore = "helper process for portable plugin lifecycle tests"]
+    fn child_waits_for_the_parent_to_terminate_it() {
+        thread::sleep(Duration::from_secs(30));
+    }
+
+    #[test]
+    fn normal_host_shutdown_waits_for_the_supervisor_to_reap_its_child() {
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        let (runtime, _received, finished) = supervised_waiting_runtime(&shared);
+        let mut panel = PluginPanel::new(PluginConfig {
+            id: "shutdown-test".into(),
+            command: vec!["mirador-plugin-shutdown-test-command-does-not-exist".into()],
+            config: toml::Table::new(),
+        });
+        panel.shared = shared;
+        panel.runtime = Some(runtime);
+        let started = Instant::now();
+
+        panel.shutdown();
+        assert!(
+            panel.runtime.is_none(),
+            "the panel retained a supervisor after shutdown"
+        );
+        assert!(
+            started.elapsed() >= SHUTDOWN_GRACE,
+            "the configured child was not given its cleanup grace"
+        );
+        assert!(
+            started.elapsed() < SUPERVISOR_JOIN_GRACE + SUPERVISOR_ABORT_GRACE,
+            "normal shutdown exceeded the host's bounded wait"
+        );
+        assert!(
+            finished.load(Ordering::Acquire),
+            "shutdown returned before kill/wait completed"
+        );
+    }
+
+    #[test]
+    fn runtime_drop_enforces_the_same_bounded_child_cleanup() {
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        let (runtime, _received, finished) = supervised_waiting_runtime(&shared);
+        let started = Instant::now();
+
+        drop(runtime);
+
+        assert!(started.elapsed() >= SHUTDOWN_GRACE);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(
+            finished.load(Ordering::Acquire),
+            "dropping the runtime orphaned its child supervisor"
+        );
+    }
+
+    #[test]
+    fn the_startup_timeout_terminates_and_reaps_an_unready_child() {
+        let mut child = waiting_child();
+        let (_commands, received) = mpsc::channel();
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        let started = Instant::now();
+
+        supervisor_loop(
+            &mut child,
+            &received,
+            &shared,
+            Instant::now() + Duration::from_millis(25),
+        );
+
+        assert!(matches!(
+            shared.lock().unwrap().phase,
+            Phase::Failed(ref error) if error.contains("did not send `ready`")
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the unready helper was waited out instead of terminated"
+        );
+    }
+
+    #[test]
+    fn closed_output_gets_a_short_grace_then_terminates_the_child() {
+        let mut child = waiting_child();
+        let (commands, received) = mpsc::channel();
+        let mut state = Shared::starting();
+        state.ready = true;
+        state.phase = Phase::Running;
+        let shared = Arc::new(Mutex::new(state));
+        commands.send(SupervisorCommand::OutputClosed).unwrap();
+        let started = Instant::now();
+
+        supervisor_loop(
+            &mut child,
+            &received,
+            &shared,
+            Instant::now() + STARTUP_TIMEOUT,
+        );
+
+        assert!(started.elapsed() >= OUTPUT_CLOSE_GRACE);
+        assert!(matches!(
+            shared.lock().unwrap().phase,
+            Phase::Failed(ref error) if error.contains("closed stdout")
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the output-closed helper was waited out instead of terminated"
+        );
+    }
+
+    #[test]
+    fn a_child_that_exits_is_recorded_without_waiting_for_a_command() {
+        let executable = std::env::current_exe().expect("test executable has a path");
+        let mut child = Command::new(executable)
+            .arg("--help")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("short-lived test child starts");
+        let (_commands, received) = mpsc::channel();
+        let mut state = Shared::starting();
+        state.ready = true;
+        state.phase = Phase::Running;
+        let shared = Arc::new(Mutex::new(state));
+
+        supervisor_loop(
+            &mut child,
+            &received,
+            &shared,
+            Instant::now() + STARTUP_TIMEOUT,
+        );
+
+        assert!(matches!(shared.lock().unwrap().phase, Phase::Exited(_)));
     }
 
     #[test]
@@ -805,6 +1198,17 @@ mod tests {
             shared.lock().unwrap().phase,
             Phase::Failed(ref error) if error.contains("stderr bytes")
         ));
+    }
+
+    #[test]
+    fn stderr_decoder_preserves_utf8_split_at_a_read_boundary() {
+        let encoded = "é".as_bytes();
+        let mut decoder = StderrDecoder::default();
+        assert_eq!(decoder.decode(&encoded[..1], false), "");
+        assert_eq!(decoder.decode(&encoded[1..], false), "é");
+
+        let mut incomplete = StderrDecoder::default();
+        assert_eq!(incomplete.decode(&encoded[..1], true), "\u{fffd}");
     }
 
     #[test]

--- a/src/plugin/process.rs
+++ b/src/plugin/process.rs
@@ -1,0 +1,857 @@
+//! Child lifecycle and bounded stdio workers for one external panel.
+
+use std::collections::VecDeque;
+use std::io::{self, BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::config::PluginConfig;
+
+use super::{
+    DEFAULT_REFRESH, HostMessage, InputPolicy, MAX_BINDING_ACTION_BYTES, MAX_BINDING_KEY_BYTES,
+    MAX_BINDINGS, MAX_COLOR_BYTES, MAX_COUNTER_BYTES, MAX_ERROR_BYTES, MAX_FRAME_LINES,
+    MAX_FRAME_SPANS, MAX_INPUT_KEYS, MAX_MESSAGE_BYTES, MAX_RETAINED_FRAME_TEXT_BYTES,
+    MAX_TITLE_BYTES, MAX_WATCH_TEXT_BYTES, PROTOCOL_VERSION, PluginMessage, WireBinding, WireFrame,
+    WireLine, binding_mentions_host_key, host_owned_chord, is_ctrl_c_chord, wire_color,
+};
+
+const MAX_STDERR_BYTES: usize = 8 * 1024;
+const EVENT_QUEUE: usize = 256;
+const WATCH_QUEUE: usize = 64;
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(300);
+const OUTPUT_CLOSE_GRACE: Duration = Duration::from_millis(100);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+const MESSAGE_RATE_WINDOW: Duration = Duration::from_secs(1);
+const MAX_MESSAGES_PER_WINDOW: usize = 120;
+const MAX_STDOUT_BYTES_PER_WINDOW: usize = 16 * 1024 * 1024;
+const MAX_STDERR_BYTES_PER_WINDOW: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Phase {
+    Starting,
+    Running,
+    Exited(String),
+    Failed(String),
+    Stopping,
+}
+
+pub(super) struct Shared {
+    pub(super) generation: u64,
+    pub(super) ready: bool,
+    pub(super) phase: Phase,
+    pub(super) title: Option<String>,
+    pub(super) refresh: Duration,
+    pub(super) frame: Option<Arc<WireFrame>>,
+    pub(super) notice: Option<String>,
+    pub(super) stderr: String,
+    pub(super) watch: VecDeque<String>,
+}
+
+impl Shared {
+    pub(super) fn starting() -> Self {
+        Self {
+            generation: 0,
+            ready: false,
+            phase: Phase::Starting,
+            title: None,
+            refresh: DEFAULT_REFRESH,
+            frame: None,
+            notice: None,
+            stderr: String::new(),
+            watch: VecDeque::new(),
+        }
+    }
+
+    pub(super) fn changed(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    pub(super) fn fail(&mut self, message: impl Into<String>) {
+        // Stdio workers and the supervisor can discover the same failure in a
+        // different order. Preserve the first terminal explanation instead of
+        // replacing a useful protocol error with the broken pipe caused by
+        // terminating that process.
+        if matches!(
+            self.phase,
+            Phase::Exited(_) | Phase::Failed(_) | Phase::Stopping
+        ) {
+            return;
+        }
+        self.phase = Phase::Failed(message.into());
+        self.changed();
+    }
+}
+
+enum SupervisorCommand {
+    Shutdown,
+    Abort,
+    OutputClosed,
+}
+
+pub(super) struct Runtime {
+    pub(super) events: SyncSender<HostMessage>,
+    supervisor: mpsc::Sender<SupervisorCommand>,
+}
+
+impl Runtime {
+    pub(super) fn shutdown(&self) {
+        let _ = self.events.try_send(HostMessage::Shutdown);
+        let _ = self.supervisor.send(SupervisorCommand::Shutdown);
+    }
+}
+
+pub(super) fn spawn_process(
+    spec: &PluginConfig,
+    shared: &Arc<Mutex<Shared>>,
+) -> io::Result<Runtime> {
+    let mut command = Command::new(&spec.command[0]);
+    command
+        .args(&spec.command[1..])
+        .env("MIRADOR_PLUGIN_PROTOCOL", PROTOCOL_VERSION.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    let startup_deadline = Instant::now() + STARTUP_TIMEOUT;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("missing stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("missing stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("missing stderr"))?;
+
+    let (event_tx, event_rx) = mpsc::sync_channel(EVENT_QUEUE);
+    let (supervisor_tx, supervisor_rx) = mpsc::channel();
+
+    let writer_shared = Arc::clone(shared);
+    let writer_supervisor = supervisor_tx.clone();
+    thread::spawn(move || writer_loop(stdin, event_rx, &writer_shared, &writer_supervisor));
+
+    let reader_shared = Arc::clone(shared);
+    let reader_supervisor = supervisor_tx.clone();
+    thread::spawn(move || reader_loop(stdout, &reader_shared, &reader_supervisor));
+
+    let stderr_shared = Arc::clone(shared);
+    let stderr_supervisor = supervisor_tx.clone();
+    thread::spawn(move || stderr_loop(stderr, &stderr_shared, &stderr_supervisor));
+
+    let supervisor_shared = Arc::clone(shared);
+    thread::spawn(move || {
+        supervisor_loop(
+            &mut child,
+            &supervisor_rx,
+            &supervisor_shared,
+            startup_deadline,
+        );
+    });
+
+    let cwd = std::env::current_dir()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let config = serde_json::to_value(&spec.config).unwrap_or(serde_json::Value::Null);
+    let hello = HostMessage::Hello {
+        protocol: PROTOCOL_VERSION,
+        host_version: env!("CARGO_PKG_VERSION"),
+        plugin: spec.id.clone(),
+        config,
+        cwd,
+    };
+    event_tx
+        .try_send(hello)
+        .map_err(|error| io::Error::other(format!("sending hello: {error}")))?;
+
+    Ok(Runtime {
+        events: event_tx,
+        supervisor: supervisor_tx,
+    })
+}
+
+fn writer_loop(
+    mut stdin: impl Write,
+    events: Receiver<HostMessage>,
+    shared: &Arc<Mutex<Shared>>,
+    supervisor: &mpsc::Sender<SupervisorCommand>,
+) {
+    for event in events {
+        let result = write_host_message(&mut stdin, &event);
+        if let Err(error) = result {
+            shared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .fail(format!("writing to plugin: {error}"));
+            let _ = supervisor.send(SupervisorCommand::Abort);
+            break;
+        }
+        if matches!(event, HostMessage::Shutdown) {
+            break;
+        }
+    }
+}
+
+fn write_host_message(mut target: impl Write, event: &HostMessage) -> io::Result<()> {
+    let encoded = serde_json::to_vec(event).map_err(io::Error::other)?;
+    if encoded.len().saturating_add(1) > MAX_MESSAGE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("host message exceeds {MAX_MESSAGE_BYTES} bytes"),
+        ));
+    }
+    target.write_all(&encoded)?;
+    target.write_all(b"\n")?;
+    target.flush()
+}
+
+#[derive(Default)]
+struct MessageRate {
+    recent: VecDeque<(Instant, usize)>,
+    bytes: usize,
+}
+
+impl MessageRate {
+    fn accepts(&mut self, now: Instant, bytes: usize) -> bool {
+        while self
+            .recent
+            .front()
+            .is_some_and(|(then, _)| now.saturating_duration_since(*then) >= MESSAGE_RATE_WINDOW)
+        {
+            if let Some((_, expired)) = self.recent.pop_front() {
+                self.bytes = self.bytes.saturating_sub(expired);
+            }
+        }
+        if self.recent.len() >= MAX_MESSAGES_PER_WINDOW
+            || self.bytes.saturating_add(bytes) > MAX_STDOUT_BYTES_PER_WINDOW
+        {
+            return false;
+        }
+        self.recent.push_back((now, bytes));
+        self.bytes += bytes;
+        true
+    }
+}
+
+fn reader_loop(
+    stdout: impl io::Read,
+    shared: &Arc<Mutex<Shared>>,
+    supervisor: &mpsc::Sender<SupervisorCommand>,
+) {
+    let mut reader = BufReader::new(stdout);
+    let mut rate = MessageRate::default();
+    loop {
+        let mut bytes = Vec::new();
+        match read_limited_line(&mut reader, &mut bytes) {
+            Ok(0) => {
+                let _ = supervisor.send(SupervisorCommand::OutputClosed);
+                break;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .fail(format!("reading plugin output: {error}"));
+                let _ = supervisor.send(SupervisorCommand::Abort);
+                break;
+            }
+        }
+        if !rate.accepts(Instant::now(), bytes.len()) {
+            shared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .fail(format!(
+                    "plugin exceeded {MAX_MESSAGES_PER_WINDOW} messages or {MAX_STDOUT_BYTES_PER_WINDOW} output bytes in one second"
+                ));
+            let _ = supervisor.send(SupervisorCommand::Abort);
+            break;
+        }
+        while matches!(bytes.last(), Some(b'\n' | b'\r')) {
+            bytes.pop();
+        }
+        let message: PluginMessage = match serde_json::from_slice(&bytes) {
+            Ok(message) => message,
+            Err(error) => {
+                shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .fail(format!("invalid plugin message: {error}"));
+                let _ = supervisor.send(SupervisorCommand::Abort);
+                break;
+            }
+        };
+        if !apply_message(message, shared) {
+            let _ = supervisor.send(SupervisorCommand::Abort);
+            break;
+        }
+    }
+}
+
+pub(super) fn read_limited_line(
+    reader: &mut impl BufRead,
+    target: &mut Vec<u8>,
+) -> io::Result<usize> {
+    let mut limited = io::Read::take(
+        reader,
+        u64::try_from(MAX_MESSAGE_BYTES + 1).unwrap_or(u64::MAX),
+    );
+    let read = limited.read_until(b'\n', target)?;
+    if read > MAX_MESSAGE_BYTES || (read == MAX_MESSAGE_BYTES && !target.ends_with(b"\n")) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("message exceeds {MAX_MESSAGE_BYTES} bytes"),
+        ));
+    }
+    if read > 0 && !target.ends_with(b"\n") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "plugin message is not terminated by a newline",
+        ));
+    }
+    Ok(read)
+}
+
+pub(super) fn apply_message(message: PluginMessage, shared: &Arc<Mutex<Shared>>) -> bool {
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    match message {
+        PluginMessage::Ready {
+            protocol,
+            title,
+            refresh_ms,
+        } => return apply_ready(protocol, title, refresh_ms, &mut shared),
+        PluginMessage::Frame {
+            revision,
+            title,
+            counter,
+            lines,
+            bindings,
+            input,
+            cursor,
+        } => {
+            return apply_frame(
+                WireFrame {
+                    revision,
+                    title,
+                    counter,
+                    lines,
+                    bindings,
+                    input,
+                    cursor,
+                },
+                &mut shared,
+            );
+        }
+        PluginMessage::Error { message, fatal } => {
+            if !shared.ready {
+                shared.fail("plugin sent an error before `ready`");
+                return false;
+            }
+            if let Err(error) = validate_text(&message, "error message", MAX_ERROR_BYTES) {
+                shared.fail(error);
+                return false;
+            }
+            if fatal {
+                shared.fail(message);
+                return false;
+            }
+            shared.notice = Some(message);
+            shared.changed();
+        }
+        PluginMessage::Watch { text } => {
+            if !shared.ready {
+                shared.fail("plugin sent a watch event before `ready`");
+                return false;
+            }
+            if text.trim().is_empty()
+                || text.len() > MAX_WATCH_TEXT_BYTES
+                || text.chars().any(char::is_control)
+            {
+                shared.fail(format!(
+                    "plugin watch text must be one non-empty line of at most {MAX_WATCH_TEXT_BYTES} UTF-8 bytes"
+                ));
+                return false;
+            }
+            if shared.watch.len() == WATCH_QUEUE {
+                shared.watch.pop_front();
+                shared.notice = Some("plugin watch queue overflowed; oldest event dropped".into());
+            }
+            shared.watch.push_back(text);
+            shared.changed();
+        }
+    }
+    true
+}
+
+fn apply_ready(
+    protocol: u16,
+    title: Option<String>,
+    refresh_ms: Option<u64>,
+    shared: &mut Shared,
+) -> bool {
+    if protocol != PROTOCOL_VERSION {
+        shared.fail(format!(
+            "protocol {protocol} is incompatible with host protocol {PROTOCOL_VERSION}"
+        ));
+        return false;
+    }
+    if shared.ready {
+        shared.fail("plugin sent `ready` more than once");
+        return false;
+    }
+    if let Some(title) = title.as_deref()
+        && let Err(error) = validate_text(title, "ready title", MAX_TITLE_BYTES)
+    {
+        shared.fail(error);
+        return false;
+    }
+    shared.ready = true;
+    shared.phase = Phase::Running;
+    shared.title = title;
+    shared.refresh = refresh_ms.map_or(DEFAULT_REFRESH, |milliseconds| {
+        Duration::from_millis(milliseconds.clamp(16, 60_000))
+    });
+    shared.changed();
+    true
+}
+
+fn apply_frame(frame: WireFrame, shared: &mut Shared) -> bool {
+    if !shared.ready {
+        shared.fail("plugin sent a frame before `ready`");
+        return false;
+    }
+    if let Err(error) = validate_frame(
+        frame.title.as_deref(),
+        frame.counter.as_deref(),
+        &frame.lines,
+        &frame.bindings,
+        &frame.input,
+    ) {
+        shared.fail(error);
+        return false;
+    }
+    if shared
+        .frame
+        .as_ref()
+        .is_some_and(|previous| frame.revision <= previous.revision)
+    {
+        return true;
+    }
+    shared.frame = Some(Arc::new(frame));
+    shared.notice = None;
+    shared.changed();
+    true
+}
+
+fn validate_frame(
+    title: Option<&str>,
+    counter: Option<&str>,
+    lines: &[WireLine],
+    bindings: &[WireBinding],
+    input: &InputPolicy,
+) -> Result<(), String> {
+    if lines.len() > MAX_FRAME_LINES {
+        return Err(format!("plugin frame exceeds {MAX_FRAME_LINES} lines"));
+    }
+    if bindings.len() > MAX_BINDINGS {
+        return Err(format!("plugin frame exceeds {MAX_BINDINGS} bindings"));
+    }
+    if input.keys.len() > MAX_INPUT_KEYS {
+        return Err(format!("plugin frame exceeds {MAX_INPUT_KEYS} input keys"));
+    }
+
+    let mut retained = 0usize;
+    if let Some(title) = title {
+        validate_text(title, "frame title", MAX_TITLE_BYTES)?;
+        add_retained(&mut retained, title.len())?;
+    }
+    if let Some(counter) = counter {
+        validate_text(counter, "frame counter", MAX_COUNTER_BYTES)?;
+        add_retained(&mut retained, counter.len())?;
+    }
+
+    let mut spans = 0usize;
+    let theme = crate::theme::Theme::default();
+    for line in lines {
+        spans = spans
+            .checked_add(line.spans.len())
+            .ok_or_else(|| "plugin frame span count overflowed".to_string())?;
+        if spans > MAX_FRAME_SPANS {
+            return Err(format!("plugin frame exceeds {MAX_FRAME_SPANS} spans"));
+        }
+        for span in &line.spans {
+            validate_display_text(&span.text, "span text")?;
+            add_retained(&mut retained, span.text.len())?;
+            for (field, color) in [("foreground", &span.fg), ("background", &span.bg)] {
+                if let Some(color) = color {
+                    validate_text(color, field, MAX_COLOR_BYTES)?;
+                    if wire_color(color, &theme).is_none() {
+                        return Err(format!(
+                            "plugin span has an unknown {field} colour `{color}`"
+                        ));
+                    }
+                    add_retained(&mut retained, color.len())?;
+                }
+            }
+        }
+    }
+
+    for binding in bindings {
+        validate_text(&binding.key, "binding key", MAX_BINDING_KEY_BYTES)?;
+        validate_text(&binding.action, "binding action", MAX_BINDING_ACTION_BYTES)?;
+        if binding_mentions_host_key(&binding.key, input.capture) {
+            return Err(format!(
+                "plugin binding `{}` is owned by the Mirador shell",
+                binding.key
+            ));
+        }
+        add_retained(&mut retained, binding.key.len())?;
+        add_retained(&mut retained, binding.action.len())?;
+    }
+
+    for key in &input.keys {
+        validate_text(key, "input key", MAX_BINDING_KEY_BYTES)?;
+        if is_ctrl_c_chord(key) || (!input.capture && host_owned_chord(key)) {
+            return Err(format!(
+                "plugin input key `{key}` is owned by the Mirador shell"
+            ));
+        }
+        add_retained(&mut retained, key.len())?;
+    }
+    Ok(())
+}
+
+fn validate_text(text: &str, field: &str, max_bytes: usize) -> Result<(), String> {
+    if text.len() > max_bytes {
+        return Err(format!("plugin {field} exceeds {max_bytes} UTF-8 bytes"));
+    }
+    validate_display_text(text, field)
+}
+
+fn validate_display_text(text: &str, field: &str) -> Result<(), String> {
+    if text.chars().any(char::is_control) {
+        return Err(format!(
+            "plugin {field} contains a terminal control character"
+        ));
+    }
+    Ok(())
+}
+
+fn add_retained(total: &mut usize, bytes: usize) -> Result<(), String> {
+    *total = total
+        .checked_add(bytes)
+        .ok_or_else(|| "plugin frame text size overflowed".to_string())?;
+    if *total > MAX_RETAINED_FRAME_TEXT_BYTES {
+        return Err(format!(
+            "plugin frame retains more than {MAX_RETAINED_FRAME_TEXT_BYTES} UTF-8 text bytes"
+        ));
+    }
+    Ok(())
+}
+
+fn stderr_loop(
+    mut stderr: impl io::Read,
+    shared: &Arc<Mutex<Shared>>,
+    supervisor: &mpsc::Sender<SupervisorCommand>,
+) {
+    let mut buffer = [0u8; 1024];
+    let mut window_started = Instant::now();
+    let mut window_bytes = 0usize;
+    loop {
+        let read = match stderr.read(&mut buffer) {
+            Ok(0) => return,
+            Ok(read) => read,
+            Err(error) => {
+                shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .fail(format!("reading plugin stderr: {error}"));
+                let _ = supervisor.send(SupervisorCommand::Abort);
+                return;
+            }
+        };
+        let now = Instant::now();
+        if now.saturating_duration_since(window_started) >= MESSAGE_RATE_WINDOW {
+            window_started = now;
+            window_bytes = 0;
+        }
+        window_bytes = window_bytes.saturating_add(read);
+        if window_bytes > MAX_STDERR_BYTES_PER_WINDOW {
+            shared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .fail(format!(
+                    "plugin exceeded {MAX_STDERR_BYTES_PER_WINDOW} stderr bytes in one second"
+                ));
+            let _ = supervisor.send(SupervisorCommand::Abort);
+            return;
+        }
+
+        let text: String = String::from_utf8_lossy(&buffer[..read])
+            .chars()
+            .map(|character| match character {
+                '\n' | '\r' => '\n',
+                '\t' => ' ',
+                control if control.is_control() => '\u{fffd}',
+                printable => printable,
+            })
+            .collect();
+        let mut shared = shared
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        shared.stderr.push_str(&text);
+        if shared.stderr.len() > MAX_STDERR_BYTES {
+            let excess = shared.stderr.len() - MAX_STDERR_BYTES;
+            let mut boundary = excess;
+            while boundary < shared.stderr.len() && !shared.stderr.is_char_boundary(boundary) {
+                boundary += 1;
+            }
+            shared.stderr.drain(..boundary);
+        }
+        shared.changed();
+    }
+}
+
+fn supervisor_loop(
+    child: &mut Child,
+    commands: &Receiver<SupervisorCommand>,
+    shared: &Arc<Mutex<Shared>>,
+    startup_deadline: Instant,
+) {
+    let mut deadline = None;
+    let mut output_closed = None;
+    loop {
+        match commands.try_recv() {
+            Ok(SupervisorCommand::Abort) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+            Ok(SupervisorCommand::Shutdown) => {
+                deadline = Some(Instant::now() + SHUTDOWN_GRACE);
+                let mut shared = shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !matches!(shared.phase, Phase::Exited(_) | Phase::Failed(_)) {
+                    shared.phase = Phase::Stopping;
+                    shared.changed();
+                }
+            }
+            Ok(SupervisorCommand::OutputClosed) => {
+                output_closed = Some(Instant::now() + OUTPUT_CLOSE_GRACE);
+            }
+            Err(TryRecvError::Disconnected) if deadline.is_none() => {
+                deadline = Some(Instant::now() + SHUTDOWN_GRACE);
+            }
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => {}
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut shared = shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !matches!(shared.phase, Phase::Stopping | Phase::Failed(_)) {
+                    if shared.ready {
+                        shared.phase = Phase::Exited(status.to_string());
+                    } else {
+                        shared.phase =
+                            Phase::Failed(format!("plugin exited before `ready`: {status}"));
+                    }
+                    shared.changed();
+                }
+                return;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .fail(format!("checking plugin process: {error}"));
+                return;
+            }
+        }
+
+        let startup_timed_out = expire_startup(shared, Instant::now(), startup_deadline);
+        if startup_timed_out {
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+
+        if output_closed.is_some_and(|when| Instant::now() >= when) {
+            let should_fail = {
+                let mut shared = shared
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if matches!(shared.phase, Phase::Stopping | Phase::Failed(_)) {
+                    false
+                } else {
+                    shared.fail("plugin closed stdout without exiting");
+                    true
+                }
+            };
+            if should_fail {
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+            output_closed = None;
+        }
+
+        if deadline.is_some_and(|when| Instant::now() >= when) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn expire_startup(shared: &Arc<Mutex<Shared>>, now: Instant, deadline: Instant) -> bool {
+    let mut shared = shared
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if now >= deadline && !shared.ready && matches!(shared.phase, Phase::Starting) {
+        shared.fail(format!(
+            "plugin did not send `ready` within {} seconds",
+            STARTUP_TIMEOUT.as_secs()
+        ));
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{WireBinding, WireSpan};
+
+    fn span(text: impl Into<String>) -> WireSpan {
+        WireSpan {
+            text: text.into(),
+            fg: None,
+            bg: None,
+            bold: false,
+            dim: false,
+            italic: false,
+            underlined: false,
+            reversed: false,
+        }
+    }
+
+    #[test]
+    fn inbound_message_rate_has_a_rolling_bound() {
+        let start = Instant::now();
+        let mut rate = MessageRate::default();
+        for _ in 0..MAX_MESSAGES_PER_WINDOW {
+            assert!(rate.accepts(start, 1));
+        }
+        assert!(!rate.accepts(start, 1));
+        assert!(rate.accepts(start + MESSAGE_RATE_WINDOW, 1));
+
+        let mut bytes = MessageRate::default();
+        assert!(bytes.accepts(start, MAX_STDOUT_BYTES_PER_WINDOW));
+        assert!(!bytes.accepts(start, 1));
+    }
+
+    #[test]
+    fn startup_deadline_fails_only_an_unready_process() {
+        let now = Instant::now();
+        let waiting = Arc::new(Mutex::new(Shared::starting()));
+        assert!(expire_startup(&waiting, now, now));
+        assert!(matches!(
+            waiting.lock().unwrap().phase,
+            Phase::Failed(ref error) if error.contains("within 5 seconds")
+        ));
+
+        let ready = Arc::new(Mutex::new(Shared::starting()));
+        ready.lock().unwrap().ready = true;
+        assert!(!expire_startup(&ready, now, now));
+    }
+
+    #[test]
+    fn concurrent_workers_preserve_the_first_terminal_error() {
+        let mut shared = Shared::starting();
+        shared.fail("invalid plugin message");
+        let generation = shared.generation;
+        shared.fail("writing to plugin: broken pipe");
+        assert_eq!(shared.generation, generation);
+        assert_eq!(shared.phase, Phase::Failed("invalid plugin message".into()));
+    }
+
+    #[test]
+    fn stderr_is_sanitised_retained_and_rate_bounded() {
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        let (supervisor, _commands) = mpsc::channel();
+        stderr_loop("safe\u{1b}[2J".as_bytes(), &shared, &supervisor);
+        assert_eq!(shared.lock().unwrap().stderr, "safe�[2J");
+
+        let shared = Arc::new(Mutex::new(Shared::starting()));
+        stderr_loop(
+            &vec![b'x'; MAX_STDERR_BYTES_PER_WINDOW + 1][..],
+            &shared,
+            &supervisor,
+        );
+        assert!(matches!(
+            shared.lock().unwrap().phase,
+            Phase::Failed(ref error) if error.contains("stderr bytes")
+        ));
+    }
+
+    #[test]
+    fn outbound_messages_obey_the_same_byte_limit() {
+        let event = HostMessage::Paste {
+            text: "x".repeat(MAX_MESSAGE_BYTES),
+        };
+        let error = write_host_message(Vec::new(), &event).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn frames_cannot_smuggle_terminal_controls_or_retain_unbounded_text() {
+        let controls = [WireLine {
+            spans: vec![span("safe\u{1b}[2Jnot safe")],
+        }];
+        let error =
+            validate_frame(None, None, &controls, &[], &InputPolicy::default()).unwrap_err();
+        assert!(error.contains("control character"), "{error}");
+
+        let oversized = [WireLine {
+            spans: vec![span("x".repeat(MAX_RETAINED_FRAME_TEXT_BYTES + 1))],
+        }];
+        let error =
+            validate_frame(None, None, &oversized, &[], &InputPolicy::default()).unwrap_err();
+        assert!(error.contains("retains more"), "{error}");
+    }
+
+    #[test]
+    fn passive_frames_cannot_advertise_shell_bindings() {
+        let input = InputPolicy {
+            keys: vec!["q".into()],
+            ..InputPolicy::default()
+        };
+        let error = validate_frame(None, None, &[], &[], &input).unwrap_err();
+        assert!(error.contains("owned by the Mirador shell"), "{error}");
+
+        let bindings = [WireBinding {
+            key: "Ctrl+C / Ctrl+X".into(),
+            action: "interrupt".into(),
+            primary: true,
+        }];
+        let capturing = InputPolicy {
+            capture: true,
+            ..InputPolicy::default()
+        };
+        let error = validate_frame(None, None, &[], &bindings, &capturing).unwrap_err();
+        assert!(error.contains("owned by the Mirador shell"), "{error}");
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -49,16 +49,16 @@ pub struct Event {
     /// When it happened.
     pub at: Zoned,
     /// The panel that noticed, for grouping and for the reader's orientation.
-    pub source: &'static str,
+    pub source: String,
     /// One line, in the past tense, naming the thing rather than the panel.
     pub text: String,
 }
 
 impl Event {
-    pub fn new(source: &'static str, text: impl Into<String>) -> Self {
+    pub fn new(source: impl Into<String>, text: impl Into<String>) -> Self {
         Self {
             at: Zoned::now(),
-            source,
+            source: source.into(),
             text: text.into(),
         }
     }
@@ -145,7 +145,7 @@ mod tests {
                 .since
                 .checked_add(Span::new().minutes(minutes))
                 .expect("in range"),
-            source: "test",
+            source: "test".into(),
             text: format!("thing {minutes}"),
         }
     }

--- a/src/widgets/calculator.rs
+++ b/src/widgets/calculator.rs
@@ -950,15 +950,21 @@ mod tests {
         let tail: Vec<(&str, &str)> = TAPE_BINDINGS
             .iter()
             .skip(2)
-            .map(|b| (b.key, b.action))
+            .map(|b| (b.key.as_ref(), b.action.as_ref()))
             .collect();
-        let entry: Vec<(&str, &str)> = ENTRY_BINDINGS.iter().map(|b| (b.key, b.action)).collect();
+        let entry: Vec<(&str, &str)> = ENTRY_BINDINGS
+            .iter()
+            .map(|b| (b.key.as_ref(), b.action.as_ref()))
+            .collect();
         assert_eq!(
             entry, tail,
             "the shared part of the two lists has drifted apart"
         );
         assert_eq!(
-            TAPE_BINDINGS[..2].iter().map(|b| b.key).collect::<Vec<_>>(),
+            TAPE_BINDINGS[..2]
+                .iter()
+                .map(|b| b.key.as_ref())
+                .collect::<Vec<_>>(),
             vec!["y", "p"],
             "the tape actions lead, because the border fills with primaries in order"
         );

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -1215,7 +1215,7 @@ mod tests {
         let primaries: Vec<&str> = BINDINGS
             .iter()
             .filter(|b| b.primary)
-            .map(|b| b.action)
+            .map(|b| b.action.as_ref())
             .collect();
         // `expect`, not a bare comparison. `position` returns `Option`, and
         // `None < Some(_)` is true — so comparing them directly passed when the

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,8 +1,8 @@
 //! Built-in widgets and the registry that turns a config name into a panel.
 //!
-//! Adding a widget means implementing [`crate::panel::Panel`], adding its name
-//! to [`WIDGET_NAMES`] and adding one arm to [`build`]. Nothing else in the
-//! codebase needs to know it exists.
+//! Built-ins are compiled here. Explicit external declarations fall through
+//! to the process-protocol adapter; they do not add a runtime dependency to
+//! Mirador and are started only when the layout actually places them.
 
 pub mod agenda;
 pub mod calculator;
@@ -79,7 +79,12 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
         "cpu" => Box::new(cpu::CpuPanel::new(config.cpu.clone())),
         "network" => Box::new(network::NetworkPanel::new(config.network.clone())),
         "calculator" => Box::new(calculator::CalculatorPanel::new(config.calculator)),
-        _ => return Ok(None),
+        _ => {
+            let Some(plugin) = config.plugin(name) else {
+                return Ok(None);
+            };
+            Box::new(crate::plugin::PluginPanel::new(plugin.clone()))
+        }
     };
     Ok(Some(panel))
 }


### PR DESCRIPTION
## Why

This formalizes the process-boundary direction and host obligations agreed in Discussion #191. The canonical review target is now the language-neutral [docs/plugin-protocol.md](https://github.com/krflol/mirador/blob/feat/external-panels-v1/docs/plugin-protocol.md), with the implementation held against that text.

This is not a terminal PR. Protocol v1 deliberately offers no PTY, raw terminal control, signal forwarding, discovery, embedded runtime, or public Rust ABI.

This branch is intentionally stacked on #193, the maintainer-authored direction note. If #193 merges first, GitHub will naturally narrow this PR to the implementation and finalized contract.

## Host contract

- Ctrl+C remains host-owned in every plugin state and is never sent over the protocol.
- Input uses Mirador's existing focus/capture arbitration; passive panels cannot claim the shell/status-bar keys.
- Mirador alone renders, cell-wraps, clips, styles, and positions plugin text. External tiles are visibly labelled EXTERNAL.
- Commands are explicit argv arrays. There is no scan, discovery, shell interpolation, Python lookup, or process when a declared plugin is not placed.
- Startup, wire messages, output rate, retained frames, Watch Log events, stderr, and host input queues are bounded per panel.
- Malformed, flooding, stalled, or crashed children become failed panels. Shutdown has a grace period and then terminates the configured process.
- The host has no credential configuration, persistence, forwarding, or logging channel. A plugin may collect credentials through its own UI, and owns any storage it provides.
- The protocol is versioned from its first message and strict about unknown fields and message types.

The host also accepts bounded completed events into the native Watch Log. That makes the conservative mirador-process-watch example useful without giving the plugin access to Watch Log internals.

## Separation

Core owns the small, permanent side of the boundary: protocol compatibility, reserved keys, rendering, bounds, lifecycle, disclosure, and terminal restoration.

SDKs and plugins own everything beyond it: language/runtime, dependencies, packaging, network behavior, plugin configuration, credentials, and support. The optional Python SDK remains in [krflol/mirador-plugins](https://github.com/krflol/mirador-plugins); Mirador does not depend on Python or adopt that repository's issue tracker.

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked --all-targets -- --test-threads=1 - 804 passed, 9 intentionally ignored
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
- cargo deny check
- cargo publish --dry-run
- cargo +1.95.0 check --locked --all-targets
- ignored cross-repository integration exercised Rust host ? Python SDK ? process watcher ? child process ? protocol Watch event ? native Panel::events

The exact parallel test command also reproduced the existing Windows store::tests::concurrent_writers_do_not_take_each_others_saves_away stress-test flake (13 of 800 saves in this run). It reproduces on untouched origin/main, passes in the deterministic single-threaded suite above, and this branch does not touch store.rs.

## A personal note on timing

Apologies for putting the full implementation up while you are away. I am dealing with health issues and may not have the availability for another long design round when you return, so I chose to capture the invariants we agreed on as both canonical text and reviewable code now rather than leave them implicit. There is no urgency to review this while you are away, and I do not read silence as acceptance. I may simply be slower to respond when review begins.