### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-09-01
+
 ### Added
 
 - **Headlines are hyperlinks.** In a terminal that renders OSC 8 links —
@@ -1727,7 +1729,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/jchultarsky/mirador/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/jchultarsky/mirador/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/jchultarsky/mirador/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/jchultarsky/mirador/compare/v1.6.0...v1.6.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1778,14 +1778,18 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.8.0` is released**, on crates.io and as a GitHub release with binaries
-  for macOS arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows
-  x86-64. It brings the bundled themes to sixteen (the light-first batch,
-  owner-approved on rendered captures) and puts NetBSD in the README's badge;
-  1.7.0 wired the gain/loss ramps and the doc catch-up, 1.6.1 fixed the
-  address-family fallback confirmed on NetBSD (#205, now pkgsrc
-  `sysutils/mirador`), and 1.6.0 shipped the external panel protocol, so v1
-  of that protocol is a compatibility promise. The aarch64 Linux
+- **`1.9.0` is released**, as a GitHub release with binaries for macOS
+  arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64 —
+  the crates.io publish is the manual step and had not yet been run when
+  this line was written; strike this clause when it has. It makes news
+  headlines OSC 8 hyperlinks (#222), the feature 1.8.0's notes still
+  called parked; 1.8.0 brought the bundled themes to sixteen (the
+  light-first batch, owner-approved on rendered captures) and put NetBSD
+  in the README's badge, 1.7.0 wired the gain/loss ramps and the doc
+  catch-up, 1.6.1 fixed the address-family fallback confirmed on NetBSD
+  (#205, now pkgsrc `sysutils/mirador`), and 1.6.0 shipped the external
+  panel protocol, so v1 of that protocol is a compatibility promise. The
+  aarch64 Linux
   archive first shipped in 1.5.1 and was executed the same day by its
   contributor — "it starts and draws" on Fedora 44 Asahi
   ([#197](https://github.com/jchultarsky/mirador/pull/197)) — so every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
# Summary

The 1.9.0 version bump, owner-requested. The release carries one feature — news headlines are OSC 8 hyperlinks ([#222](https://github.com/jchultarsky/mirador/pull/222)) — plus the quick-xml 0.41 → 0.42 port ([#221](https://github.com/jchultarsky/mirador/pull/221)). Per the release procedure in CLAUDE.md: merge this, then the `v1.9.0` tag goes on the squashed commit; the workflow builds and attests the artifacts, and the crates.io publish stays manual.

## What changed

- `Cargo.toml` / `Cargo.lock`: `1.8.0` → `1.9.0`. The MSRV floor was re-checked after the quick-xml bump: still 1.95.
- `CHANGELOG.md`: `Unreleased` rolled into `[1.9.0] - 2026-09-01`, compare links added, empty `[Unreleased]` heading kept per the file's convention.
- `CLAUDE.md`: the released-version housekeeping line moved to 1.9.0 in the same commit as the bump, as `the_released_version_in_the_notes_matches_the_manifest` requires. It notes honestly that the crates.io publish is pending, with an instruction to strike that clause once run.

## How it was tested

All four checks pass at the new version: `cargo test` (828, including the docs guards on the version line and changelog links), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and rustdoc with `-D warnings`.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes
- [x] New behaviour has tests, or there is a note below explaining why not — no behaviour change; a version bump
- [x] `CHANGELOG.md` updated under `Unreleased` — rolled into `[1.9.0]`
- [x] Documentation updated — the CLAUDE.md release line, per its guard

## Notes for the reviewer

Tag after merge, on the squash commit — 0.8.0 is the recorded cautionary tale for tagging the local commit first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1o6kUbuUddfDvoWgTawRE)_