### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-25
+
 ### Added
 
 - **Six more bundled themes, chosen light-first.** The first six ports were
@@ -17,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mirroring its dark sibling where one exists and body text left on the
   terminal's own foreground. Light themes start their graph ramps light, so
   an idle chart recedes into a pale background.
+
+### Changed
+
+- **NetBSD appears in the platform badge and the install table**, pointing at
+  pkgsrc's `sysutils/mirador` — the community package that arrived with
+  1.6.1's fix.
 
 ## [1.7.0] - 2026-08-25
 
@@ -1699,7 +1707,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/jchultarsky/mirador/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/jchultarsky/mirador/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/jchultarsky/mirador/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/jchultarsky/mirador/compare/v1.5.1...v1.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1738,13 +1738,14 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.7.0` is released**, on crates.io and as a GitHub release with binaries
+- **`1.8.0` is released**, on crates.io and as a GitHub release with binaries
   for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows
-  x86-64. It wires the gain/loss ramps into the markets panel and carries the
-  documentation catch-up; 1.6.1 before it fixed the address-family fallback,
-  confirmed on NetBSD (#205, now packaged as pkgsrc `sysutils/mirador`), and
-  1.6.0 shipped the external panel protocol, so v1 of that protocol is a
-  compatibility promise. The aarch64 Linux
+  x86-64. It brings the bundled themes to sixteen (the light-first batch,
+  owner-approved on rendered captures) and puts NetBSD in the README's badge;
+  1.7.0 wired the gain/loss ramps and the doc catch-up, 1.6.1 fixed the
+  address-family fallback confirmed on NetBSD (#205, now pkgsrc
+  `sysutils/mirador`), and 1.6.0 shipped the external panel protocol, so v1
+  of that protocol is a compatibility promise. The aarch64 Linux
   archive first shipped in 1.5.1 and was executed the same day by its
   contributor — "it starts and draws" on Fedora 44 Asahi
   ([#197](https://github.com/jchultarsky/mirador/pull/197)) — so every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump. 1.8.0 carries the six new bundled themes (#216 — five light plus kanagawa, the light five approved by the owner on rendered captures) and NetBSD's promotion into the platform badge and install table (#217).

CHANGELOG moves the Unreleased entries under [1.8.0] with link references, plus a line for the NetBSD README change; CLAUDE.md's released-version note updated in the same commit as its guard requires. Step 0 done: the release build driven under tmux — dashboard drew with live data, the t picker lists the new themes, clean q exit.

After merge: tag v1.8.0 on the squashed commit, release workflow, attestation checks with the wrong-repo control, cargo publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)