### PR TITLE
Six more bundled themes, chosen light-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Six more bundled themes, chosen light-first.** The first six ports were
+  all dark, so this batch is five light and one dark: `solarized-light`,
+  `gruvbox-light`, `catppuccin-latte`, `rose-pine-dawn`, `everforest-light`,
+  and `kanagawa` (Wave). Each is a port in the established sense — hex values
+  from the palette's own specification, cited in the file, with the mapping
+  mirroring its dark sibling where one exists and body text left on the
+  terminal's own foreground. Light themes start their graph ramps light, so
+  an idle chart recedes into a pale background.
+
 ## [1.7.0] - 2026-08-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 325 of them, including the ones mirador
+    trip through `toml` discards all 327 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -486,18 +486,28 @@ costs exactly one request. **Requires a browser `User-Agent`** or you get HTTP
 
 ## Named themes — built
 
-`theme = "name"` resolves through `themes.rs`. Ten themes are `include_str!`-
+`theme = "name"` resolves through `themes.rs`. Sixteen themes are `include_str!`-
 baked and anything in `<config>/mirador/themes/<name>.toml` is found first, so a
 bundled theme can be replaced without renaming it.
 
 Four are mirador's own (`default`, `default-light`, `high-contrast`, `ansi`).
-Six are **ports** of palettes from elsewhere — `nord`, `gruvbox`, `dracula`,
-`catppuccin-mocha`, `tokyo-night`, `solarized-dark`. Each file cites the
-upstream source its hex values came from, and that is the point: someone who
-picks `nord` wants Nord. Adjust the *mapping* onto mirador's keys if a palette
-reads badly; never adjust the palette. All six keep `text = "reset"`, so body
-text still follows the terminal's own foreground — invariant 8 is not suspended
-because a theme has a name.
+Twelve are **ports** of palettes from elsewhere — `nord`, `gruvbox`,
+`gruvbox-light`, `dracula`, `catppuccin-mocha`, `catppuccin-latte`,
+`tokyo-night`, `kanagawa`, `solarized-dark`, `solarized-light`,
+`everforest-light`, `rose-pine-dawn`. The 2026-08-25 batch of six was chosen
+deliberately light-heavy (five light, one dark) because the first six ports
+were all dark and the owner asked for variety. The `t` picker sorts names
+alphabetically — verified by opening it, not assumed from `BUNDLED`'s order —
+which happens to seat each palette's modes together anyway. Each file
+cites the upstream source its hex values came from, and that is the point:
+someone who picks `nord` wants Nord. Adjust the *mapping* onto mirador's keys
+if a palette reads badly; never adjust the palette. A light port mirrors its
+dark sibling's mapping role for role, using the palette's own light-mode
+answers (gruvbox's "faded" set, Latte's darker renderings), and its gradients
+*start light* so an idle graph recedes into a pale background — the
+`default-light` rule. All twelve keep `text = "reset"`, so body text still
+follows the terminal's own foreground — invariant 8 is not suspended because
+a theme has a name.
 
 Adding one: write `assets/themes/<name>.toml`, add it to `BUNDLED`. Three things
 will bite, and all three are pinned by tests rather than left to memory — the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,8 +143,9 @@ dashboard.
 
 Write `assets/themes/<name>.toml` and add it to `BUNDLED` in `src/themes.rs`.
 The `t` picker then lists it — that part needs nothing else. Two prose counts
-do have to follow, though, and nothing pins them: "Ten ship inside the binary"
-in `assets/default_config.toml`, and the theme table in the README.
+do have to follow, though, and nothing pins them: the bundled-count sentence
+("Sixteen ship inside the binary…") in `assets/default_config.toml`, and the
+theme table in the README.
 
 Four things will catch you out. The first three have tests rather than
 conventions behind them:

--- a/README.md
+++ b/README.md
@@ -1061,18 +1061,24 @@ Four are mirador's own:
 | `high-contrast` | Bright rooms, projectors, low vision. `muted` is deliberately *not* dim — faint grey is the first thing to vanish on a washed-out screen, so de-emphasis is carried by hue instead |
 | `ansi` | The sixteen ANSI colours and nothing else, so it follows whatever palette your terminal already uses and works with no true-colour support |
 
-Six more are ports of palettes you may already be running in your editor,
-terminal or multiplexer, so mirador can match the rest of your screen. All six
-are dark:
+Twelve more are ports of palettes you may already be running in your editor,
+terminal or multiplexer, so mirador can match the rest of your screen — seven
+dark, five light:
 
 | Theme | Palette |
 | --- | --- |
 | `nord` | [Nord](https://www.nordtheme.com/docs/colors-and-palettes) — arctic, north-bluish; Frost for the instruments, Aurora for the signals |
-| `gruvbox` | [Gruvbox](https://github.com/morhetz/gruvbox) dark — retro groove; the warmest and highest-contrast of the six |
+| `gruvbox` | [Gruvbox](https://github.com/morhetz/gruvbox) dark — retro groove; the warmest and highest-contrast of the ports |
+| `gruvbox-light` | The same retro groove on parchment — the "faded" accents, which are Gruvbox's own light-mode set |
 | `dracula` | [Dracula](https://spec.draculatheme.com/) — the loudest, six saturated accents at the same brightness |
 | `catppuccin-mocha` | [Catppuccin](https://github.com/catppuccin/catppuccin) Mocha — pastel accents on soft charcoal |
+| `catppuccin-latte` | Catppuccin's one light flavour — the same names, rendered darker so they hold on paper |
 | `tokyo-night` | [Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) Storm — the lifted variant, so mirador's slate chrome stays visible |
-| `solarized-dark` | [Solarized](https://ethanschoonover.com/solarized/) dark — designed against measured contrast rather than by eye, and the calmest of the six |
+| `kanagawa` | [Kanagawa](https://github.com/rebelot/kanagawa.nvim) Wave — Hokusai's ink and pastels; the closest in temperament to mirador's own default |
+| `solarized-dark` | [Solarized](https://ethanschoonover.com/solarized/) dark — designed against measured contrast rather than by eye, and the calmest of the ports |
+| `solarized-light` | The daylight half of the same design — Solarized shares its accents across both modes and swaps only the greys |
+| `everforest-light` | [Everforest](https://github.com/sainnhe/everforest) light — a green-based comfort palette; even its greys lean toward the forest |
+| `rose-pine-dawn` | [Rosé Pine](https://rosepinetheme.com/) Dawn — soho vibes at first light; rose for the instruments, pine standing in for green |
 
 These are ports, not reinterpretations: the hex values come from each palette's
 own specification, and the theme file cites its source. Body text stays `reset`

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -145,11 +145,13 @@ rows = [
 #
 #     theme = "high-contrast"
 #
-# Ten ship inside the binary. Four are mirador's own — `default` (this),
-# `default-light`, `high-contrast` and `ansi` — and six are ports of palettes
-# you may already be running elsewhere: `nord`, `gruvbox`, `dracula`,
-# `catppuccin-mocha`, `tokyo-night` and `solarized-dark`. All six are dark; on
-# a light terminal, `default-light` is the one to reach for.
+# Sixteen ship inside the binary. Four are mirador's own — `default` (this),
+# `default-light`, `high-contrast` and `ansi` — and twelve are ports of
+# palettes you may already be running elsewhere: `nord`, `gruvbox`,
+# `gruvbox-light`, `dracula`, `catppuccin-mocha`, `catppuccin-latte`,
+# `tokyo-night`, `kanagawa`, `solarized-dark`, `solarized-light`,
+# `everforest-light` and `rose-pine-dawn`. Five of the ports are light, so a
+# pale terminal has real choices beyond `default-light`.
 #
 # Anything in themes/<name>.toml beside this file is found first, so a bundled
 # theme can be replaced without renaming it. A theme file may `inherits`

--- a/assets/themes/catppuccin-latte.toml
+++ b/assets/themes/catppuccin-latte.toml
@@ -1,0 +1,67 @@
+# Catppuccin Latte — the one light flavour of the four.
+#
+# The mapping mirrors `catppuccin-mocha` role for role: mauve is still the
+# documented accent, and Latte's surface/overlay ramp provides the same three
+# distinct chrome greys the dark flavour has — just running away from a light
+# base instead of a dark one. Latte's accents are the saturated, darker
+# renderings of the same names, which is Catppuccin's own answer to keeping
+# contrast on paper.
+#
+# Values from github.com/catppuccin/catppuccin.
+
+border         = "surface1"
+border_focused = "mauve"
+rule           = "surface0"
+title          = "mauve"
+text           = "reset"
+muted          = "overlay0"
+label          = "teal"
+accent         = "mauve"
+key            = "blue"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "surface0"
+
+[palette]
+surface0 = "#ccd0da"
+surface1 = "#bcc0cc"
+overlay0 = "#9ca0b0"
+subtext0 = "#6c6f85"
+mauve    = "#8839ef"
+red      = "#d20f39"
+peach    = "#fe640b"
+yellow   = "#df8e1d"
+green    = "#40a02b"
+teal     = "#179299"
+sky      = "#04a5e5"
+blue     = "#1e66f5"
+lavender = "#7287fd"
+
+# Ramps start at the light surfaces, the mirror of mocha starting at its dark
+# ones: idle graphs recede into the latte rather than floating over it.
+
+[cpu_gradient]
+start = "#ccd0da"
+mid   = "#df8e1d"
+end   = "#d20f39"
+
+[rx_gradient]
+start = "#bcc0cc"
+mid   = "#04a5e5"
+end   = "#40a02b"
+
+[tx_gradient]
+start = "#bcc0cc"
+mid   = "#1e66f5"
+end   = "#8839ef"
+
+[gain_gradient]
+start = "#bcc0cc"
+mid   = "#40a02b"
+end   = "#40a02b"
+
+[loss_gradient]
+start = "#bcc0cc"
+mid   = "#d20f39"
+end   = "#d20f39"

--- a/assets/themes/everforest-light.toml
+++ b/assets/themes/everforest-light.toml
@@ -1,0 +1,66 @@
+# Everforest light — a green-based comfort palette, by Sainnhe Park.
+#
+# The medium light variant. Everforest's whole identity is green, so green
+# carries the focus and title the way orange carries Gruvbox's — and it doubles
+# as `success`, which the palette invites: its green *is* its statement of
+# things being well. Aqua takes the labels to keep two distinct green-family
+# tones in play, and the background ramp's own bg tones make an unusually
+# gentle chrome — the palette is designed so that even its greys leaf toward
+# green.
+#
+# Values from sainnhe/everforest's palette.md (light medium, palette1 + 2).
+
+border         = "bg5"
+border_focused = "green"
+rule           = "bg2"
+title          = "green"
+text           = "reset"
+muted          = "grey1"
+label          = "aqua"
+accent         = "green"
+key            = "purple"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "bg3"
+
+[palette]
+bg2    = "#efebd4"
+bg3    = "#e6e2cc"
+bg5    = "#bdc3af"
+grey1  = "#939f91"
+red    = "#f85552"
+orange = "#f57d26"
+yellow = "#dfa000"
+green  = "#8da101"
+aqua   = "#35a77c"
+blue   = "#3a94c5"
+purple = "#df69ba"
+
+# Light starts from the palette's own background ramp, so idle graphs sink
+# into the forest floor instead of standing on it.
+
+[cpu_gradient]
+start = "#e6e2cc"
+mid   = "#dfa000"
+end   = "#f85552"
+
+[rx_gradient]
+start = "#e6e2cc"
+mid   = "#35a77c"
+end   = "#8da101"
+
+[tx_gradient]
+start = "#e6e2cc"
+mid   = "#3a94c5"
+end   = "#df69ba"
+
+[gain_gradient]
+start = "#e6e2cc"
+mid   = "#8da101"
+end   = "#8da101"
+
+[loss_gradient]
+start = "#e6e2cc"
+mid   = "#f85552"
+end   = "#f85552"

--- a/assets/themes/gruvbox-light.toml
+++ b/assets/themes/gruvbox-light.toml
@@ -1,0 +1,65 @@
+# Gruvbox light — retro groove in daylight, by Pavel Pertsev.
+#
+# The mapping mirrors the dark `gruvbox` file role for role, using Gruvbox's
+# own light-mode answer to each colour: where dark mode reaches for the
+# "bright" accents, light mode uses the "faded" set — the same hues pulled
+# darker so they hold their contrast on cream — and the dark greys give way to
+# the light background ramp. The signature orange stays the accent, exactly as
+# it is in the dark file.
+#
+# Values from morhetz/gruvbox-contrib's colour table.
+
+border         = "light3"
+border_focused = "faded-orange"
+rule           = "light1"
+title          = "faded-orange"
+text           = "reset"
+muted          = "gray"
+label          = "faded-aqua"
+accent         = "faded-orange"
+key            = "faded-yellow"
+success        = "faded-green"
+warning        = "faded-yellow"
+error          = "faded-red"
+track          = "light1"
+
+[palette]
+light1       = "#ebdbb2"
+light2       = "#d5c4a1"
+light3       = "#bdae93"
+gray         = "#928374"
+faded-red    = "#9d0006"
+faded-green  = "#79740e"
+faded-yellow = "#b57614"
+faded-blue   = "#076678"
+faded-purple = "#8f3f71"
+faded-aqua   = "#427b58"
+faded-orange = "#af3a03"
+
+# Light starts for the ramps, mirroring where the dark file starts at its
+# own chrome: an idle graph should recede into the parchment, not stain it.
+
+[cpu_gradient]
+start = "#ebdbb2"
+mid   = "#b57614"
+end   = "#9d0006"
+
+[rx_gradient]
+start = "#d5c4a1"
+mid   = "#427b58"
+end   = "#79740e"
+
+[tx_gradient]
+start = "#d5c4a1"
+mid   = "#8f3f71"
+end   = "#076678"
+
+[gain_gradient]
+start = "#d5c4a1"
+mid   = "#79740e"
+end   = "#79740e"
+
+[loss_gradient]
+start = "#d5c4a1"
+mid   = "#9d0006"
+end   = "#9d0006"

--- a/assets/themes/kanagawa.toml
+++ b/assets/themes/kanagawa.toml
@@ -1,0 +1,67 @@
+# Kanagawa — colours of Hokusai's Great Wave, by Tommaso Laurenzi.
+#
+# The wave variant, which is the one people mean by "kanagawa". Muted ink
+# backgrounds under low-saturation pastels — closer in temperament to mirador's
+# own default than any other port here, dark wood and old paper rather than
+# neon. Crystal blue is the scheme's de facto accent (it is what the upstream
+# theme paints functions, the thing you look at). `warning` is roninYellow and
+# `error` peachRed, Kanagawa's own softer diagnostic pair — samuraiRed exists
+# but is a shout, and this dashboard does not shout.
+#
+# Values from rebelot/kanagawa.nvim's colors.lua.
+
+border         = "sumi-ink6"
+border_focused = "crystal-blue"
+rule           = "sumi-ink4"
+title          = "crystal-blue"
+text           = "reset"
+muted          = "fuji-gray"
+label          = "wave-aqua2"
+accent         = "crystal-blue"
+key            = "oni-violet"
+success        = "spring-green"
+warning        = "ronin-yellow"
+error          = "peach-red"
+track          = "sumi-ink5"
+
+[palette]
+sumi-ink4    = "#2A2A37"
+sumi-ink5    = "#363646"
+sumi-ink6    = "#54546D"
+fuji-gray    = "#727169"
+old-white    = "#C8C093"
+crystal-blue = "#7E9CD8"
+spring-blue  = "#7FB4CA"
+wave-aqua2   = "#7AA89F"
+spring-green = "#98BB6C"
+carp-yellow  = "#E6C384"
+ronin-yellow = "#FF9E3B"
+oni-violet   = "#957FB8"
+sakura-pink  = "#D27E99"
+wave-red     = "#E46876"
+peach-red    = "#FF5D62"
+
+[cpu_gradient]
+start = "#363646"
+mid   = "#E6C384"
+end   = "#FF5D62"
+
+[rx_gradient]
+start = "#363646"
+mid   = "#7AA89F"
+end   = "#98BB6C"
+
+[tx_gradient]
+start = "#363646"
+mid   = "#7FB4CA"
+end   = "#957FB8"
+
+[gain_gradient]
+start = "#363646"
+mid   = "#98BB6C"
+end   = "#98BB6C"
+
+[loss_gradient]
+start = "#363646"
+mid   = "#E46876"
+end   = "#FF5D62"

--- a/assets/themes/rose-pine-dawn.toml
+++ b/assets/themes/rose-pine-dawn.toml
@@ -1,0 +1,66 @@
+# Rosé Pine Dawn — "all natural pine, faux fur and a bit of soho vibes",
+# in its light variant.
+#
+# Rosé Pine names its colours by role rather than hue, and the roles map onto
+# mirador's almost one to one: their `muted` is mirador's muted, their
+# highlight ramp is the chrome, and rose — the palette's namesake — takes the
+# accent. The one judgement call is `success`: the palette has no green, and
+# pine is what Rosé Pine's own terminal ports assign to green, so pine it is.
+# Gold and love are similarly their yellow and red.
+#
+# Values from rose-pine/neovim's palette.lua (the canonical role table).
+
+border         = "highlight-high"
+border_focused = "rose"
+rule           = "overlay"
+title          = "rose"
+text           = "reset"
+muted          = "subtle"
+label          = "foam"
+accent         = "rose"
+key            = "iris"
+success        = "pine"
+warning        = "gold"
+error          = "love"
+track          = "highlight-med"
+
+[palette]
+overlay        = "#f2e9e1"
+highlight-low  = "#f4ede8"
+highlight-med  = "#dfdad9"
+highlight-high = "#cecacd"
+subtle         = "#797593"
+love           = "#b4637a"
+gold           = "#ea9d34"
+rose           = "#d7827e"
+pine           = "#286983"
+foam           = "#56949f"
+iris           = "#907aa9"
+
+# Ramps rise out of the overlay tone, the palest chrome the palette has, so
+# an idle graph is barely a watermark on the dawn background.
+
+[cpu_gradient]
+start = "#f2e9e1"
+mid   = "#ea9d34"
+end   = "#b4637a"
+
+[rx_gradient]
+start = "#f2e9e1"
+mid   = "#56949f"
+end   = "#286983"
+
+[tx_gradient]
+start = "#f2e9e1"
+mid   = "#d7827e"
+end   = "#907aa9"
+
+[gain_gradient]
+start = "#f2e9e1"
+mid   = "#286983"
+end   = "#286983"
+
+[loss_gradient]
+start = "#f2e9e1"
+mid   = "#b4637a"
+end   = "#b4637a"

--- a/assets/themes/solarized-light.toml
+++ b/assets/themes/solarized-light.toml
@@ -1,0 +1,70 @@
+# Solarized light — by Ethan Schoonover.
+#
+# The daylight half of the same measured-contrast design as `solarized-dark`,
+# and the mapping mirrors it: the accents are identical by design — Solarized
+# shares its eight accents across both modes and swaps only the base greys —
+# so this file differs from its sibling exactly where Solarized itself does.
+#
+# The greys invert with the background: base2 (cream chrome) takes the roles
+# base02 (near-black chrome) has in the dark file, and secondary text moves
+# from base0 down to base00, the darker grey a pale background needs. As in
+# the dark file, `muted` and `border` are deliberately one step apart so
+# secondary text and chrome never blur together.
+#
+# Values from ethanschoonover.com/solarized.
+
+border         = "base1"
+border_focused = "blue"
+rule           = "base2"
+title          = "blue"
+text           = "reset"
+muted          = "base00"
+label          = "cyan"
+accent         = "blue"
+key            = "violet"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "base2"
+
+[palette]
+base2   = "#eee8d5"
+base1   = "#93a1a1"
+base0   = "#839496"
+base00  = "#657b83"
+yellow  = "#b58900"
+orange  = "#cb4b16"
+red     = "#dc322f"
+magenta = "#d33682"
+violet  = "#6c71c4"
+blue    = "#268bd2"
+cyan    = "#2aa198"
+green   = "#859900"
+
+# Ramps start at the cream chrome rather than a dark tone, so an idle graph
+# recedes into a pale background instead of sitting on it as a smudge.
+
+[cpu_gradient]
+start = "#eee8d5"
+mid   = "#b58900"
+end   = "#dc322f"
+
+[rx_gradient]
+start = "#eee8d5"
+mid   = "#2aa198"
+end   = "#859900"
+
+[tx_gradient]
+start = "#eee8d5"
+mid   = "#268bd2"
+end   = "#6c71c4"
+
+[gain_gradient]
+start = "#eee8d5"
+mid   = "#859900"
+end   = "#859900"
+
+[loss_gradient]
+start = "#eee8d5"
+mid   = "#dc322f"
+end   = "#dc322f"

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 325;
+        const CITED: usize = 327;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -62,18 +62,39 @@ const BUNDLED: &[(&str, &str)] = &[
     // be "improved" away from it. Someone picking `nord` wants Nord.
     ("nord", include_str!("../assets/themes/nord.toml")),
     ("gruvbox", include_str!("../assets/themes/gruvbox.toml")),
+    (
+        "gruvbox-light",
+        include_str!("../assets/themes/gruvbox-light.toml"),
+    ),
     ("dracula", include_str!("../assets/themes/dracula.toml")),
     (
         "catppuccin-mocha",
         include_str!("../assets/themes/catppuccin-mocha.toml"),
     ),
     (
+        "catppuccin-latte",
+        include_str!("../assets/themes/catppuccin-latte.toml"),
+    ),
+    (
         "tokyo-night",
         include_str!("../assets/themes/tokyo-night.toml"),
     ),
+    ("kanagawa", include_str!("../assets/themes/kanagawa.toml")),
     (
         "solarized-dark",
         include_str!("../assets/themes/solarized-dark.toml"),
+    ),
+    (
+        "solarized-light",
+        include_str!("../assets/themes/solarized-light.toml"),
+    ),
+    (
+        "everforest-light",
+        include_str!("../assets/themes/everforest-light.toml"),
+    ),
+    (
+        "rose-pine-dawn",
+        include_str!("../assets/themes/rose-pine-dawn.toml"),
     ),
 ];
 


### PR DESCRIPTION
The bundled set was ten with every port dark. This adds six — five light, one dark — so a pale terminal has real choices beyond `default-light`: `solarized-light`, `gruvbox-light`, `catppuccin-latte`, `rose-pine-dawn`, `everforest-light`, and `kanagawa` (Wave), the one broadly popular dark palette the set lacked.

All porting rules held: upstream hexes cited per file (everforest, kanagawa and rosé pine verified against their canonical palette files), mappings mirror each dark sibling using the palette's own light-mode set, `text = "reset"` everywhere, and light ramps start light per `default-light`'s rule. Every theme was driven in a real terminal and its border escapes decode to the exact upstream values; the `t` picker lists and previews all sixteen.

Existing themes untouched. Counts updated in the shipped config, README table, CONTRIBUTING and CLAUDE.md; comment-count guard 325 → 327.

Worth your eye before the next release: I verified the hexes are faithful and nothing breaks, but the aesthetic call on the light themes belongs to a light terminal and its owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)