### PR TITLE
Record the 1.5.1 overnight RSS soak beside the original

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1449,6 +1449,18 @@ ever disagree again.
   page reclaim, not accumulation. **Do not draw a trend from two RSS samples of
   this program**: an earlier pair read as "+3548 KB in 5–6 h" and looked like a
   leak, when both samples simply landed at different points in the same cycle.
+
+  **Re-run against 1.5.1, 2026-08-24→25** (15 h, 60 samples, default 13-panel
+  dashboard, fresh `HOME`, macOS): a different shape and the same verdict.
+  Ninety minutes of warm-up (15120 → 16272 KB, and the first sample predates
+  the caches filling — a naive "net +1232" reading is the warm-up, not a
+  trend), then an asymptote in 16 KB page steps: **dead flat at 16336 KB for
+  eight consecutive hours**, ending 16352. Total movement after warm-up, 80 KB
+  in 13.5 h. The 2026-07 run oscillated; this one plateaued — allocator
+  behaviour differs by machine, and both shapes are healthy. What a leak looks
+  like is neither: a *tail that climbs*. The run also crossed a real midnight
+  and drew `00:00 Tuesday 25 August began`, and quit cleanly on `q` after
+  fifteen hours.
 - **Terminal focus reporting — answered, and the answer has two halves.**
   *mirador's handling is verified*: focus events are bytes on stdin, so
   `tmux send-keys -H 1b 5b 49` (gained) and `1b 5b 4f` (lost) inject them, and


### PR DESCRIPTION
Fresh 15-hour soak, 2026-08-24→25: 60 samples at 15-minute intervals, default 13-panel dashboard, fresh `HOME`, pristine 1.5.1-lineage release build (instrumentation absence verified before launch).

```
15120 (t+15s) → 16272 by 90 min → 16320 by 4.5 h → 16336 from 6.5 h,
flat for 8 consecutive hours → 16352 at the end. Post-warm-up movement: 80 KB.
```

The note records the shape lesson: the original run oscillated in a 4.5 MB band, this one plateaued flat to the 16 KB page — both healthy, and a naive endpoint-to-endpoint "+1232 KB" reading is the warm-up, not a trend. The run also crossed a real midnight (`00:00 Tuesday 25 August began` drawn in the watch log) and quit cleanly on `q` after fifteen hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)