### PR TITLE
The protocol document catches up with the host it promises

### DIFF
--- a/docs/plugin-protocol.md
+++ b/docs/plugin-protocol.md
@@ -1,5 +1,9 @@
 # External panel protocol v1
 
+Protocol **v1**, first shipped in mirador 1.6.0 and a compatibility
+commitment from that release on. This document is the contract's source of
+truth: changes land here before host code.
+
 Mirador can adapt an explicitly configured child process into one dashboard
 tile. The process sends text and controls; Mirador remains the only renderer
 and the only owner of the real terminal.
@@ -20,7 +24,10 @@ When Mirador hosts an external panel, it keeps these permanent obligations:
   that blocks, floods, crashes or sends malformed data becomes a failed panel,
   not a blocked dashboard or damaged terminal session.
 - Keyboard input follows the same focus and capture arbitration as an in-tree
-  panel. Mouse input goes to the panel under the pointer.
+  panel. Mouse input goes to the panel under the pointer — except while any
+  panel captures input or an input barrier is open, when the focused panel
+  owns the pointer and events outside its rectangle are dropped rather than
+  moving focus.
 - Every external tile is labelled `EXTERNAL` in its frame. Configuration names
   the executable explicitly; Mirador never scans or discovers plugins.
 - The protocol remains compatible on Mirador's side of its version.
@@ -51,7 +58,10 @@ only commands you trust.
 ## Configuration and credentials
 
 Commands are argv arrays launched directly, without a platform shell. Paths
-and quoting therefore have the same meaning on Windows, Linux and macOS.
+and quoting therefore have the same meaning on Windows, Linux and macOS. The
+child is launched with `MIRADOR_PLUGIN_PROTOCOL=1` in its environment — the
+same number `hello` carries — so an SDK can refuse early, before speaking,
+when the host's protocol is not one it knows.
 
 ```toml
 [[plugins]]
@@ -83,9 +93,10 @@ Watch Log event or stderr diagnostic.
 Each placement owns one child process. Stdin and stdout carry UTF-8 JSON Lines;
 stderr is a diagnostic stream. On removal or normal application exit, Mirador
 sends `shutdown`, allows 300 ms for cleanup, then terminates a child that
-remains. The exit path waits, for at most one second, for the process supervisor
-to finish that grace-then-terminate sequence before terminal restoration. A
-failed panel can be restarted with `r`.
+remains. The exit path waits — a 750 ms join grace, then 250 ms to abort,
+about one second in all — for the process supervisor to finish that
+grace-then-terminate sequence before terminal restoration. A failed panel can
+be restarted with `r`.
 
 ## Bounds
 
@@ -102,21 +113,32 @@ The host applies these v1 limits independently to every panel:
 | Ready or frame title / counter | 256 / 128 UTF-8 bytes |
 | Binding key / action | 64 / 256 UTF-8 bytes |
 | Non-fatal or fatal error text | 1,024 UTF-8 bytes |
+| Colour string / one `input.keys` chord | 64 UTF-8 bytes each |
 | Undrained Watch Log events | 64, each at most 1,024 UTF-8 bytes |
 | Host-to-child input queue | 256 messages |
-| Child stderr accepted / retained | 64 KiB per second / latest 8 KiB |
+| Child stderr accepted / retained | 64 KiB per fixed one-second window / latest 8 KiB |
+| Grace after stdout closes with the child still alive | 100 ms |
 | Passive-key frame acknowledgement | 3 x `refresh_ms`, clamped to 100 ms through 1 second |
 
+The stdout rate window is rolling; the stderr window is fixed, so a burst
+straddling its boundary can briefly reach twice the stated figure. Closing
+stdout while the process lives is treated as the child abandoning the
+protocol: the panel fails and the child is terminated after the grace.
+
 Only the newest complete frame is retained. A newer frame replaces the prior
-one rather than entering a render queue. `refresh_ms` is clamped to 16 through
-60,000 ms, so a focused interactive panel cannot turn the shell into a busy
-loop.
+one rather than entering a render queue. `refresh_ms` defaults to 33 ms when
+`ready` omits it and is clamped to 16 through 60,000 ms, so a focused
+interactive panel cannot turn the shell into a busy loop. The retained-text
+budget counts every string in a frame — span text, title, counter, colour
+names, binding keys and actions, and `input.keys` — not span text alone.
 
 Crossing a child protocol, startup, output-rate, retained-data or input-
 acknowledgement limit fails that panel and terminates its child. A full host-to-
-child queue or a host input message too large to encode drops the new input and
-shows a panel warning; input already claimed by a capturing panel never falls
-through as a Mirador global action.
+child queue drops the new input and shows a panel warning, as does a `paste`
+too large to encode — the one host message checked before writing; any other
+host message that exceeded the bound would fail the panel, though none can in
+practice. Input already claimed by a capturing panel never falls through as a
+Mirador global action.
 
 ## Framing and version negotiation
 
@@ -128,7 +150,7 @@ message is:
 {
   "type": "hello",
   "protocol": 1,
-  "host_version": "1.5.0",
+  "host_version": "1.6.0",
   "plugin": "example",
   "config": {"answer": 42},
   "cwd": "/current/working/directory"
@@ -146,9 +168,9 @@ The first child message must arrive within five seconds and be:
 }
 ```
 
-The version must match exactly and `ready` is sent once. A frame or Watch Log
-event before `ready`, a second `ready`, an unknown field or message type, or
-malformed JSON ends the panel session.
+The version must match exactly and `ready` is sent once. A frame, Watch Log
+event or `error` before `ready`, a second `ready`, an unknown field or message
+type, or malformed JSON ends the panel session.
 
 Version 1 is a compatibility commitment. A release that advertises v1 will
 not remove or redefine its fields, weaken host-owned keys, or lower its bounds.
@@ -158,9 +180,11 @@ changing this one.
 ## Frames and host-owned rendering
 
 Frames are complete immutable snapshots, not patches. Revisions increase;
-late or duplicate revisions are ignored. Omitting a frame title uses the title
-negotiated by `ready` (or the configured plugin id when `ready` had none); it
-does not retain an override from an older frame.
+late or duplicate revisions are ignored. Only `revision` is required —
+`title`, `counter`, `lines`, `bindings`, `input` and `cursor` may each be
+omitted, and an omitted `cursor.visible` defaults to true. Omitting a frame
+title uses the title negotiated by `ready` (or the configured plugin id when
+`ready` had none); it does not retain an override from an older frame.
 
 ```json
 {
@@ -187,17 +211,24 @@ does not retain an override from an older frame.
 }
 ```
 
-Each `WireLine` is one logical line; line breaks are represented by another
-entry. Text, titles, counters, bindings and errors may not contain terminal
-control characters. Mirador rejects them rather than allowing an escape
-sequence to reach the real terminal. The host word-wraps logical lines by
-terminal display width, preserves span styles, clips to the available height,
-and replaces a glyph that cannot fit even one whole cell-width with an
-ellipsis. Ratatui is never asked to wrap plugin text.
+Each entry in `lines` is one logical line — a `{"spans": [...]}` object,
+where omitting `spans` means a blank line; line breaks are represented by
+another entry. Text, titles, counters, bindings and errors may not contain
+terminal control characters — and that check is `is_control`, so a literal
+tab is refused too; tab expansion is the plugin's job. Mirador rejects
+control characters rather than allowing an escape sequence to reach the real
+terminal. The host word-wraps logical lines by terminal display width,
+preserves span styles, clips to the available height, and replaces a glyph
+that cannot fit even one whole cell-width with an ellipsis. Ratatui is never
+asked to wrap plugin text. Rendering also budgets each frame's text at 16
+bytes per interior cell (clamped between 256 bytes and 1 MiB), so a line
+unusually dense in multi-byte text — combining marks, ZWJ emoji — can be
+truncated at that budget before any other bound is reached.
 
 Cursor coordinates are zero-based viewport coordinates relative to the panel
-interior. They are clipped to that rectangle and are not remapped when the
-host wraps an over-wide logical line.
+interior. A cursor outside that rectangle is suppressed, not clamped to the
+nearest edge, and the cursor is drawn only while the panel is focused.
+Coordinates are not remapped when the host wraps an over-wide logical line.
 
 Every span requires `text`. Optional `fg` and `bg` values accept:
 
@@ -209,8 +240,8 @@ Every span requires `text`. Optional `fg` and `bg` values accept:
 - a ratatui colour name or `#rrggbb`.
 
 The optional style flags are `bold`, `dim`, `italic`, `underlined` and
-`reversed`. Unknown colours fail the panel rather than changing meaning with a
-fallback.
+`reversed`. A colour string is at most 64 UTF-8 bytes, and unknown colours
+fail the panel rather than changing meaning with a fallback.
 
 A child may report a visible error:
 
@@ -219,7 +250,15 @@ A child may report a visible error:
 ```
 
 A fatal error ends the process. A non-fatal error remains as a bounded panel
-notice until a later frame replaces it.
+notice until a later frame replaces it, drawn over the bottom row of the
+panel's interior — a full-height frame loses that row while the notice
+stands.
+
+Outside the running states the frame's `counter` is host-owned — the panel
+shows `starting`, `exited` or `failed` regardless of what the last frame
+said — and in those states the panel surfaces the last few lines of the
+child's stderr (at most three) as its body: before the first frame, and
+after a crash or failure.
 
 ## Watch Log events
 
@@ -236,9 +275,11 @@ updates; the Watch Log's existing high bar for what counts still applies.
 
 ## Host-to-child messages
 
-After negotiation the host may send the following messages. `shutdown` is the
-one exception to that ordering: it may follow `hello` immediately when Mirador
-exits or removes a panel during startup.
+After negotiation the host may send the following messages. Between `hello`
+and `ready` the host sends nothing at all, with one exception: `shutdown` may
+follow `hello` immediately when Mirador exits or removes a panel during
+startup. `resize` and `focus` are sent when their value changes, not on a
+schedule, and `tick` arrives at the negotiated refresh cadence.
 
 ```json
 {"type":"resize","columns":80,"rows":24}
@@ -261,8 +302,15 @@ Keys include both a stable code and the canonical chord used by `input.keys`:
 ```
 
 Named canonical keys include `Enter`, `Backspace`, `Tab`, `BackTab`, `Esc`,
-`Left`, `Right`, `Up`, `Down`, `Home`, `End`, `PageUp`, `PageDown`, `Delete`,
-`Insert`, and `F1` through `F12`. Modifier order is `Ctrl`, `Alt`, `Shift`,
+`Space`, `Left`, `Right`, `Up`, `Down`, `Home`, `End`, `PageUp`, `PageDown`,
+`Delete`, `Insert`, and `F1` through `F12` — a space character is the named
+key `Space`, never a literal `" "` in `input.keys`. Any key outside this list
+uses its Rust debug spelling (`Menu`, `KeypadBegin`, `Media(PlayPause)`), so
+an SDK should treat the set as open rather than an enum. `code` is `char` for
+character keys, `f1` through `f12` for function keys, and otherwise the
+lowercased key name (`esc`, `backtab`, `pagedown`). `text` is present and
+`null` for non-character keys — the field is not omitted — and the same is
+true of `button` on wheel messages. Modifier order is `Ctrl`, `Alt`, `Shift`,
 `Super`, `Hyper`, `Meta`. Character case is preserved.
 
 Mouse coordinates are panel-relative:
@@ -299,9 +347,15 @@ decide whether a global key is safe.
   `Ctrl+x` for its own cancel or interrupt action.
 
 A passive plugin cannot claim or advertise the shell's `q`, `Tab`, `BackTab`,
-`?`, `w`, `m`, `t`, `1` through `9`, `Ctrl+arrows`, or `Ctrl+C` bindings. In an
-explicit capture state the ordinary keys are suspended just as they are for a
-built-in editor; `Ctrl+C` remains reserved without exception.
+`?`, `w`, `m`, `t`, `1` through `9`, `Ctrl+arrows`, or `Ctrl+C` bindings. The
+refusal matches on the key itself regardless of modifiers — `Alt+q` and
+`Shift+BackTab` are refused along with the bare chords — while uppercase `Q`
+is a different key and is not reserved. Binding declarations are validated as
+text as well: a binding whose `key` mentions a host-owned key anywhere in it
+(`q / quit`, `ctrl+arrows`) fails the panel rather than advertising a hint
+the host will not honour. In an explicit capture state the ordinary keys are
+suspended just as they are for a built-in editor; `Ctrl+C` remains reserved
+without exception.
 
 After Mirador accepts a named key from a passive panel, it conservatively
 captures subsequent keyboard input for three of that panel's refresh intervals,
@@ -310,6 +364,14 @@ transition where, for example, `Enter` opens a login form but a rapidly typed
 `q` arrives before the form's capture frame. Paste and mouse remain independent
 capabilities during this barrier: an event not opted into by the latest frame
 is not sent to the plugin or converted into fallback key events.
+
+One consequence to state plainly: **while the barrier is open, every key is
+forwarded to the plugin — including the shell bindings a passive panel cannot
+otherwise claim.** The barrier exists precisely so a keystroke racing a mode
+change cannot leak to the wrong owner, and for its bounded window that owner
+is the plugin. `Ctrl+C` is the sole exception, never delivered in any state.
+An SDK should expect, and silently ignore, keys it never declared during this
+window.
 
 Any valid frame accepted during the barrier acknowledges the action and
 releases it, even when its revision is equal to or older than the retained


### PR DESCRIPTION
Documentation only — no code changes. Part 1 of the doc-review batch from today's adversarial pass (the review compared every claim in docs/plugin-protocol.md against src/plugin/mod.rs, src/plugin/process.rs and config/plugins.rs).

The good news from that pass: every numeric bound in the table matched its constant exactly, and the enforcement layer (negotiation, barriers, clipping, reserved keys) verified correct. The doc lagged the code, not the other way round. This PR closes the gap: two corrected claims (cursor suppression vs "clipping"; mouse routing during capture/barrier), nineteen newly documented behaviors an SDK author could trip on — the barrier's host-key forwarding stated plainly, with Ctrl+C as the sole exception — and a version stamp so the document says which mirador first spoke it.

On the barrier: documenting the current behavior was the deliberate choice over narrowing the code — the shipped behavior is tested and intentional (a keystroke racing a mode change must not leak), and v1 is a compatibility promise. If the forwarding should narrow instead, that's a protocol discussion, not a doc edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)