### PR TITLE
Fall back across address families when a connect is unroutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fetching works again on machines that prefer IPv6 without an IPv6 route.**
+  When DNS returns an AAAA record first and the kernel has no route to it,
+  every connect died instantly with `No route to host` and the IPv4 address
+  was never tried — a condition browsers and curl mask with happy-eyeballs
+  fallback, so the machine looks healthy everywhere except mirador. A request
+  that fails unroutable is now retried pinned to one address family at a
+  time. Reported from NetBSD in
+  [#205](https://github.com/jchultarsky/mirador/issues/205).
+
 ## [1.6.0] - 2026-08-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ note.rs      note model + TOML store
 quote.rs     Quote + the pluggable QuoteSource trait + the watchlist store
 poll.rs      the sliced sleep the background threads share — weather,
              stocks and news fetch; agenda reloads a file
+fetch.rs     the blocking GET those fetches share, and its address-family
+             fallback for a v6-first resolver with no v6 route (#205)
 samples.rs   the bounded history behind the cpu and network graphs
 selection.rs list cursor movement and click-to-row
 clipboard.rs OSC 52, with base64 hand-rolled rather than taken as a dependency

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,179 @@
+//! The blocking HTTP GET the network panels share.
+//!
+//! Extracted from four near-identical call sites for one reason: the
+//! address-family fallback. On a machine whose resolver returns AAAA records
+//! first but which has no IPv6 route — common wherever a network hands out v6
+//! addresses it cannot actually route, and confirmed from NetBSD in #205 —
+//! every connect dies immediately with `EHOSTUNREACH` before the IPv4 address
+//! is ever tried. Browsers and curl mask the same condition with happy-eyeballs
+//! fallback, which is exactly why such a machine "has working internet"
+//! everywhere except programs that connect in resolver order.
+//!
+//! `ureq` iterates the resolved addresses but moves past one only on
+//! `ConnectionRefused`; an unroutable connect makes it bail with the rest of
+//! the list untried. Until that is fixed upstream, the fallback lives here:
+//! when a request dies unroutable, it is retried pinned to one address family
+//! at a time, which keeps the whole mechanism on `ureq`'s stable config
+//! surface rather than reaching into its semver-exempt `unversioned` module.
+
+use std::io;
+use std::time::Duration;
+
+use ureq::config::IpFamily;
+
+/// A blocking GET with a timeout, returning the body as a string.
+///
+/// The body read is bounded by `ureq`'s 10MB cap, which `feed` and `agenda`
+/// both lean on. `user_agent` of `None` sends `ureq`'s own default.
+///
+/// Each retry gets the full `timeout` again, and that is not the hazard it
+/// looks like: the fallback only fires on an *unroutable* connect, and the
+/// meaning of unroutable is that the kernel refused at routing level without
+/// waiting for anything.
+pub fn get(url: &str, timeout: Duration, user_agent: Option<&str>) -> Result<String, ureq::Error> {
+    with_family_fallback(&mut |family| {
+        let mut config = ureq::Agent::config_builder()
+            .timeout_global(Some(timeout))
+            .ip_family(family);
+        if let Some(ua) = user_agent {
+            config = config.user_agent(ua);
+        }
+        let agent = config.build().new_agent();
+        agent.get(url).call()?.body_mut().read_to_string()
+    })
+}
+
+/// Try `IpFamily::Any` first, and on an unroutable connect retry one family
+/// at a time.
+///
+/// Split from [`get`] so the policy can be tested with closures — no test in
+/// this repository touches the network.
+fn with_family_fallback(
+    attempt: &mut dyn FnMut(IpFamily) -> Result<String, ureq::Error>,
+) -> Result<String, ureq::Error> {
+    let original = match attempt(IpFamily::Any) {
+        Err(e) if is_unroutable(&e) => e,
+        other => return other,
+    };
+    for family in [IpFamily::Ipv4Only, IpFamily::Ipv6Only] {
+        match attempt(family) {
+            // This family resolves to no addresses at all, or dead-ends the
+            // same way; the other one may still get through.
+            Err(e) if is_unroutable(&e) || matches!(e, ureq::Error::HostNotFound) => {}
+            // Anything else reached past routing — a body, or a real answer
+            // from a server. A status error is proof the network worked, so
+            // it is the answer, not a reason to keep dialling.
+            other => return other,
+        }
+    }
+    // Neither family improved on the first attempt. Report the error from
+    // the route the system chose, not from a family the host may not have.
+    Err(original)
+}
+
+/// Whether an error is the kernel refusing a connect at routing level.
+///
+/// `HostUnreachable` is `EHOSTUNREACH`, the confirmed #205 case;
+/// `NetworkUnreachable` is `ENETUNREACH`, which is what Linux returns for the
+/// identical v6-without-a-route condition; `AddrNotAvailable` is
+/// `EADDRNOTAVAIL`, seen where IPv6 is disabled outright. `ConnectionRefused`
+/// is deliberately absent — refused means something answered, and `ureq`
+/// already walks the address list for it.
+fn is_unroutable(error: &ureq::Error) -> bool {
+    let ureq::Error::Io(io) = error else {
+        return false;
+    };
+    matches!(
+        io.kind(),
+        io::ErrorKind::HostUnreachable
+            | io::ErrorKind::NetworkUnreachable
+            | io::ErrorKind::AddrNotAvailable
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unroutable(kind: io::ErrorKind) -> ureq::Error {
+        ureq::Error::Io(io::Error::from(kind))
+    }
+
+    /// #205: DNS answered AAAA-first, the machine had no IPv6 route, and
+    /// every fetch died with `No route to host` while curl on the same
+    /// machine fell back to the A record and got a 200.
+    #[test]
+    fn an_unroutable_connect_is_retried_one_family_at_a_time() {
+        let mut tried = Vec::new();
+        let result = with_family_fallback(&mut |family| {
+            tried.push(family);
+            match family {
+                IpFamily::Ipv4Only => Ok("body".to_string()),
+                _ => Err(unroutable(io::ErrorKind::HostUnreachable)),
+            }
+        });
+        assert_eq!(result.unwrap(), "body");
+        assert_eq!(tried, vec![IpFamily::Any, IpFamily::Ipv4Only]);
+    }
+
+    /// A refused connect means something answered; `ureq` already tries the
+    /// rest of the address list for it, and a second agent would not learn
+    /// anything the first did not.
+    #[test]
+    fn a_refused_connect_is_not_retried() {
+        let mut attempts = 0;
+        let result = with_family_fallback(&mut |_| {
+            attempts += 1;
+            Err(unroutable(io::ErrorKind::ConnectionRefused))
+        });
+        assert!(result.is_err());
+        assert_eq!(attempts, 1);
+    }
+
+    /// A status error out of a retry proves the fallback family reached the
+    /// server, so it is the real answer — swallowing it in favour of the
+    /// original unroutable error would hide a rate limit behind a routing
+    /// complaint.
+    #[test]
+    fn a_status_error_from_a_retry_is_the_answer() {
+        let result = with_family_fallback(&mut |family| match family {
+            IpFamily::Any => Err(unroutable(io::ErrorKind::HostUnreachable)),
+            _ => Err(ureq::Error::StatusCode(429)),
+        });
+        assert!(matches!(result, Err(ureq::Error::StatusCode(429))));
+    }
+
+    /// When no family gets through, the reader sees the error from the route
+    /// the system chose — not `HostNotFound` from pinning a family the host
+    /// never had addresses for.
+    #[test]
+    fn a_failed_fallback_reports_the_original_error() {
+        let result = with_family_fallback(&mut |family| match family {
+            IpFamily::Any => Err(unroutable(io::ErrorKind::HostUnreachable)),
+            IpFamily::Ipv4Only => Err(ureq::Error::HostNotFound),
+            IpFamily::Ipv6Only => Err(unroutable(io::ErrorKind::NetworkUnreachable)),
+        });
+        match result {
+            Err(ureq::Error::Io(e)) => assert_eq!(e.kind(), io::ErrorKind::HostUnreachable),
+            other => panic!("expected the original io error back, got {other:?}"),
+        }
+    }
+
+    /// The three kinds that mean "refused at routing level", and two that do
+    /// not. Losing `NetworkUnreachable` from the list would break the fix on
+    /// Linux specifically, which is why each kind is asserted by name.
+    #[test]
+    fn only_routing_level_failures_trigger_the_fallback() {
+        for kind in [
+            io::ErrorKind::HostUnreachable,
+            io::ErrorKind::NetworkUnreachable,
+            io::ErrorKind::AddrNotAvailable,
+        ] {
+            assert!(is_unroutable(&unroutable(kind)), "{kind:?} should trigger");
+        }
+        for kind in [io::ErrorKind::ConnectionRefused, io::ErrorKind::TimedOut] {
+            assert!(!is_unroutable(&unroutable(kind)), "{kind:?} should not");
+        }
+        assert!(!is_unroutable(&ureq::Error::StatusCode(500)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod dateinput;
 #[cfg(test)]
 mod docs;
 mod feed;
+mod fetch;
 mod frame;
 mod glyphs;
 mod grid;

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -262,13 +262,7 @@ fn http_get(_url: &str) -> Result<String> {
 
 #[cfg(not(test))]
 fn http_get(url: &str) -> Result<String> {
-    let agent = ureq::Agent::config_builder()
-        .timeout_global(Some(HTTP_TIMEOUT))
-        .user_agent(BROWSER_UA)
-        .build()
-        .new_agent();
-
-    let mut response = agent.get(url).call().map_err(|e| match e {
+    crate::fetch::get(url, HTTP_TIMEOUT, Some(BROWSER_UA)).map_err(|e| match e {
         ureq::Error::StatusCode(429) => anyhow::anyhow!(
             "the quote service is rate-limiting this network (HTTP 429). \
              Yahoo blocks datacenter and VPN addresses outright; on such a \
@@ -282,12 +276,7 @@ fn http_get(url: &str) -> Result<String> {
             anyhow::anyhow!("the quote service returned HTTP {code}")
         }
         other => anyhow::anyhow!("network request failed: {other}"),
-    })?;
-
-    response
-        .body_mut()
-        .read_to_string()
-        .context("reading the response body")
+    })
 }
 
 /// Percent-encode the characters that matter in a path segment.

--- a/src/update.rs
+++ b/src/update.rs
@@ -194,21 +194,17 @@ fn fetch(url: &str) -> Result<String> {
         max_version: Option<String>,
     }
 
-    let agent = ureq::Agent::config_builder()
-        .timeout_global(Some(HTTP_TIMEOUT))
-        // crates.io asks for a user agent that says who is calling and how to
-        // get in touch. Honouring that is the price of using the API politely.
-        .user_agent(concat!(
-            "mirador/",
-            env!("CARGO_PKG_VERSION"),
-            " (update check; https://github.com/jchultarsky/mirador)"
-        ))
-        .build()
-        .new_agent();
+    // crates.io asks for a user agent that says who is calling and how to
+    // get in touch. Honouring that is the price of using the API politely.
+    let ua = concat!(
+        "mirador/",
+        env!("CARGO_PKG_VERSION"),
+        " (update check; https://github.com/jchultarsky/mirador)"
+    );
 
     // Read as text then parse, matching how the other two network paths in this
     // crate do it — it keeps the JSON handling in one crate rather than two.
-    let text = agent.get(url).call()?.body_mut().read_to_string()?;
+    let text = crate::fetch::get(url, HTTP_TIMEOUT, Some(ua))?;
     let body: Body = serde_json::from_str(&text)?;
     // `max_stable_version` skips pre-releases, which is what someone running a
     // release build wants to hear about. It is absent on a crate that has only

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -803,13 +803,7 @@ fn interleave(stories: Vec<Story>) -> Vec<Story> {
 
 /// Fetch and parse one feed.
 fn read_feed(url: &str) -> anyhow::Result<Vec<Story>> {
-    let body = ureq::get(url)
-        .config()
-        .timeout_global(Some(HTTP_TIMEOUT))
-        .build()
-        .call()?
-        .body_mut()
-        .read_to_string()?;
+    let body = crate::fetch::get(url, HTTP_TIMEOUT, None)?;
     crate::feed::parse(&body)
 }
 

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -733,23 +733,13 @@ fn hour_label(timestamp: &str) -> Option<String> {
 
 /// A blocking GET with a timeout, returning the body as a string.
 fn http_get(url: &str) -> Result<String> {
-    let agent = ureq::Agent::config_builder()
-        .timeout_global(Some(HTTP_TIMEOUT))
-        .user_agent(concat!("mirador/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .new_agent();
-
-    let mut response = agent.get(url).call().map_err(|e| match e {
+    let ua = concat!("mirador/", env!("CARGO_PKG_VERSION"));
+    crate::fetch::get(url, HTTP_TIMEOUT, Some(ua)).map_err(|e| match e {
         ureq::Error::StatusCode(code) => {
             anyhow::anyhow!("the weather service returned HTTP {code}")
         }
         other => anyhow::anyhow!("network request failed: {other}"),
-    })?;
-
-    response
-        .body_mut()
-        .read_to_string()
-        .context("reading the response body")
+    })
 }
 
 /// Percent-encode the characters that matter for a query string value.


### PR DESCRIPTION
Addresses #205 (leaving it open for the reporter to confirm on the affected machine).

## The failure

On a machine whose resolver returns AAAA records first but which has no IPv6 route, every fetch dies with `network request failed: io: No route to host`. The curl trace in #205 shows the whole story: the v6 connect fails immediately with `EHOSTUNREACH`, curl falls back to the A record and gets a 200. mirador never got to the A record.

The mechanism is in ureq 3.4.0's connect loop (`unversioned/transport/tcp.rs`): it iterates the resolved addresses, but only `ConnectionRefused` (or a per-address timeout) moves it to the next one — any other error, including `EHOSTUNREACH`, hits the `// Other errors bail` arm with the rest of the list untried. Browsers and curl mask the identical condition with happy-eyeballs fallback, which is why such a machine looks healthy everywhere except mirador. An upstream issue is being filed; this fix stands on its own and stays worthwhile regardless, since a ureq fix only reaches users on the next bump.

## The fix

The four HTTP call sites (`quote`, `weather`, `update`, `news`) shared no code; they now share one blocking GET in `src/fetch.rs`. On an unroutable connect (`HostUnreachable`, `NetworkUnreachable`, `AddrNotAvailable` — the second being what Linux returns for the same condition, the third what a v6-disabled host returns) it retries the request pinned to `IpFamily::Ipv4Only`, then `Ipv6Only`. That keeps the whole mechanism on ureq's stable config surface rather than reaching into the semver-exempt `unversioned` module.

Three deliberate edges:

- A **status error from a retry propagates** — it proves the fallback family reached the server, and swallowing it would hide a rate limit behind a routing complaint.
- A **family with no addresses** (`HostNotFound` under a pinned family) is skipped, not reported.
- If **nothing improves**, the original error from the unpinned attempt is reported — not an artifact of pinning a family the host never had.

Each retry gets the full timeout again, and that is not the hazard it looks like: the fallback only fires on an unroutable connect, and unroutable means the kernel refused at routing level without waiting for anything.

## Tests

The policy is split from the HTTP call (`with_family_fallback`) so tests drive it with closures — no network. Five tests cover the fallback order, refused-is-not-retried, the status-error edge, original-error reporting, and each triggering `ErrorKind` by name. Each was verified by breaking the fix on purpose and watching it go red.

`cargo test` (818 passing), clippy `-D warnings`, `fmt --check`, and rustdoc `-D warnings` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)