### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-08-25
+
 ### Fixed
 
 - **Fetching works again on machines that prefer IPv6 without an IPv6 route.**
@@ -1659,7 +1661,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/jchultarsky/mirador/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/jchultarsky/mirador/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/jchultarsky/mirador/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/jchultarsky/mirador/compare/v1.4.1...v1.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1707,10 +1707,12 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.6.0` is released**, on crates.io and as a GitHub release with binaries
+- **`1.6.1` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows
-  x86-64. It is the release that ships the external panel protocol, so v1 of
-  that protocol is a compatibility promise from here on. The aarch64 Linux
+  x86-64. It carries the address-family fallback (#205, #207), confirmed on
+  NetBSD before tagging by the pkgsrc packager — the first BSD mirador has
+  been seen running on. 1.6.0 before it shipped the external panel protocol,
+  so v1 of that protocol is a compatibility promise. The aarch64 Linux
   archive first shipped in 1.5.1 and was executed the same day by its
   contributor — "it starts and draws" on Fedora 44 Asahi
   ([#197](https://github.com/jchultarsky/mirador/pull/197)) — so every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump for the address-family fallback (#207), confirmed working on NetBSD by the reporter in #205 — built from pkgsrc infrastructure at b6d1321, config wiped first, all panels fetching.

CHANGELOG moves the Unreleased entry under [1.6.1] with its link references; CLAUDE.md's released-version note updated in the same commit, as its guard requires. Step 0 done before this PR: the release build was driven in a real terminal under tmux — live weather/stocks fetches through the new fetch path, help overlay, focus ring, clean q exit.

After merge: tag v1.6.1 on the squashed commit, release workflow, attestation checks, cargo publish, closing note on #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)