### PR TITLE
release: also create aarch64-unknown-linux-gnu binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Linux aarch64 binaries.** Releases now carry `mirador-aarch64-unknown-linux-gnu.tar.gz`,
+  built natively on GitHub's ARM runners, alongside the x86-64 Linux archive.
+
 ## [1.5.0] - 2026-08-02
 
 Both features in this release came from outside the project, contributed by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1626,7 +1626,8 @@ and had to be added back was the one that did not.
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
 - **`1.5.0` is released**, on crates.io and as a GitHub release with binaries
-  for macOS arm64, macOS x86-64, Linux x86-64 and Windows x86-64. This line goes
+  for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64.
+  This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four
   releases behind by the time anybody noticed. `0.0.0` is still on
@@ -1685,6 +1686,11 @@ and had to be added back was the one that did not.
   `dist` provides its own version-tag guard (`dist plan --tag=v9.9.9` exits
   255) and its own prerelease detection from the semver hyphen, which is why
   the hand-written versions of both were dropped when it took the file over.
+
+  The target list lives only in `[workspace.metadata.dist] targets` — the
+  generated workflow is fully generic, and the matrix is computed at runtime by
+  the `plan` job. Adding a target means editing Cargo.toml and re-running
+  `dist generate`; the workflow file itself may not change at all.
 
 - **Windows runs**, confirmed by the owner on 25 July 2026 and again on
   28 July — so all three shipped targets have been started, not merely built.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Checksums to generate for each App
 checksum = "sha256"
 # Have GitHub sign a provenance attestation for every artifact, so anyone can

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Get-Content .\mirador-x86_64-pc-windows-msvc.zip.sha256
 | macOS, Apple silicon | `mirador-aarch64-apple-darwin.tar.gz` |
 | macOS, Intel | `mirador-x86_64-apple-darwin.tar.gz` |
 | Linux x86-64 | `mirador-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux, ARM64 | `mirador-aarch64-unknown-linux-gnu.tar.gz` |
 | Windows x86-64 | `mirador-x86_64-pc-windows-msvc.zip` |
 
 Requires Rust 1.95 or newer to build from source.

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@
 # advisory would go unchecked until someone ran it on Windows.
 targets = [
     "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "x86_64-pc-windows-msvc",


### PR DESCRIPTION
# Summary

Adds aarch64 binaries to the release set.

## What changed

CI data and documentation.

## How it was tested

Will test CI-generated binaries next week.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all-targets` passes
- [x] New behaviour has tests, or there is a note below explaining why not
- [x] `CHANGELOG.md` updated under `Unreleased` for any user-visible change
- [x] Documentation updated: README, and `assets/default_config.toml` for any
      new config option

## Notes for the reviewer

Any other locations that might need updated?