### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-08-24
+
 ### Added
 
 - **Linux aarch64 binaries.** Releases now carry `mirador-aarch64-unknown-linux-gnu.tar.gz`,
   built natively on GitHub's ARM runners, alongside the x86-64 Linux archive.
+
+### Changed
+
+- **`ureq` 3.3.0 → 3.4.0.** Pooled connections now age out as configured, and
+  IPv6-literal hosts present the right TLS server name. No behaviour change on
+  the paths mirador exercises; the fetch stack was driven live before release.
 
 ## [1.5.0] - 2026-08-02
 
@@ -1623,7 +1631,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/jchultarsky/mirador/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/jchultarsky/mirador/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/jchultarsky/mirador/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/jchultarsky/mirador/compare/v1.3.2...v1.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1675,9 +1675,10 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.5.0` is released**, on crates.io and as a GitHub release with binaries
-  for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64.
-  This line goes
+- **`1.5.1` is released**, on crates.io and as a GitHub release with binaries
+  for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows
+  x86-64 — the first release where the aarch64 Linux archive exists, so until
+  someone runs it that target is built, not exercised. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four
   releases behind by the time anybody noticed. `0.0.0` is still on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump and CHANGELOG for 1.5.1 — the first release carrying `mirador-aarch64-unknown-linux-gnu.tar.gz` (#197), plus the ureq 3.4.0 bump (#198) and the stable-1.98 clippy fix (#199, internal).

Step 0 was done before this bump: the release build was driven in a real terminal under tmux with a fresh `HOME` — panels drew, weather and both index quotes fetched live over ureq 3.4.0, the help overlay opened and closed, and `q` quit cleanly.

Tag `v1.5.1` goes on the squashed commit after merge, per the release notes in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)