### PR TITLE
OSC 8 hyperlinks: the prototype, then clickable news headlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Headlines are hyperlinks.** In a terminal that renders OSC 8 links —
+  iTerm2, WezTerm, kitty, recent GNOME Terminal among them — a news headline
+  is now clickable and opens the story the way the terminal opens any link
+  (usually a modifier plus a click, since mirador holds the mouse). Nothing
+  changes anywhere else: the sequences occupy no cells, so a terminal
+  without support shows exactly the panel it always did, and `o`, `y` and
+  `↵` are untouched. A feed's URL rides *inside* an escape sequence, so only
+  plain `http(s)` URLs made of RFC 3986 characters are linked — anything
+  else (a control byte smuggled through an entity, an off-web scheme) gets
+  no link rather than an escaped one.
+
 ### Changed
 
 - **`quick-xml` 0.41 → 0.42**, which rebuilt its API around `str` instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1675,11 +1675,39 @@ focus events still do not survive zellij.
 One thing is parked on its merits rather than forgotten. **OSC 8 hyperlinks**
 were the third mechanism in the news-link design; `y` and `[news].open_command`
 shipped and this did not. It would make a link genuinely clickable, which is
-better than either, and it fights ratatui's renderer: cells are written as cells,
-not as escape sequences, and a *wrapped* link has to carry the same target across
-several rows. It wants a prototype before it wants a promise. Note also that
-1.0.0 is out, so anything that changes a config key or a data file now costs a
-major version.
+better than either. The prototype it wanted now exists —
+`examples/osc8_probe.rs`, verified byte-for-byte under tmux by capturing the
+pane's raw stream with `pipe-pane` (method in the example's docs). What it
+established:
+
+- The "fights ratatui's renderer" objection this paragraph used to make is
+  dated: ratatui 0.30 grew the exact hook the feature needs.
+  `CellDiffOption::ForcedWidth` lets a cell's symbol carry zero-width escape
+  sequences around its glyph while declaring its real width, and the
+  crossterm backend prints symbols verbatim. No fork, no upstream work.
+- **Every linked cell must be self-contained** — open sequence, glyph, close
+  sequence, all sharing an `id=` parameter so the terminal reads the run as
+  one link. The obvious alternative, open on the first cell and close on the
+  last, is unsound against the diff, and the probe demonstrates it on the
+  wire (its case F): OSC 8 is modal, so a partial re-emission either strips
+  linkage from the rewritten cells or leaks the open state onto everything
+  printed after them. The shared id is also the whole wrapped-link answer —
+  one call per row, same id, one logical link across rows.
+- The diff stays minimal: over a 30-frame run with a ticker forcing a diff
+  every frame, a static link's cells hit the wire exactly once, and a label
+  flip re-emitted only its changed cells, each self-contained. Wide glyphs
+  cost one emission per glyph rather than per column, and the columns after
+  them do not drift.
+- tmux 3.4 stores the link per cell and re-emits it (`capture-pane -e` shows
+  it back), so links survive the multiplexer mirador expects to live inside.
+
+What remains is product work, not renderer work: applying it to the news
+panel wants a grapheme-walking `linkify` (the probe's callers align ranges by
+construction), and a real click in a hyperlink-capable terminal is the one
+thing a headless rig cannot prove. No config key or data file changes are
+implied — a link is free where the terminal supports it and invisible bytes
+where it does not, so the major-version note that used to close this
+paragraph does not apply to this feature.
 
 When something goes back on this list, put the *reason* beside it. Every entry
 that was ever useful here said why it mattered; the one that got quietly dropped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,9 @@ theme_picker.rs the `t` dialog — same shape, but previews as the cursor moves
 arrange.rs   the `m` mode's arithmetic: where a panel goes when you move it
 prompt.rs    the one-line question a panel asks for a path, place or zone,
              with an optional list to choose from
+link.rs      OSC 8 hyperlinks punched into rendered cells — one self-contained
+             sequence per glyph, and the strict allowlist a URL must pass to
+             ride inside an escape sequence at all
 zones.rs     world clocks as a data file, plus the city→zone table
 migrate.rs   textual in-place upgrade of configs written by older versions
 layout_edit.rs surgical `[layout]` rewrites, so panel changes reach the config
@@ -1701,13 +1704,22 @@ established:
 - tmux 3.4 stores the link per cell and re-emits it (`capture-pane -e` shows
   it back), so links survive the multiplexer mirador expects to live inside.
 
-What remains is product work, not renderer work: applying it to the news
-panel wants a grapheme-walking `linkify` (the probe's callers align ranges by
-construction), and a real click in a hyperlink-capable terminal is the one
-thing a headless rig cannot prove. No config key or data file changes are
-implied — a link is free where the terminal supports it and invisible bytes
-where it does not, so the major-version note that used to close this
-paragraph does not apply to this feature.
+The product work that remained after the probe is done: `link.rs` carries the
+per-glyph `linkify` — walking by each glyph's measured width, which is the
+only way to skip the covered cell behind a wide character, since the buffer
+resets it to something indistinguishable from a real space — plus the
+allowlist a URL must pass to ride inside an escape sequence at all. A feed
+link with a control byte smuggled through an `&#27;` entity, or any scheme
+but `http(s)`, gets no link rather than an escaped one: there is no encoding
+a terminal is guaranteed to undo, and a headline without a link loses nothing
+but the shortcut. The news panel punches links in *after* the `List` draws,
+so the link wraps whatever actually reached the screen, shifted by the
+two-cell highlight gutter once a selection exists. No config key and no data
+file changed, so no major version is implied.
+
+What is left is the one thing a headless rig cannot prove: a real click in a
+hyperlink-capable terminal. `cargo run` in iTerm2 or WezTerm and
+modifier-click a headline; when that lands, this entry closes.
 
 When something goes back on this list, put the *reason* beside it. Every entry
 that was ever useful here said why it mattered; the one that got quietly dropped

--- a/README.md
+++ b/README.md
@@ -579,6 +579,13 @@ panel holds the newest from *each* feed. Sorting by date alone hands the whole
 window to whichever outlet publishes most often, which is fresh but is not a
 window on the world.
 
+The headline itself is a hyperlink in terminals that render OSC 8 — iTerm2,
+WezTerm, kitty, recent GNOME Terminal among them — so clicking it the way your
+terminal opens links (usually a modifier plus a click, since mirador holds the
+mouse) goes straight to the story. No key, no configuration, and no cost
+anywhere else: where the terminal does not support it the link is invisible
+bytes and the panel reads identically. The three keys below work everywhere.
+
 `o` shows the selected story's link, in brass beneath a `↳`, wrapped whole so
 you can read all of it.
 

--- a/examples/osc8_probe.rs
+++ b/examples/osc8_probe.rs
@@ -1,0 +1,293 @@
+//! OSC 8 hyperlink probe — the prototype the parked item in CLAUDE.md asked
+//! for before any promise gets made.
+//!
+//! The question it answers: can OSC 8 hyperlinks be pushed through ratatui's
+//! cell-diffing renderer cleanly — sequences intact on the wire, no column
+//! drift, no unpaired state, and a story for a link that wraps onto a second
+//! row?
+//!
+//! The mechanism under test is ratatui 0.30's `CellDiffOption::ForcedWidth`:
+//! a cell's symbol may carry zero-width control sequences around its glyph,
+//! with the declared width keeping the buffer's column arithmetic honest.
+//! The backend prints symbols verbatim, so the sequences reach the terminal
+//! exactly as written. Links are applied by post-processing the frame buffer
+//! after the widgets have drawn — the same order a mirador panel would use,
+//! and the reason the text underneath stays subject to `grid`'s clipping
+//! rules: the link is punched into cells that already obey invariant 19.
+//!
+//! **Every linked cell is self-contained** — open sequence, glyph, close
+//! sequence — with a shared `id=` parameter so the terminal treats the run
+//! as one link. The tempting alternative, opening on the first cell and
+//! closing on the last, is unsound against the diff: OSC 8 is *modal*, and
+//! the diff re-emits whichever cells changed. A middle-only change rewrites
+//! cells with no link active (linkage silently lost), and a change that
+//! re-emits the opener without the closer leaks link state onto every cell
+//! printed after it. Case F below builds the span version on purpose so the
+//! captured byte stream shows the failure; nothing real should use it.
+//!
+//! Run it interactively (`cargo run --example osc8_probe`) in a terminal
+//! that renders hyperlinks (iTerm2, `WezTerm`, kitty, recent GNOME Terminal)
+//! and the labels are clickable. Run it headlessly for the byte-level
+//! evidence:
+//!
+//! ```sh
+//! tmux -L osc8 new-session -d -x 80 -y 24
+//! tmux -L osc8 pipe-pane -t 0 -o 'cat >> /tmp/osc8-raw.bin'
+//! tmux -L osc8 send-keys -t 0 'cargo run --example osc8_probe -- --ticks 30' Enter
+//! # wait, then inspect /tmp/osc8-raw.bin for \x1b]8; sequences
+//! ```
+//!
+//! `--ticks N` renders N frames at ~100ms and exits without a keypress, so a
+//! harness can count emissions deterministically. Without it, `q` or Ctrl+C
+//! quits — the probe honours the exit guarantee even though no panel here
+//! captures input.
+
+use std::num::NonZeroU16;
+use std::time::Duration;
+
+use ratatui::Frame;
+use ratatui::buffer::{Buffer, CellDiffOption};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, BorderType};
+use unicode_width::UnicodeWidthStr;
+
+const BRASS: Color = Color::Rgb(0xd7, 0xaf, 0x87);
+const VERDIGRIS: Color = Color::Rgb(0x5f, 0x87, 0x87);
+
+fn main() {
+    let ticks: Option<u32> = {
+        let args: Vec<String> = std::env::args().collect();
+        args.iter()
+            .position(|a| a == "--ticks")
+            .and_then(|i| args.get(i + 1))
+            .and_then(|n| n.parse().ok())
+    };
+
+    let mut terminal = ratatui::init();
+    let mut frame_no: u32 = 0;
+    loop {
+        terminal
+            .draw(|frame| draw(frame, frame_no))
+            .expect("drawing the probe frame");
+        frame_no += 1;
+        if let Some(limit) = ticks
+            && frame_no >= limit
+        {
+            break;
+        }
+        if event::poll(Duration::from_millis(100)).unwrap_or(false)
+            && let Ok(Event::Key(key)) = event::read()
+        {
+            let ctrl_c =
+                key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+            if key.code == KeyCode::Char('q') || ctrl_c {
+                break;
+            }
+        }
+    }
+    ratatui::restore();
+}
+
+#[allow(clippy::too_many_lines)] // a display of numbered cases, not logic
+fn draw(frame: &mut Frame, frame_no: u32) {
+    let area = Rect::new(
+        0,
+        0,
+        74.min(frame.area().width),
+        14.min(frame.area().height),
+    );
+    let block = Block::bordered()
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(BRASS))
+        .title("┤OSC 8 PROBE├");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width < 60 || inner.height < 11 {
+        return;
+    }
+
+    let label = Style::default().fg(VERDIGRIS).add_modifier(Modifier::BOLD);
+    let linkish = Style::default().add_modifier(Modifier::UNDERLINED);
+    let buf = frame.buffer_mut();
+    let x = inner.x;
+    let y = inner.y;
+
+    // Case A: a static link. With the ticker below forcing a fresh diff every
+    // frame, its cells must reach the wire exactly once across the whole run.
+    buf.set_string(x, y, "STATIC   Example Domain", label);
+    buf.set_style(Rect::new(x + 9, y, 14, 1), linkish);
+    linkify(
+        buf,
+        y,
+        x + 9,
+        x + 23,
+        "https://example.com/static",
+        "probe-static",
+    );
+
+    // Case B: no link at all — it exists to change every frame so the diff
+    // machinery runs, which is what makes case A's count meaningful.
+    buf.set_string(x, y + 1, format!("TICKER   frame {frame_no:06}"), label);
+
+    // Case C: a link whose label flips every 10 frames, so re-emission
+    // through the diff is exercised on purpose. Both labels are 11 cells and
+    // share the "state " prefix, so a flip rewrites only the changed tail —
+    // which self-contained cells survive and a spanning link would not.
+    let toggled = if (frame_no / 10).is_multiple_of(2) {
+        "state alpha"
+    } else {
+        "state beta "
+    };
+    buf.set_string(x, y + 2, format!("TOGGLE   {toggled}"), label);
+    buf.set_style(Rect::new(x + 9, y + 2, 11, 1), linkish);
+    linkify(
+        buf,
+        y + 2,
+        x + 9,
+        x + 20,
+        "https://example.com/toggle",
+        "probe-toggle",
+    );
+
+    // Case D: one logical link wrapped across two rows. The shared id= is
+    // what tells the terminal every cell belongs to the same link, so
+    // hovering either row highlights both.
+    let row1 = "this headline is long enough that it";
+    let row2 = "continues on the following row";
+    buf.set_string(x, y + 3, format!("WRAPPED  {row1}"), label);
+    buf.set_string(x + 9, y + 4, row2, label);
+    buf.set_style(Rect::new(x + 9, y + 3, row1.width() as u16, 1), linkish);
+    buf.set_style(Rect::new(x + 9, y + 4, row2.width() as u16, 1), linkish);
+    let wrap_url = "https://example.com/wrapped";
+    linkify(
+        buf,
+        y + 3,
+        x + 9,
+        x + 9 + row1.width() as u16,
+        wrap_url,
+        "probe-wrap",
+    );
+    linkify(
+        buf,
+        y + 4,
+        x + 9,
+        x + 9 + row2.width() as u16,
+        wrap_url,
+        "probe-wrap",
+    );
+
+    // Case E: wide glyphs inside a link, with a column marker to make drift
+    // visible. The `|` on both rows must line up in a capture; if ForcedWidth
+    // lied about a cell, the second one moves.
+    let wide = "日本語 link";
+    buf.set_string(
+        x,
+        y + 5,
+        format!("         {:w$}|", "", w = wide.width()),
+        label,
+    );
+    buf.set_string(x, y + 6, format!("WIDE     {wide}|"), label);
+    buf.set_style(Rect::new(x + 9, y + 6, wide.width() as u16, 1), linkish);
+    linkify(
+        buf,
+        y + 6,
+        x + 9,
+        x + 9 + wide.width() as u16,
+        "https://example.com/wide",
+        "probe-wide",
+    );
+
+    // Case F: the deliberately unsound spanning strategy — open on the first
+    // cell, close on the last — around a label whose middle flips while both
+    // ends hold still. The captured stream shows the flipped cells rewritten
+    // with no open sequence anywhere near them: those cells have silently
+    // left the link. This case exists to be read in the capture, not copied.
+    let mid = if (frame_no / 10).is_multiple_of(2) {
+        "aaaa"
+    } else {
+        "bbbb"
+    };
+    buf.set_string(x, y + 8, format!("SPANHAZ  fixed {mid} fixed"), label);
+    buf.set_style(Rect::new(x + 9, y + 8, 16, 1), linkish);
+    linkify_span(
+        buf,
+        y + 8,
+        x + 9,
+        x + 25,
+        "https://example.com/span-hazard",
+        "probe-span",
+    );
+
+    buf.set_string(
+        x,
+        y + 10,
+        "q quits · --ticks N for headless runs",
+        Style::default().fg(VERDIGRIS),
+    );
+}
+
+/// Turns the cells of row `y` from `x0` to `x1` (exclusive) into an OSC 8
+/// hyperlink, leaving the glyphs and styles the widgets drew untouched.
+///
+/// Every cell is made self-contained — open sequence, its own glyph, close
+/// sequence — declared at the glyph's real width via
+/// `CellDiffOption::ForcedWidth` so the escape bytes cost no columns. The
+/// shared `id` makes the cells one logical link to the terminal, and it is
+/// also what lets a wrapped link span rows: call this once per row with the
+/// same `id` and URL. Self-containment is what makes the scheme safe against
+/// partial redraws — see the module docs and case F for the alternative.
+///
+/// A continuation cell of a wide glyph (width 0) is left alone: it renders
+/// as the skipped half of its neighbour, and the neighbour's own sequences
+/// already cover both columns.
+fn linkify(buf: &mut Buffer, y: u16, x0: u16, x1: u16, url: &str, id: &str) {
+    let open = format!("\x1b]8;id={id};{url}\x1b\\");
+    let close = "\x1b]8;;\x1b\\";
+    for x in x0..x1 {
+        if cell_width(buf, x, y) > 0 {
+            wrap_cell(buf, x, y, &open, close);
+        }
+    }
+}
+
+/// The spanning variant — open rides in the first cell, close in the last —
+/// kept only so case F can demonstrate on the wire why it is unsound. OSC 8
+/// is modal, and the diff re-emits individual cells: a change confined to
+/// the middle of the span rewrites those cells with no link active, and a
+/// change that re-emits the opener without the closer would leak link state
+/// onto everything printed after it.
+fn linkify_span(buf: &mut Buffer, y: u16, x0: u16, x1: u16, url: &str, id: &str) {
+    if x1 <= x0 {
+        return;
+    }
+    let open = format!("\x1b]8;id={id};{url}\x1b\\");
+    let close = "\x1b]8;;\x1b\\";
+    if x1 == x0 + 1 {
+        wrap_cell(buf, x0, y, &open, close);
+        return;
+    }
+    wrap_cell(buf, x0, y, &open, "");
+    let mut last = x1 - 1;
+    if cell_width(buf, last, y) == 0 && last > x0 {
+        last -= 1;
+    }
+    wrap_cell(buf, last, y, "", close);
+}
+
+fn cell_width(buf: &Buffer, x: u16, y: u16) -> u16 {
+    buf.cell((x, y)).map_or(1, |c| c.symbol().width() as u16)
+}
+
+fn wrap_cell(buf: &mut Buffer, x: u16, y: u16, before: &str, after: &str) {
+    let Some(cell) = buf.cell_mut((x, y)) else {
+        return;
+    };
+    let glyph = cell.symbol().to_string();
+    let width = glyph.width().max(1) as u16;
+    cell.set_symbol(&format!("{before}{glyph}{after}"));
+    cell.set_diff_option(CellDiffOption::ForcedWidth(
+        NonZeroU16::new(width).expect("width floored at 1"),
+    ));
+}

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,0 +1,251 @@
+//! OSC 8 hyperlinks, punched into cells the widgets already drew.
+//!
+//! `linkify` runs after a panel has rendered, so the text underneath was
+//! measured, wrapped and clipped by the same code as everything else —
+//! invariant 19 is settled before a link exists. Each cell in the range is
+//! made *self-contained*: its symbol becomes open sequence + glyph + close
+//! sequence, declared at the glyph's real width via
+//! [`CellDiffOption::ForcedWidth`] so the escape bytes cost no columns. The
+//! shared `id=` parameter is what makes the run one logical link to the
+//! terminal, and it is also the whole answer for a link that wraps: call
+//! `linkify` once per row with the same id and URL.
+//!
+//! Self-containment is not a style choice. OSC 8 is *modal* — an open
+//! sequence stays in force until a close arrives — and ratatui's diff
+//! re-emits individual cells. A link spanning cells (open on the first,
+//! close on the last) breaks the moment the diff rewrites a subset: a
+//! middle-only change rewrites cells with no link active, and a re-emitted
+//! opener without its closer leaks link state onto everything printed after
+//! it. `examples/osc8_probe.rs` demonstrates both on a captured byte
+//! stream. With every cell self-contained, any subset the diff picks is
+//! consistent by construction.
+//!
+//! The URL rides *inside* an escape sequence, and the URLs mirador links to
+//! come from RSS feeds — the one input somebody else writes. An entity like
+//! `&#27;` puts a real escape byte in a parsed link, and a string terminator
+//! smuggled there would end the sequence early and feed the rest to the
+//! terminal as input. So `linkable` is a strict allowlist, the same shape as
+//! the quote module's symbol check: `http`/`https` only, RFC 3986 characters
+//! only, and anything else simply gets no link — the headline still renders,
+//! `o` and `y` still work.
+
+use std::num::NonZeroU16;
+
+use ratatui::buffer::{Buffer, CellDiffOption};
+use unicode_width::UnicodeWidthStr;
+
+/// Whether a URL is safe to embed in an OSC 8 sequence.
+///
+/// `http://` or `https://` and RFC 3986 characters only — unreserved,
+/// reserved, and `%`. Everything else, most importantly every control byte,
+/// refuses the whole link rather than escaping it: there is no encoding a
+/// terminal is guaranteed to undo, and a headline without a link loses
+/// nothing but the shortcut.
+pub fn linkable(url: &str) -> bool {
+    (url.starts_with("http://") || url.starts_with("https://"))
+        && url.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'-' | b'.'
+                        | b'_'
+                        | b'~'
+                        | b':'
+                        | b'/'
+                        | b'?'
+                        | b'#'
+                        | b'['
+                        | b']'
+                        | b'@'
+                        | b'!'
+                        | b'$'
+                        | b'&'
+                        | b'\''
+                        | b'('
+                        | b')'
+                        | b'*'
+                        | b'+'
+                        | b','
+                        | b';'
+                        | b'='
+                        | b'%'
+                )
+        })
+}
+
+/// Turns the cells of row `y` from `x0` to `x1` (exclusive) into an OSC 8
+/// hyperlink, leaving the glyphs and styles the widgets drew untouched.
+///
+/// A URL that fails [`linkable`] links nothing, silently — see the module
+/// docs for why refusal beats escaping. The `id` is truncated to the
+/// characters that are safe in a parameter (letters, digits, dash), which
+/// every caller-provided id already consists of; the guard exists so no
+/// future caller has to think about it.
+///
+/// The walk advances by each glyph's width, so the continuation cell behind
+/// a double-width glyph is passed over rather than wrapped: the buffer
+/// resets it to an empty cell indistinguishable from a real space, and the
+/// only way to know it is covered is to have measured its neighbour. `x0`
+/// must sit on a glyph boundary, which ranges taken from a `Line`'s own
+/// width are by construction. A range reaching past the buffer stops at the
+/// edge.
+pub fn linkify(buf: &mut Buffer, y: u16, x0: u16, x1: u16, url: &str, id: &str) {
+    if !linkable(url) {
+        return;
+    }
+    let id: String = id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-')
+        .collect();
+    let open = format!("\x1b]8;id={id};{url}\x1b\\");
+    let mut x = x0;
+    while x < x1 {
+        let Some(cell) = buf.cell_mut((x, y)) else {
+            return;
+        };
+        let glyph = cell.symbol().to_string();
+        // A symbol measuring 0 would stall the walk; treating it as 1 keeps
+        // the loop moving, the same guard `samples::push_bounded` carries.
+        let width = glyph.width().max(1) as u16;
+        cell.set_symbol(&format!("{open}{glyph}\x1b]8;;\x1b\\"));
+        cell.set_diff_option(CellDiffOption::ForcedWidth(
+            NonZeroU16::new(width).expect("width floored at 1"),
+        ));
+        x += width;
+    }
+}
+
+/// The text of `symbol` with any OSC 8 sequences removed.
+///
+/// For tests that read a rendered buffer back as a string: a linked cell's
+/// symbol carries the URL in escape bytes, so a substring assertion against
+/// the raw concatenation would see text nobody can see on screen.
+#[cfg(test)]
+pub fn without_links(symbol: &str) -> String {
+    let mut out = String::with_capacity(symbol.len());
+    let mut rest = symbol;
+    while let Some(start) = rest.find("\x1b]8;") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 4..];
+        match after.find("\x1b\\") {
+            Some(end) => rest = &after[end + 2..],
+            None => return out, // torn sequence: drop the tail, as a terminal would
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::layout::Rect;
+    use ratatui::style::{Modifier, Style};
+
+    use super::*;
+
+    fn buffer_with(text: &str) -> Buffer {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 2));
+        buf.set_string(0, 0, text, Style::default().add_modifier(Modifier::BOLD));
+        buf
+    }
+
+    #[test]
+    fn a_linked_cell_is_self_contained_and_keeps_its_width() {
+        let mut buf = buffer_with("news");
+        linkify(&mut buf, 0, 0, 4, "https://example.com/a", "story-1");
+
+        let cell = buf.cell((0, 0)).unwrap();
+        assert_eq!(
+            cell.symbol(),
+            "\x1b]8;id=story-1;https://example.com/a\x1b\\n\x1b]8;;\x1b\\",
+            "open sequence, the glyph, close sequence — nothing shared \
+             between cells, so any subset the diff re-emits is consistent"
+        );
+        assert_eq!(
+            cell.diff_option,
+            CellDiffOption::ForcedWidth(NonZeroU16::new(1).unwrap()),
+            "the declared width is the glyph's, or every column after \
+             this cell drifts"
+        );
+        assert!(
+            cell.modifier.contains(Modifier::BOLD),
+            "linkify must not disturb the style the widget chose"
+        );
+    }
+
+    #[test]
+    fn a_wide_glyph_keeps_its_width_and_its_continuation_cell() {
+        let mut buf = buffer_with("日x");
+        linkify(&mut buf, 0, 0, 3, "https://example.com/w", "story-2");
+
+        let wide = buf.cell((0, 0)).unwrap();
+        assert!(wide.symbol().contains('日'));
+        assert_eq!(
+            wide.diff_option,
+            CellDiffOption::ForcedWidth(NonZeroU16::new(2).unwrap()),
+            "a double-width glyph must declare both its columns"
+        );
+        let continuation = buf.cell((1, 0)).unwrap();
+        assert!(
+            !continuation.symbol().contains('\x1b'),
+            "the continuation cell is the covered half of its neighbour and \
+             must not grow sequences of its own; it holds {:?}",
+            continuation.symbol()
+        );
+        assert_eq!(continuation.diff_option, CellDiffOption::None);
+        let after = buf.cell((2, 0)).unwrap();
+        assert!(
+            after.symbol().contains('x') && after.symbol().contains("]8;"),
+            "the glyph after the wide one is back on a boundary and linked"
+        );
+    }
+
+    #[test]
+    fn an_unsafe_url_links_nothing() {
+        // Each of these reached a Story::link once upon parsing somebody
+        // else's feed: a smuggled escape byte (an `&#27;` entity), a BEL
+        // that terminates an OSC early, a scheme that is not the web, and
+        // a link the feed simply did not have.
+        for url in [
+            "https://example.com/\x1b]8;;evil",
+            "https://example.com/\x07",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "",
+        ] {
+            let mut buf = buffer_with("headline");
+            linkify(&mut buf, 0, 0, 8, url, "story-3");
+            for x in 0..8 {
+                let cell = buf.cell((x, 0)).unwrap();
+                assert!(
+                    !cell.symbol().contains('\x1b'),
+                    "url {url:?} must not reach the terminal, in a link or \
+                     otherwise; cell {x} holds {:?}",
+                    cell.symbol()
+                );
+                assert_eq!(cell.diff_option, CellDiffOption::None);
+            }
+        }
+    }
+
+    #[test]
+    fn a_range_past_the_buffer_edge_is_clipped_not_fatal() {
+        let mut buf = buffer_with("ok");
+        linkify(&mut buf, 0, 0, 200, "https://example.com/e", "story-4");
+        linkify(&mut buf, 9, 0, 4, "https://example.com/e", "story-4");
+        assert!(buf.cell((0, 0)).unwrap().symbol().contains("]8;"));
+    }
+
+    #[test]
+    fn stripping_links_recovers_exactly_the_visible_text() {
+        let mut buf = buffer_with("ab 日");
+        linkify(&mut buf, 0, 0, 5, "https://example.com/s", "story-5");
+        let text: String = (0..5)
+            .filter_map(|x| buf.cell((x, 0)).map(|c| without_links(c.symbol())))
+            .collect();
+        // The trailing space is the covered cell behind 日 — concatenating
+        // symbols has always shown it, links or no links.
+        assert_eq!(text, "ab 日 ");
+        assert_eq!(without_links("plain"), "plain");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod glyphs;
 mod grid;
 mod ical;
 mod layout_edit;
+mod link;
 mod migrate;
 mod note;
 mod panel;

--- a/src/widgets/news.rs
+++ b/src/widgets/news.rs
@@ -177,6 +177,40 @@ impl NewsPanel {
         }
     }
 
+    /// Punch an OSC 8 link into each headline's cells, so a terminal that
+    /// renders hyperlinks makes the headline itself clickable — and one that
+    /// does not sees only the glyphs, because the sequences cost no columns.
+    /// This runs after the `List` has drawn, so the link wraps whatever
+    /// actually reached the screen, and the per-story id keeps a wrapped
+    /// headline one logical link across its rows. `linkify` is the door every
+    /// URL goes through: a link a feed laced with control bytes or an off-web
+    /// scheme gets no sequence at all. The `List` shifts every line right by
+    /// its two-cell highlight symbol once a selection exists, and the links
+    /// have to follow.
+    fn link_headlines(&self, frame: &mut Frame, body: Rect, headline_rows: &[(u16, u16, usize)]) {
+        let indent = if self.selected.selected().is_some() {
+            2
+        } else {
+            0
+        };
+        let buf = frame.buffer_mut();
+        for &(y, w, index) in headline_rows {
+            if y >= body.y + body.height {
+                continue;
+            }
+            let x0 = body.x + indent;
+            let x1 = (x0 + w).min(body.x + body.width);
+            crate::link::linkify(
+                buf,
+                y,
+                x0,
+                x1,
+                &self.shown[index].link,
+                &format!("news-{index}"),
+            );
+        }
+    }
+
     /// The link of the story the cursor is on, or the top one when it has not
     /// been placed — the same rule `o` follows, so all three keys act on the
     /// same story.
@@ -427,9 +461,19 @@ impl Panel for NewsPanel {
         }
 
         let mut items: Vec<ListItem> = Vec::with_capacity(keep);
+        // `(row, width, story)` for every title row that will reach the
+        // screen, recorded while the blocks are still lines: once they become
+        // `ListItem`s their geometry is the widget's business, and the links
+        // punched in after the draw need to know where each headline landed.
+        let mut headline_rows: Vec<(u16, u16, usize)> = Vec::new();
+        let mut row = body.y;
         for (index, mut lines) in blocks.into_iter().take(keep).enumerate() {
             if clipped {
                 lines.truncate(budget);
+            }
+            // Every line after the masthead is a wrapped title row.
+            for (offset, line) in lines.iter().enumerate().skip(1) {
+                headline_rows.push((row + offset as u16, line.width() as u16, index));
             }
             // The gap goes *between* stories, not after every one. A trailing
             // blank on the last item costs a whole row, and `List` draws only
@@ -438,6 +482,7 @@ impl Panel for NewsPanel {
             if index + 1 != keep {
                 lines.push(Line::from(""));
             }
+            row += lines.len() as u16;
             items.push(ListItem::new(lines));
         }
 
@@ -466,6 +511,8 @@ impl Panel for NewsPanel {
             body,
             &mut self.selected,
         );
+
+        self.link_headlines(frame, body, &headline_rows);
 
         // A `(text, style)` pair rather than a `Span`, because the link case is
         // multi-line and a `Span` holding newlines renders as one line with the
@@ -852,7 +899,11 @@ mod tests {
             (0..12)
                 .map(|y| {
                     (0..46)
-                        .filter_map(|x| buffer.cell((x, y)).map(|c| c.symbol().to_string()))
+                        .filter_map(|x| {
+                            buffer
+                                .cell((x, y))
+                                .map(|c| crate::link::without_links(c.symbol()))
+                        })
                         .collect::<String>()
                 })
                 .collect::<Vec<_>>()
@@ -922,7 +973,11 @@ mod tests {
             let buffer = terminal.backend().buffer().clone();
             let screen: String = (0..height)
                 .flat_map(|y| (0..width).map(move |x| (x, y)))
-                .filter_map(|(x, y)| buffer.cell((x, y)).map(|c| c.symbol().to_string()))
+                .filter_map(|(x, y)| {
+                    buffer
+                        .cell((x, y))
+                        .map(|c| crate::link::without_links(c.symbol()))
+                })
                 .collect();
             let squashed: String = screen.chars().filter(|c| !c.is_whitespace()).collect();
 
@@ -945,6 +1000,184 @@ mod tests {
             published: Zoned::now()
                 .checked_sub(jiff::Span::new().minutes(minutes_ago))
                 .ok(),
+        }
+    }
+
+    /// Renders `panel` at the given size and hands back the raw buffer, links
+    /// and all — the tests below are about the escape sequences themselves,
+    /// which `without_links` would hide.
+    fn raw_buffer(panel: &mut NewsPanel, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| {
+                panel.render(
+                    frame,
+                    frame.area(),
+                    RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    /// The row whose visible text contains `needle`.
+    fn row_containing(buffer: &ratatui::buffer::Buffer, needle: &str) -> u16 {
+        let area = buffer.area;
+        (0..area.height)
+            .find(|y| {
+                let text: String = (0..area.width)
+                    .filter_map(|x| {
+                        buffer
+                            .cell((x, *y))
+                            .map(|c| crate::link::without_links(c.symbol()))
+                    })
+                    .collect();
+                text.contains(needle)
+            })
+            .unwrap_or_else(|| panic!("no row shows {needle:?}"))
+    }
+
+    /// The headline itself is now the link: every glyph cell of a title row
+    /// carries a self-contained OSC 8 sequence naming the story's URL, and
+    /// the masthead above it carries none. What the reader *sees* does not
+    /// change — the sequences cost no cells — which is what keeps this on the
+    /// right side of the calm-panel commitments.
+    #[test]
+    fn a_headline_is_a_link_to_its_story() {
+        let mut panel = NewsPanel::new(&NewsConfig {
+            feeds: Vec::new(),
+            ..NewsConfig::default()
+        });
+        panel.shown = vec![
+            Story {
+                link: "https://example.test/one".into(),
+                ..story("NASA", "Orbit story", 5)
+            },
+            Story {
+                link: "https://example.test/two".into(),
+                ..story("BBC", "Second story", 10)
+            },
+        ];
+        let buffer = raw_buffer(&mut panel, 46, 12);
+
+        let title_row = row_containing(&buffer, "Orbit story");
+        let first = buffer.cell((0, title_row)).unwrap();
+        assert!(
+            first
+                .symbol()
+                .starts_with("\x1b]8;id=news-0;https://example.test/one\x1b\\"),
+            "the first title cell must open its story's link, got {:?}",
+            first.symbol()
+        );
+        assert!(
+            first.symbol().ends_with("\x1b]8;;\x1b\\"),
+            "every linked cell closes its own sequence — OSC 8 is modal, and \
+             a cell that leaves it open leaks the link onto whatever the diff \
+             prints next"
+        );
+
+        let masthead_row = row_containing(&buffer, "NASA");
+        let masthead: String = (0..46)
+            .filter_map(|x| {
+                buffer
+                    .cell((x, masthead_row))
+                    .map(|c| c.symbol().to_string())
+            })
+            .collect();
+        assert!(
+            !masthead.contains('\x1b'),
+            "the masthead is not part of the link"
+        );
+
+        let second_row = row_containing(&buffer, "Second story");
+        assert!(
+            buffer
+                .cell((0, second_row))
+                .unwrap()
+                .symbol()
+                .contains("id=news-1;https://example.test/two"),
+            "each story links to its own URL under its own id"
+        );
+    }
+
+    /// A headline that wraps is one logical link: every row repeats the same
+    /// id and URL, which is what tells the terminal the rows belong together.
+    #[test]
+    fn a_wrapped_headline_is_one_logical_link_across_its_rows() {
+        let mut panel = NewsPanel::new(&NewsConfig {
+            feeds: Vec::new(),
+            ..NewsConfig::default()
+        });
+        panel.shown = vec![Story {
+            link: "https://example.test/long".into(),
+            ..story(
+                "NASA",
+                "A headline comfortably long enough to wrap onto a second row",
+                5,
+            )
+        }];
+        let buffer = raw_buffer(&mut panel, 30, 12);
+
+        let first_row = row_containing(&buffer, "A headline");
+        let mut linked_rows = 0;
+        for y in first_row..buffer.area.height {
+            let symbol = buffer.cell((0, y)).unwrap().symbol().to_string();
+            if symbol.contains("]8;") {
+                assert!(
+                    symbol.contains("id=news-0;https://example.test/long"),
+                    "row {y} of the wrapped headline must carry the same id \
+                     and URL as the first, got {symbol:?}"
+                );
+                linked_rows += 1;
+            }
+        }
+        assert!(
+            linked_rows >= 2,
+            "the title was meant to wrap; only {linked_rows} linked row(s) \
+             found — widen the fixture if wrapping changed"
+        );
+    }
+
+    /// A feed is the one input somebody else writes, and its link rides
+    /// *inside* an escape sequence — so a URL carrying control bytes (an
+    /// `&#27;` entity is all it takes) or an off-web scheme gets no sequence
+    /// at all. The headline still renders; only the shortcut is withheld.
+    #[test]
+    fn a_hostile_link_never_reaches_the_terminal() {
+        for link in [
+            "https://example.test/\x1b]8;;https://evil.test\x1b\\",
+            "https://example.test/\x07",
+            "file:///etc/passwd",
+        ] {
+            let mut panel = NewsPanel::new(&NewsConfig {
+                feeds: Vec::new(),
+                ..NewsConfig::default()
+            });
+            panel.shown = vec![Story {
+                link: link.into(),
+                ..story("NASA", "An ordinary headline", 5)
+            }];
+            let buffer = raw_buffer(&mut panel, 46, 12);
+
+            let title_row = row_containing(&buffer, "An ordinary headline");
+            for x in 0..46 {
+                let symbol = buffer.cell((x, title_row)).unwrap().symbol().to_string();
+                assert!(
+                    !symbol.contains('\x1b'),
+                    "link {link:?} must not reach the terminal; cell {x} \
+                     holds {symbol:?}"
+                );
+            }
         }
     }
 
@@ -1297,7 +1530,11 @@ mod tests {
         (0..height)
             .map(|y| {
                 (0..width)
-                    .filter_map(|x| buffer.cell((x, y)).map(|c| c.symbol().to_string()))
+                    .filter_map(|x| {
+                        buffer
+                            .cell((x, y))
+                            .map(|c| crate::link::without_links(c.symbol()))
+                    })
                     .collect::<String>()
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
# Summary

Two commits, in the order the parked item in CLAUDE.md asked for them. First the prototype that proves OSC 8 hyperlinks survive ratatui's cell-diffing renderer (`examples/osc8_probe.rs`); then the feature built on its findings: **every news headline is now a clickable hyperlink** in terminals that render OSC 8, and exactly the panel it always was everywhere else.

## What changed

**Commit 1 — the prototype** (`examples/osc8_probe.rs`): five link cases and one deliberate counter-example, verified byte-for-byte under tmux. It established that ratatui 0.30's `CellDiffOption::ForcedWidth` is the whole mechanism (a cell's symbol carries zero-width escape sequences while declaring its true width), that the diff stays minimal, and that **every linked cell must be self-contained** — OSC 8 is modal, and a spanning link partially rewritten by the diff either drops linkage or leaks link state; the probe's case F shows this failing on the wire.

**Commit 2 — the feature**:

- **`src/link.rs`** — `linkify` wraps each glyph cell of a range in its own open + glyph + close sequence under a shared `id=`, which is also the whole wrapped-link answer: one call per row, same id, one logical link. The walk advances by each glyph's *measured width*, because the buffer resets the covered cell behind a wide character to something indistinguishable from a real space — width-0 detection was tried first and cannot work.
- **Security boundary**: the URL rides *inside* an escape sequence, and feed links are the one input somebody else writes — an `&#27;` entity is all it takes to smuggle a sequence terminator. `linkable()` is a strict allowlist (`http`/`https`, RFC 3986 characters); anything else gets **no link rather than an escaped one**, since no encoding is guaranteed to survive every terminal. The headline still renders; only the shortcut is withheld.
- **`src/widgets/news.rs`** — headline geometry is recorded while the story blocks are still lines, and links are punched in *after* the `List` draws (shifted by the two-cell highlight gutter once a selection exists), so the link covers exactly what reached the screen. `o`, `y`, and `↵` are unchanged.
- No new config key, no data file change — a link is free where the terminal supports it and invisible bytes where it does not.

## How it was tested

- **Unit tests at both layers**, each verified red by breaking the code on purpose (the repo's discipline): removing the `linkify` call fails the headline tests; weakening `linkable` fails the hostile-URL tests in both `link.rs` and the panel. Coverage: self-contained cells at their declared widths, wide-glyph continuation cells left bare, one id across a wrapped headline's rows, masthead unlinked, hostile URLs (smuggled ESC, BEL, `file://`) never reaching the terminal.
- **End to end on the real binary**: mirador run under tmux 3.4 against a local RSS feed, raw byte stream captured with `pipe-pane` — 135 opens, 135 closes, strictly alternating, stream ends closed; the short headline's 29 glyphs under `id=news-0`, the wrapped headline's 106 glyphs across two rows all under `id=news-1`; visible capture pixel-identical to the pre-change panel.
- Existing tests that read rendered buffers now strip link sequences first (`link::without_links`), since a raw concatenation would assert against bytes nobody sees — the no-counter test caught this itself when the id `news-0` put the literal word "new" into raw buffer text.
- Not machine-checkable: a real mouse click. `cargo run` in iTerm2/WezTerm/kitty and modifier-click a headline.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes (828 tests)
- [x] New behaviour has tests, or there is a note below explaining why not — three panel tests and five `link.rs` tests, all proven able to fail
- [x] `CHANGELOG.md` updated under `Unreleased` — "Headlines are hyperlinks"
- [x] Documentation updated: README news section gains the hyperlink paragraph; no config option to document; CLAUDE.md's architecture map and open-work entry updated

## Notes for the reviewer

- The probe's case F is deliberately "wrong" code kept in the example so the spanning-link hazard exists as a demonstration rather than only prose; it can be cut without touching anything else.
- `render` in news.rs crossed clippy's 100-line limit with the link pass added; the pass was extracted into `NewsPanel::link_headlines` rather than `#[allow]`ed.
- `rustdoc` (`RUSTDOCFLAGS="-D warnings"`) also passes, per the four-check bar.
- The one remaining human check is the click itself, on a hyperlink-capable terminal; CLAUDE.md's open-work entry says exactly that and closes when it lands.