### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-24
+
 ### Added
 
 - **External panels are an explicit, language-neutral process boundary.** A
@@ -19,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unconditional host-owned exit even when a child is stuck. The protocol is
   documented independently so SDKs do not link against Mirador's private Rust
   `Panel` trait. External panels can also hand bounded, completed events to
-  Mirador's native Watch Log.
+  Mirador's native Watch Log. Protocol v1 is a compatibility commitment from
+  this release — see the README's Compatibility section.
 
 ## [1.5.1] - 2026-08-24
 
@@ -1645,7 +1648,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/jchultarsky/mirador/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/jchultarsky/mirador/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/jchultarsky/mirador/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/jchultarsky/mirador/compare/v1.4.0...v1.4.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1693,10 +1693,12 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.5.1` is released**, on crates.io and as a GitHub release with binaries
+- **`1.6.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows
-  x86-64 — the first release where the aarch64 Linux archive exists, so until
-  someone runs it that target is built, not exercised. This line goes
+  x86-64. It is the release that ships the external panel protocol, so v1 of
+  that protocol is a compatibility promise from here on. The aarch64 Linux
+  archive first shipped in 1.5.1 and is still built, not exercised, until
+  someone runs it on real ARM hardware. This line goes
   stale every release and is worth a glance before you trust anything near it;
   `git tag --list 'v*' | sort -V | tail -1` is the truth — it had been four
   releases behind by the time anybody noticed. `0.0.0` is still on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,13 @@ opens in an older one with the settings it understands intact. The one exception
 is `update-check.toml`, which is a cache: the worst a stale one costs is a single
 extra version check.
 
+**The external panel protocol.** From 1.6.0 the promise has a third part:
+protocol v1, as written in [docs/plugin-protocol.md](docs/plugin-protocol.md),
+is a compatibility commitment. A release that advertises v1 will not remove or
+redefine its fields, weaken the host-owned keys, or lower its documented
+bounds; an incompatible shape gets a new protocol number rather than a silent
+change to this one. A plugin written against v1 today keeps working.
+
 **What this does not promise.** Running an older mirador after a newer one may
 drop a preference the older version has no idea about — it cannot write back
 what it never understood. Nothing else is lost, and nothing is corrupted.


### PR DESCRIPTION
Version bump, CHANGELOG, and the protocol-promise wording for 1.6.0 — the release that ships the external panel protocol (#196).

**README Compatibility gains its third part:** protocol v1 is a compatibility commitment — no removed/redefined fields, no weakened host-owned keys, no lowered bounds; incompatible shapes get a new protocol number. The CHANGELOG entry references it.

**Step 0 (real terminal), both halves:**
- Default dashboard with no plugins: unchanged behaviour, live fetches, clean exits (smoked at 1.5.1 and re-driven on this merge).
- The new feature end to end: a minimal Python plugin against the v1 spec — spawn from `[[plugins]]` argv, `hello`/`ready` negotiation, ticking styled frames under a `┤EXTERNAL · Soak Probe├` title beside a native panel, and on `q` the child process was verified reaped (the review's top blocker, live).

Tag `v1.6.0` goes on the squashed commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)