### PR TITLE
The shipped config documents what the code accepts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 290 of them, including the ones mirador
+    trip through `toml` discards all 324 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.151"
 sysinfo = "0.39.6"
 toml = "1.1.3"
 unicode-width = "0.2.2"
-ureq = "3.3.0"
+ureq = "3.4.0"
 
 [profile.release]
 lto = true

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -42,8 +42,9 @@ mouse = true
 #
 # When it is on: no identifier is sent, the answer is cached in
 # update-check.toml beside your tasks, a failure is silent, and the notice
-# disappears on your first keypress. NO_UPDATE_CHECK=1 or DO_NOT_TRACK=1 in the
-# environment overrides this even when it is true.
+# disappears on your first keypress. NO_UPDATE_CHECK or DO_NOT_TRACK in the
+# environment overrides this even when it is true — any non-empty value except
+# `0` counts, so `=1` and `=true` both work.
 check_for_updates = false
 
 # ---------------------------------------------------------------------------
@@ -53,7 +54,8 @@ check_for_updates = false
 # not cell counts, so the proportions hold at any terminal size.
 #
 # Available widgets: clocks, weather, todo, notes, stocks, calendar, agenda,
-# pomodoro, watchlog, news, cpu, network, calculator
+# pomodoro, watchlog, news, cpu, network, calculator — plus the id of any
+# external panel declared under "External panels" below
 # ---------------------------------------------------------------------------
 [layout]
 rows = [
@@ -98,10 +100,34 @@ rows = [
 ]
 
 # ---------------------------------------------------------------------------
+# External panels
+#
+# mirador can host a program you name as one dashboard tile. Nothing is ever
+# scanned or discovered: a plugin runs only when it is both declared here and
+# placed in [layout] by its id, and with neither, mirador starts no child
+# process at all. The tile is labelled EXTERNAL, because a plugin is somebody
+# else's program running with your permissions — it can do what mirador
+# promises never to do itself, like talk to a server of its own choosing.
+#
+# The command is an argv array run directly, never through a shell, and the
+# [plugins.config] table is handed to the plugin unread: its schema belongs to
+# the plugin. It is configuration, not secret storage — a plugin that needs a
+# login collects it in its own panel. The full protocol, with every bound the
+# host enforces, is docs/plugin-protocol.md in the repository.
+#
+#   [[plugins]]
+#   id = "example"
+#   command = ["example-mirador-plugin", "--optional-argument"]
+#
+#   [plugins.config]
+#   answer = 42
+#
+# ---------------------------------------------------------------------------
 # Theme
 #
 # Colours accept a name (`red`, `light-blue`), a hex string (`#d7af87`), a
-# 256-colour index (`179`), or `reset` for your terminal's own default.
+# 256-colour index written as a string (`"179"`, quotes included — a bare
+# number will not parse), or `reset` for your terminal's own default.
 #
 # The shipped palette is an aged instrument panel: brass for the instruments,
 # verdigris for engraved labels, slate for chrome. Body text is `reset` so it
@@ -166,6 +192,11 @@ end   = "#afd787"
 start = "#4a3a5a"
 mid   = "#8a6f9f"
 end   = "#c7afd7"
+
+# Two further ramps are accepted — [theme.gain_gradient] and
+# [theme.loss_gradient], green and red in the shipped themes. Nothing draws
+# from them yet: they are reserved for the markets panel's sparkline, and a
+# theme may set them now so it is already complete when that lands.
 
 # ---------------------------------------------------------------------------
 # World clocks
@@ -265,7 +296,8 @@ preview     = "below"        # below | beside
 # rate will fix it.
 #
 # `refresh_secs` is clamped to a minimum of 60, and symbols are requested one at
-# a time `stagger_ms` apart rather than all at once. These services are free and
+# a time `stagger_ms` apart rather than all at once — that delay is itself
+# clamped to 100 through 10,000 ms. These services are free and
 # unauthenticated; hammering them gets the address blocked for everyone on it.
 # ---------------------------------------------------------------------------
 [stocks]
@@ -289,7 +321,8 @@ show_sparkline = true
 # rows of months rather than leaving a void, up to a year in view at once.
 # ---------------------------------------------------------------------------
 [calendar]
-months      = 2          # months across; more stack when there is height
+months      = 2          # months across; more stack when there is height.
+                         # At most 12 — a year is already the whole cycle
 week_starts = "sunday"   # sunday | monday
 
 # ---------------------------------------------------------------------------
@@ -318,9 +351,9 @@ week_starts = "sunday"   # sunday | monday
 [agenda]
 # file        = "~/calendar.ics"   # `f` sets this from the panel, with Tab
                                    # completing path segments as you type
-days          = 7        # how far ahead to look
+days          = 7        # how far ahead to look; clamped to 1 through 365
 show_location = true     # show the location when the row has room for both
-refresh_secs  = 60       # how often to re-read the file
+refresh_secs  = 60       # how often to re-read the file; no faster than 5
 
 # ---------------------------------------------------------------------------
 # News
@@ -346,6 +379,7 @@ refresh_minutes = 60     # also the floor; news moves slower than a dashboard
 per_feed        = 4      # kept from each feed, so a chatty one cannot crowd
                          # out a quiet one. Stories are then interleaved, so
                          # the top of the panel holds one from each.
+                         # Clamped to 1 through 20.
 
 # What Enter runs on the selected story, with the link added as the last
 # argument. Empty means Enter opens nothing — mirador launches no program you
@@ -410,7 +444,8 @@ chime_command            = []
 # CPU
 # ---------------------------------------------------------------------------
 [cpu]
-history       = 120            # samples kept in the moving chart
+history       = 120            # a floor on the samples kept, not a cap: the
+                               # buffer grows to what a wider panel can draw
 sample_secs   = 2             # seconds between samples. Every sample is a new
                               # number, and a new number means a repaint, so
                               # this and [network] set the floor on what an idle
@@ -430,7 +465,7 @@ critical_pct  = 90.0
 # ---------------------------------------------------------------------------
 [network]
 interfaces  = []
-history     = 120
+history     = 120             # a floor, not a cap — see the note under [cpu]
 sample_secs = 2               # see the note under [cpu]. Sampling the
                               # interface list is the more expensive of the
                               # two by roughly fifteen times.

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -180,7 +180,8 @@ impl Default for LayoutRow {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LayoutPanel {
-    /// Widget id: `clocks`, `weather`, `todo`, `cpu` or `network`.
+    /// Widget id: any name in `WIDGET_NAMES` (`clocks` through `calculator`),
+    /// or the id of a declared `[[plugins]]` entry.
     pub widget: String,
     /// Relative width weight.
     pub width: u16,

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -26,9 +26,10 @@ pub struct ClocksConfig {
     pub date_format: String,
     /// Show each zone's offset relative to the primary clock.
     pub show_offset: bool,
-    /// Include seconds in the large clock. Off by default: a ticking seconds
-    /// field draws the eye every second, which is the opposite of what a
-    /// leave-it-running dashboard wants.
+    /// Include seconds in the large clock. On by default — the block numerals
+    /// are the panel's whole face, and a chronometer that visibly runs is the
+    /// look the design is after; `s` turns them off at a keystroke for anyone
+    /// who finds the tick draws the eye.
     pub show_seconds: bool,
 }
 
@@ -86,7 +87,8 @@ pub struct WeatherConfig {
     pub longitude: Option<f64>,
     /// `metric` (C, km/h) or `imperial` (F, mph).
     pub units: String,
-    /// Number of forecast hours to show, 1 to 24.
+    /// Forecast hours to show — a floor the panel is sized for, not a cap: a
+    /// taller panel shows more, up to the 24 hours the fetch retrieves.
     pub forecast_hours: u8,
     /// Minutes between refreshes.
     pub refresh_minutes: u64,
@@ -210,8 +212,9 @@ pub struct AgendaConfig {
     /// No default that guesses at a path. An agenda pointing somewhere the user
     /// did not choose is either empty, which looks broken, or somebody else's.
     pub file: Option<PathBuf>,
-    /// How many days ahead to show. A floor on the window rather than a cap on
-    /// the panel — a taller panel simply scrolls less.
+    /// How far ahead the window reaches, clamped to 1..=365. This one is a
+    /// hard cutoff, not a floor: the parser never expands an event beyond it,
+    /// so a taller panel shows the same window with less scrolling.
     pub days: u16,
     /// Show a location beside the summary, when the row has room for both.
     pub show_location: bool,
@@ -237,8 +240,10 @@ impl Default for AgendaConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CalendarConfig {
-    /// How many months to show, starting with the current one. The panel draws
-    /// as many as its size allows, up to this number.
+    /// How many months across, starting with the current one — a floor, not a
+    /// ceiling: a tall panel stacks further rows of months rather than leaving
+    /// a void, up to twelve in view. Width the panel does not have comes off
+    /// this count rather than truncating a grid.
     pub months: u8,
     /// `sunday` or `monday`.
     pub week_starts: String,

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 290;
+        const CITED: usize = 324;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -264,10 +264,14 @@ pub struct Gradients {
     pub cpu: Gradient,
     pub rx: Gradient,
     pub tx: Gradient,
-    /// For a rising position. Unused until the watchlist panel lands.
+    /// For a rising position. The watchlist panel landed without a gradient
+    /// sparkline, so nothing reads this yet; it stays settable because themes
+    /// already set it and `deny_unknown_fields` makes removal a breaking
+    /// change. Reserved for the markets sparkline, and documented as such in
+    /// the shipped config.
     #[allow(dead_code)]
     pub gain: Gradient,
-    /// For a falling position. Unused until the watchlist panel lands.
+    /// For a falling position. Same story as `gain`.
     #[allow(dead_code)]
     pub loss: Gradient,
 }


### PR DESCRIPTION
Part 3 of the doc-review batch. Mostly the shipped config file and the struct doc comments behind it; one manifest line rides along.

- **`[[plugins]]` finally appears in the file users read first** — a commented example in the illustration indent style, so the commented-defaults guard skips it, with the layout's widget list pointing at it. Verified in the rebuilt binary via `--print-config`.
- The two dead-but-settable gradient keys are documented as reserved rather than removed (removal breaks `deny_unknown_fields` themes); wiring them into the stocks sparkline stays open as a feature if wanted.
- Clamps and floors documented where the file was silent; four struct doc comments that contradicted their own code corrected.
- The comment-count guard caught the additions exactly as designed: 290 → 324, updated in the test constant and CLAUDE.md invariant 16 together.
- `ureq = "3.3.0"` → `"3.4.0"`: the 1.5.1 CHANGELOG announced this bump but the manifest floor never moved; the lockfile and every release since already resolve 3.4.0.

One trap met on the way, already recorded in the working notes: cargo served a stale binary despite touched sources ("cargo does not always rebuild after a branch switch"), so the baked-config check first appeared to fail. `cargo clean -p mirador` resolved it; all gates re-run green after the clean rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)