### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-25
+
 ### Added
 
 - **The markets panel colours a row by the size of the day's move.** The
@@ -1686,7 +1688,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/jchultarsky/mirador/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/jchultarsky/mirador/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/jchultarsky/mirador/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/jchultarsky/mirador/compare/v1.5.0...v1.5.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1728,12 +1728,13 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.6.1` is released**, on crates.io and as a GitHub release with binaries
+- **`1.7.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows
-  x86-64. It carries the address-family fallback (#205, #207), confirmed on
-  NetBSD before tagging by the pkgsrc packager — the first BSD mirador has
-  been seen running on. 1.6.0 before it shipped the external panel protocol,
-  so v1 of that protocol is a compatibility promise. The aarch64 Linux
+  x86-64. It wires the gain/loss ramps into the markets panel and carries the
+  documentation catch-up; 1.6.1 before it fixed the address-family fallback,
+  confirmed on NetBSD (#205, now packaged as pkgsrc `sysutils/mirador`), and
+  1.6.0 shipped the external panel protocol, so v1 of that protocol is a
+  compatibility promise. The aarch64 Linux
   archive first shipped in 1.5.1 and was executed the same day by its
   contributor — "it starts and draws" on Fedora 44 Asahi
   ([#197](https://github.com/jchultarsky/mirador/pull/197)) — so every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump. 1.7.0 carries the gain/loss ramp wiring in the markets panel (#214) and the documentation catch-up batch (#209–#213), including the shipped config finally documenting `[[plugins]]` and the ureq floor correction.

CHANGELOG moves the Unreleased entries under [1.7.0] with link references; CLAUDE.md's released-version note updated in the same commit as its guard requires. Step 0 done before this PR: the release build at the exact tree to be tagged was driven under tmux — live fetches, the new ramp colours verified in the captured escapes, help overlay, clean `q` exit.

After merge: tag v1.7.0 on the squashed commit, release workflow, attestation checks (with the wrong-repo control), `cargo publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)