### PR TITLE
Take the as_chunks form the new stable clippy insists on

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -134,7 +134,9 @@ mod tests {
                 bits.push((index >> shift) & 1);
             }
         }
-        bits.chunks_exact(8)
+        bits.as_chunks::<8>()
+            .0
+            .iter()
             .map(|byte| byte.iter().fold(0u8, |acc, bit| (acc << 1) | *bit as u8))
             .collect()
     }


### PR DESCRIPTION
Stable 1.98.0 (released 2026-08-18) promoted `chunks_exact_to_as_chunks` into the pedantic set, so CI's fresh-stable clippy now rejects the test-only base64 decoder's `chunks_exact(8)` — every PR goes red on code it never touched (first seen on #197, whose diff is CI config and docs).

One mechanical change, and the suggestion was checked against the 1.95 floor rather than taken on faith: `slice::as_chunks` stabilised in 1.88, and `cargo +1.95.0 check --all-targets` passes. All four gates clean locally on 1.98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)