### PR TITLE
README, CONTRIBUTING and the notes catch up with 1.5.1 through 1.6.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,8 +848,11 @@ every design considered either embedded Python or Lua, or a public Rust API, and
 both were worse than not having the feature. A process boundary costs neither,
 which is why `panel.rs` no longer declares itself not-a-plugin-API.
 
-Nothing is built and what was posted is a position rather than a contract, but
-these parts were stated firmly and are the ones to hold: `Ctrl+C` stays
+That was written when nothing was built and what had been posted was a
+position rather than a contract. Both halves have since flipped — the contract
+was agreed in text on 2026-08-24 and shipped in 1.6.0 as protocol v1, a
+compatibility promise — but the parts stated firmly then are the ones that
+held, unchanged, all the way through: `Ctrl+C` stays
 host-owned with **no** exception, not even the first press; plugins take input
 from the start, because a panel you can only watch is not much of a widget;
 **the host does the clipping**, since a plugin cannot be trusted with invariant
@@ -1686,9 +1689,10 @@ and had to be added back was the one that did not.
     capture lands a few milliseconds in, `agg` faithfully renders those
     milliseconds of empty terminal, and the GIF opens on a black frame — the one
     a still preview shows, and a flicker on every loop.
-  - **150x42, not smaller.** The clock drops its block numerals when its row is
-    short, and those numerals are the one thing in mirador that looks like
-    nothing else.
+  - **200x50, not smaller** (the script's `COLS`/`ROWS` are the truth if this
+    number goes stale again — it sat at "150x42" here long after the script
+    moved on). The clock drops its block numerals when its row is short, and
+    those numerals are the one thing in mirador that looks like nothing else.
   - **The order of the segments is now taste, not a workaround.** It used to
     matter: toggling any panel rebuilt every panel, so starting the pomodoro
     before the picker segment recorded the timer silently resetting, and the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ a file the build needed, and a dependency `cargo deny` refused.
 cargo fmt --all -- --check
 cargo clippy --locked --all-targets -- -D warnings
 cargo test --locked --all-targets
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --document-private-items
 cargo deny check
-cargo publish --dry-run
+cargo publish --locked --dry-run
 ```
 
 `--locked` matters and is not decoration: without it cargo will quietly rewrite
@@ -67,7 +67,7 @@ cargo run -- --config /tmp/mirador.toml
 ## Adding a built-in widget
 
 The `Panel` trait in `src/panel.rs` is mirador's private in-tree seam. A widget
-that belongs in every installation still means a pull request. Six places to
+that belongs in every installation still means a pull request. Seven places to
 touch:
 
 1. Create `src/widgets/<name>.rs` and implement `Panel`.
@@ -85,18 +85,29 @@ touch:
    fails if the registry disagrees, because a grid that is not listed is a grid
    the overflow sweep never checks — and an unchecked grid draws rows wider than
    its panel, which the terminal then cuts without saying so.
-5. Document the widget in `assets/default_config.toml` and in the README's
+5. Place it in the default dashboard — **twice, and the two must match**:
+   `Default for Layout` in `src/config/layout.rs` and the `[layout]` block in
+   `assets/default_config.toml` describe the same dashboard by different
+   routes, and two tests (`the_default_layout_places_every_widget` and the
+   shipped-layout comparison) fail until both know your widget.
+6. Document the widget in `assets/default_config.toml` and in the README's
    widget table.
-6. Add tests for the logic that is not drawing — parsing, formatting,
+7. Add tests for the logic that is not drawing — parsing, formatting,
    thresholds, state transitions.
 
-Steps 2 and 4 are the ones that bite. The calculator is the proof: the pull
-request that added the panel touched no `src/grid.rs` at all, and a later one
-had to add the registry entry when the panel gained a grid.
+Steps 2, 4 and 5 are the ones that bite. The calculator is the proof twice
+over: the pull request that added the panel touched `src/config/layout.rs`,
+which this list did not name at the time — and touched no `src/grid.rs` at
+all, so a later one had to add the registry entry when the panel gained a
+grid.
 
 Widgets must not block. If your widget needs network or disk I/O, do it on a
 background thread and poll the result in `tick`, as `weather.rs` does. A panel
-that blocks freezes the whole dashboard.
+that blocks freezes the whole dashboard. Make the HTTP request itself through
+`crate::fetch::get` — it carries the address-family fallback that keeps
+fetches working on IPv6-preferring hosts with no IPv6 route (#205) — and wait
+between polls with `crate::poll::wait`, so quitting does not sit out your
+sleep. A raw `ureq` call quietly loses both.
 
 Personal or experimental panels do not need to become core widgets. The
 [external panel protocol](docs/plugin-protocol.md) is a versioned process
@@ -113,7 +124,8 @@ If your widget needs a setting the user can change from the keyboard, two
 things already exist for it. A value that is free text — a path, a place, a
 name — gets a `Prompt` from `src/prompt.rs`: open it with the current value,
 validate the answer yourself, and call `reject` to keep the dialog open with
-the text still in it. Return the value from `Panel::remember` and it persists
+the text still in it. Report the value in `Panel::remember` — it writes into
+the `UiState` it is handed rather than returning anything — and it persists
 through `state.rs`, which records only what differs from the config so the
 setting can be un-set again.
 
@@ -160,7 +172,7 @@ palette. Someone choosing `nord` wants Nord.
 
 ## Code standards
 
-- `cargo clippy --all-targets -- -D warnings` must pass. The crate enables
+- `cargo clippy --locked --all-targets -- -D warnings` must pass. The crate enables
   `clippy::pedantic`; if a lint is genuinely wrong for a piece of code, add a
   targeted `#[allow]` with a comment explaining why, rather than widening the
   allow list in `Cargo.toml`.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ Get-Content .\mirador-x86_64-pc-windows-msvc.zip.sha256
 
 Requires Rust 1.95 or newer to build from source.
 
+**NetBSD** (and anywhere pkgsrc runs) has a community package:
+`pkgin install mirador`, or build from
+[`sysutils/mirador`](https://pkgsrc.se/sysutils/mirador). It is packaged and
+maintained in pkgsrc rather than by this repository — the first BSD packaging
+of mirador, and the platform whose bug report fixed IPv6-preferring networks
+for everyone (1.6.1).
+
 **Windows** has been run and works — installed with the PowerShell one-liner
 above, in the default Windows terminal. It is still the least-travelled of the
 three: macOS and Linux are used daily and Windows has been checked rather than
@@ -243,7 +250,7 @@ Some settings you change with a keystroke are remembered across restarts:
 | Where the panels are | `m` | — |
 | Panel sizes | `Ctrl+arrows` | — |
 
-They go to two different places, and the split is deliberate.
+They go to three different places, and the split is deliberate.
 
 **Anything to do with `[layout]` is written back into your config** — which
 panels exist, and how wide they are. That is the part of the file you actually
@@ -262,6 +269,13 @@ else, so editing any other value in your config still takes effect. Delete that
 file and every remembered setting falls back to what the config says; it says
 so at the top of itself, because a preference you cannot remember setting needs
 an obvious way back.
+
+**And the two editable lists are data, not settings.** Watchlist symbols and
+the world-clock list go to files of their own beside your tasks —
+`watchlist.toml` and `zones.toml` — because a list you edit from the panel is
+something mirador owns, not a preference measured against the config. That is
+also why `[stocks].symbols` and the clock zones in the config only seed the
+first run: after that, the files are the truth.
 
 ### Upgrading
 
@@ -347,7 +361,7 @@ to-do list as a flat checklist; this one has due dates, priorities, tags,
 notes, filtering and full editing without leaving the dashboard.
 
 ```
-╭┤3 Tasks├───────────────────────────────────────────────────────────┤3 open├╮
+╭┤4 Tasks├───────────────────────────────────────────────────────────┤3 open├╮
 │ 1 overdue   1 due today   3 open   by smart                                │
 │   DONE PRI TASK                              TAGS                      DUE │
 │   [ ]  ▮▮▮ Renew the domain                  #admin            2 days late │
@@ -373,7 +387,7 @@ or `title` when you want something simpler.
 Free-form notes in a master-detail layout, the shape a mail client uses.
 
 ```
-╭┤2 Notes├───────────────────────────────┤1├╮
+╭┤6 Notes├───────────────────────────────┤1├╮
 │ 1 note                                    │
 │   TITLE                              DATE │
 │   Release checklist                ·25 J… │
@@ -437,7 +451,7 @@ run. The large clock is not removable, and nothing can be moved into its place
 either, because a clock panel with nothing to draw large is not a clock panel.
 
 ```
-╭┤1 Calendar├───────────────────╮
+╭┤2 Calendar├───────────────────╮
 │      July 2026                │
 │ Su Mo Tu We Th Fr Sa          │
 │           1  2  3  4          │
@@ -458,7 +472,7 @@ Current conditions and an hourly forecast from [Open-Meteo](https://open-meteo.c
 which needs no key and no account. `u` switches between imperial and metric at
 runtime, converting what is already on screen rather than re-fetching. `L` sets
 the location without touching your config; the panel re-geocodes and refetches
-on the spot.
+on the spot. `r` refetches by hand, ahead of the regular refresh.
 
 A failed refresh keeps the last reading and shows its age in amber rather than
 blanking the panel — weather two hours old is still useful, and an empty panel
@@ -469,7 +483,7 @@ is not. Columns drop as the panel narrows, in the order that costs you least.
 A watchlist with the last price, the day's change, and an intraday sparkline.
 
 ```
-╭┤1 Markets├──────────────────────────────────────────────────────────────┤7├╮
+╭┤Markets├────────────────────────────────────────────────────────────────┤7├╮
 │   SYMBOL         LAST       CHG        % TODAY                             │
 │ ▸ ^GSPC       7413.18     +1.20   +0.02% ▇▄▃▃▂▃▂▁▂▂▃▃                      │
 │   ^DJI       52210.08   +262.83   +0.51% ▇▅▃▃▂▂▂▂▂▂▃▄                      │
@@ -605,7 +619,7 @@ floor.
 What happened while you were not looking.
 
 ```
-╭┤7 Watch log├──────────────────────────────────╮
+╭┤8 Watch log├──────────────────────────────────╮
 │ 14:02  Standup appeared in your calendar      │
 │ ──────────────────── since you were here ──── │
 │ 13:30  Renew the domain went overdue          │
@@ -619,7 +633,9 @@ tasks change because you changed them. An entry is something that happened *to*
 you rather than because of you, and that you would want to know even if you
 never looked at the panel it came from. Out of the box that means three things:
 the day turning, a task crossing into overdue because of it, and an event
-appearing in your `.ics` that you did not put there.
+appearing in your `.ics` that you did not put there. An external panel can be
+a fourth source: a plugin may hand the log a bounded, *completed* event —
+outcomes, not progress — and it appears here under that plugin's id.
 
 The day turning is the one that always happens, which is more useful than it
 sounds — it is the divider that tells you where one day's entries end, and it
@@ -735,9 +751,9 @@ functions — the tape and carrying an answer forward cover what those were for.
 
 ### CPU and network
 
-CPU shows average load, a moving history graph and a per-core meter row.
-Network shows receive and transmit rates as two graphs, plus a session total
-and the peak rate seen.
+CPU shows average load, a moving history graph and a per-core meter row —
+`c` toggles that row when the panel is focused. Network shows receive and
+transmit rates as two graphs, plus a session total and the peak rate seen.
 
 Both draw their history in **braille**, which packs two samples into every
 character cell and four levels into every row — twice the horizontal
@@ -772,6 +788,10 @@ Every flag is optional; with none of them mirador opens the dashboard.
 | `-y`, `--yes` | Do not ask for confirmation |
 | `-h`, `--help` | Print help and exit |
 | `-V`, `--version` | Print the version and exit |
+
+The config path resolves in that order: `--config` wins over the
+`MIRADOR_CONFIG` environment variable, which wins over the platform default —
+the same order `--config-path` reports.
 
 Neither reset deletes anything. Every file they touch is renamed to a numbered
 `.bak` beside itself, and both list what they will affect before doing it.
@@ -824,10 +844,11 @@ In the task panel:
 | Key | Action |
 | --- | --- |
 | `j` / `k`, `↑` / `↓` | Move the selection |
-| `g` / `G` | Jump to first / last |
+| `g` / `G`, `Home` / `End` | Jump to first / last |
+| `PageUp` / `PageDown` | Move a screen at a time |
 | `Space` | Toggle done |
-| `a` | Add a task |
-| `e` | Edit the selected task |
+| `a` / `n` | Add a task |
+| `e` / `Enter` | Edit the selected task |
 | `d` | Delete (asks first) |
 | `p` / `P` | Cycle priority forward / back |
 | `s` | Cycle sort mode |
@@ -1107,7 +1128,9 @@ it makes a stale config look like stale code.
 ## Task file format
 
 Tasks live in one TOML file — by default under your platform's data directory,
-or wherever `[todo].file` points. Press `o` in the task panel to see the path.
+or wherever `[todo].file` points. Press `o` in the task panel to see the path —
+and the same key answers in every file-backed panel: notes, the watchlist, the
+clock zones and the agenda all show theirs.
 
 ```toml
 [[task]]
@@ -1129,8 +1152,8 @@ created = "2026-07-30"
 completed = "2026-08-02"   # set when `done` flips; used by the `c` filter
 ```
 
-Only `id`, `title`, `done` and `created` are required; everything else may be
-left out.
+Only `id`, `title` and `created` are required; everything else — `done`
+included — may be left out.
 
 Writes are atomic — the file is written under a temporary name, flushed to the
 disk, and renamed over the original — so an interrupted save or a full disk can
@@ -1144,7 +1167,7 @@ about the files mirador reads, and it is worth being precise about what it
 covers.
 
 **Your config.** No option that has ever shipped in a released version has been
-removed — every key in every `mirador.toml` written since `0.1.0` is still
+removed — every key in every `config.toml` written since `0.1.0` is still
 accepted, checked against every released version. Options are added, never
 renamed out from under you. The four keys that predate `0.1.0` are handled by
 `mirador --migrate-config`, which edits the file in place and tells you what it


### PR DESCRIPTION
Documentation only — part 2 of the doc-review batch. Every change here corrects a claim the review verified against code, or documents a shipped feature the prose predated. Highlights: the README's Compatibility section named a config file (`mirador.toml`) that has never existed; the add-a-widget checklist omitted the one step whose absence fails two tests; and NetBSD joins the install section as a community package (`sysutils/mirador`), per #205.

The mock-up borders were re-measured after renumbering — all boxes still align at their original cell widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)