### PR TITLE
Cutting a release no longer needs the owner's machine

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,75 @@
+name: Cut release
+
+# The tag-push half of cutting a release, behind workflow_dispatch so it can
+# be run through the API — the 1.9.0 release sat merged on main for hours with
+# no tag, because the only place a tag could be pushed from was the owner's
+# machine. This tags the head of main with the version Cargo.toml carries;
+# the tag push is what starts release.yml, exactly as a manual push would.
+#
+# The push authenticates with RELEASE_TAG_TOKEN, a fine-grained PAT with
+# contents read/write on this repository, not the workflow's own GITHUB_TOKEN.
+# That is load-bearing, not caution: GitHub suppresses workflow runs for
+# events created with GITHUB_TOKEN, so a tag pushed with it would be a
+# release that builds nothing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      summary:
+        description: "Tag annotation after the version, e.g. 'news headlines are OSC 8 hyperlinks'"
+        required: false
+        type: string
+
+# Read-only for the workflow token; the write happens through the PAT.
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    name: tag the release
+    runs-on: ubuntu-latest
+    steps:
+      # Actions are pinned by commit, not by tag — same reasoning as ci.yml.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Checkout wires this token into the remote, so the tag push below
+          # carries it.
+          token: ${{ secrets.RELEASE_TAG_TOKEN }}
+
+      - name: Tag the head of main with Cargo.toml's version
+        env:
+          SUMMARY: ${{ inputs.summary }}
+        run: |
+          set -euo pipefail
+
+          # A release tag belongs on main and nowhere else.
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "refusing to tag $GITHUB_REF; dispatch this workflow on main" >&2
+            exit 1
+          fi
+
+          version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+          if [ -z "$version" ]; then
+            echo "no version found in Cargo.toml" >&2
+            exit 1
+          fi
+
+          # Refuse a tag that exists (release.yml would refuse too, but this
+          # message says what to do about it) and a version the CHANGELOG has
+          # no section for — the release notes are cut from that section.
+          if git ls-remote --exit-code origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "v$version already exists; bump the version on main before cutting" >&2
+            exit 1
+          fi
+          if ! grep -q "^## \[$version\]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no [$version] section" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Annotated, subject "<version>: <summary>", matching every tag
+          # since v1.0.0.
+          git tag -a "v$version" -m "$version${SUMMARY:+: $SUMMARY}"
+          git push origin "v$version"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,10 +1,11 @@
 name: Cut release
 
 # The tag-push half of cutting a release, behind workflow_dispatch so it can
-# be run through the API — the 1.9.0 release sat merged on main for hours with
-# no tag, because the only place a tag could be pushed from was the owner's
-# machine. This tags the head of main with the version Cargo.toml carries;
-# the tag push is what starts release.yml, exactly as a manual push would.
+# be run through the API — the session that cut 1.9.0 merged the bump and
+# could not tag it, because the only place a tag could be pushed from was the
+# owner's machine. This tags the head of main with the version Cargo.toml
+# carries; the tag push is what starts release.yml, exactly as a manual push
+# would.
 #
 # The push authenticates with RELEASE_TAG_TOKEN, a fine-grained PAT with
 # contents read/write on this repository, not the workflow's own GITHUB_TOKEN.

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,64 @@
+name: Publish to crates.io
+
+# The cargo-publish half of cutting a release. Still a deliberate separate
+# step after the tag — that part of the process is unchanged — but behind
+# workflow_dispatch so it can be run through the API rather than only from a
+# machine holding a crates.io token.
+#
+# No machine holds one: authentication is crates.io Trusted Publishing, an
+# OIDC exchange that mints a token scoped to this crate and valid for this
+# run. The crate's Settings on crates.io must name this repository and this
+# workflow file (publish-crates.yml) for the exchange to succeed; nothing is
+# stored on either side.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, e.g. v1.9.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  # The OIDC exchange trusted publishing runs on.
+  id-token: write
+
+jobs:
+  publish:
+    name: cargo publish
+    runs-on: ubuntu-latest
+    steps:
+      # Actions are pinned by commit, not by tag — same reasoning as ci.yml.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      # The same guard release.yml applies to the binaries: what goes to
+      # crates.io is exactly what the tag says it is.
+      - name: The tag must carry its own version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+          if [ "v$version" != "$TAG" ]; then
+            echo "Cargo.toml at $TAG says $version; refusing to publish a mismatch" >&2
+            exit 1
+          fi
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch @ 2026-07
+        with:
+          toolchain: stable
+
+      - name: Get a trusted-publishing token
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      # `--locked` for the same reason CI uses it everywhere: publish the
+      # dependency set the repository actually carries.
+      - name: Publish
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cutting a release no longer needs the owner's machine.** Two dispatchable
+  workflows cover the two manual steps: `cut-release.yml` tags the head of
+  `main` with the manifest's version, starting the release build exactly as a
+  manual tag push would, and `publish-crates.yml` publishes a tag to crates.io
+  using Trusted Publishing, so no long-lived crates.io token exists anywhere.
+  Both steps remain runnable by hand from a machine with the right
+  credentials.
+
 ## [1.9.0] - 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1779,9 +1779,12 @@ and had to be added back was the one that did not.
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
 - **`1.9.0` is released**, as a GitHub release with binaries for macOS
-  arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64 —
-  the crates.io publish is the manual step and had not yet been run when
-  this line was written; strike this clause when it has. It makes news
+  arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
+  and published on crates.io — though the tag went up hours after the
+  merge, because it could only be pushed from the owner's machine and
+  the session that cut the release was not on it; this line spent those
+  hours claiming a release that did not exist, which is what the
+  workflows below now prevent. It makes news
   headlines OSC 8 hyperlinks (#222), the feature 1.8.0's notes still
   called parked; 1.8.0 brought the bundled themes to sixteen (the
   light-first batch, owner-approved on rendered captures) and put NetBSD
@@ -1804,8 +1807,35 @@ and had to be added back was the one that did not.
 
   Cutting a release is a tag push and a `cargo publish`, in that order. Bump
   the manifest, commit, *then* tag: a tag that disagrees with `version` in
-  Cargo.toml is refused. The workflow does **not** publish to crates.io — that
-  step stays manual and comes after the tag.
+  Cargo.toml is refused. The release workflow does **not** publish to
+  crates.io — that step stays separate and deliberate, and comes after the
+  tag.
+
+  **Both steps are now workflows, so neither needs the owner's machine.**
+  They exist because 1.9.0 proved the failure mode: the bump merged, the
+  session that merged it could not push a tag (a remote session's git
+  credentials are scoped to its own work branch), and the release sat
+  half-cut until the owner got back to a laptop. Now:
+
+  - `.github/workflows/cut-release.yml` (dispatch on `main`) tags the head
+    of `main` with the version Cargo.toml carries and pushes the tag, which
+    starts `release.yml` exactly as a manual push would. It takes an
+    optional `summary` input for the tag annotation. The push uses the
+    `RELEASE_TAG_TOKEN` secret — a fine-grained PAT with contents
+    read/write on this repository — because a tag pushed with the
+    workflow's own `GITHUB_TOKEN` triggers nothing: GitHub suppresses
+    workflow runs for events that token creates, and the result would be a
+    tag with no release behind it.
+  - `.github/workflows/publish-crates.yml` (dispatch, takes the tag) checks
+    the tag out, re-checks it against `version`, and runs
+    `cargo publish --locked` with a token minted by crates.io Trusted
+    Publishing — an OIDC exchange scoped to this crate and this run, so no
+    long-lived crates.io token exists anywhere. The crate's Settings page
+    on crates.io must name this repository and `publish-crates.yml` for
+    the exchange to succeed.
+
+  Both remain runnable by hand from a machine with the right credentials —
+  the workflows add a path, they do not close one.
 
   **`main` is protected, so "commit" there means *merged*, not committed
   locally.** The version bump reaches `main` through a PR like anything else,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1780,11 +1780,12 @@ and had to be added back was the one that did not.
   too — see the platform note below.
 - **`1.9.0` is released**, as a GitHub release with binaries for macOS
   arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
-  and published on crates.io — though the tag went up hours after the
-  merge, because it could only be pushed from the owner's machine and
-  the session that cut the release was not on it; this line spent those
-  hours claiming a release that did not exist, which is what the
-  workflows below now prevent. It makes news
+  and published on crates.io — though the session that cut it could not
+  finish the job: a tag could only be pushed from the owner's machine,
+  so this line landed on `main` claiming a release that did not yet
+  exist. The gap was under seven minutes, because the owner happened to
+  be at that machine — the workflows below remove the happened-to, not
+  the seven minutes. It makes news
   headlines OSC 8 hyperlinks (#222), the feature 1.8.0's notes still
   called parked; 1.8.0 brought the bundled themes to sixteen (the
   light-first batch, owner-approved on rendered captures) and put NetBSD
@@ -1812,10 +1813,13 @@ and had to be added back was the one that did not.
   tag.
 
   **Both steps are now workflows, so neither needs the owner's machine.**
-  They exist because 1.9.0 proved the failure mode: the bump merged, the
-  session that merged it could not push a tag (a remote session's git
-  credentials are scoped to its own work branch), and the release sat
-  half-cut until the owner got back to a laptop. Now:
+  They exist because 1.9.0 proved the failure mode: the bump merged, and
+  the session that merged it could push neither the tag nor the crate — a
+  remote session's git credentials are scoped to its own work branch, and
+  it holds no crates.io token. The release stalled half-cut; it was over
+  in minutes only because the owner was at a laptop and finished both
+  steps by hand, and nothing about the failure caps the stall at that.
+  Now:
 
   - `.github/workflows/cut-release.yml` (dispatch on `main`) tags the head
     of `main` with the version Cargo.toml carries and pushes the tag, which


### PR DESCRIPTION
# Summary

1.9.0 proved the failure mode this closes: the version bump merged, the remote session that merged it could push nothing but its own work branch, and the release sat half-cut — tagless, no binaries, notes already claiming otherwise — until the owner got back to a laptop with the credentials. This puts both manual release steps behind `workflow_dispatch` so a session (or the owner, from anywhere) can run them through the API, without weakening what stays deliberate about them.

## What changed

- **`.github/workflows/cut-release.yml`** (new): dispatched on `main`, tags its head with the version Cargo.toml carries and pushes the tag, which starts `release.yml` exactly as a manual push would. It refuses to run off `main`, refuses a version that is already tagged, and refuses a version the CHANGELOG has no section for. The tag is annotated in the `<version>: <summary>` shape every tag since v1.0.0 has used, with the summary as an optional dispatch input. The push rides a fine-grained PAT (`RELEASE_TAG_TOKEN` secret) rather than the workflow's own `GITHUB_TOKEN` — that is load-bearing: GitHub suppresses workflow runs for events `GITHUB_TOKEN` creates, so a tag pushed with it would be a release that builds nothing.
- **`.github/workflows/publish-crates.yml`** (new): dispatched with a tag, checks it out, re-checks the tag against `version` in Cargo.toml, and runs `cargo publish --locked` with a token minted by crates.io Trusted Publishing — an OIDC exchange scoped to this crate and this run, so no long-lived crates.io token exists anywhere, in a secret or otherwise.
- Both pin actions by commit SHA with a version comment, matching `ci.yml`'s reasoning, and keep the workflow token read-only. `release.yml` is untouched — these sit beside the generated file, not inside it, so `dist generate` stays clean.
- **CLAUDE.md**: the release-cut paragraph documents the two workflows and their one-time setup; the 1.9.0 line strikes its "not yet on crates.io" clause as it asked to be, and records how the gap happened.
- **CHANGELOG.md**: an `Unreleased` entry.

Two pieces of one-time setup only the owner can do, before either workflow works:

1. Create a fine-grained PAT scoped to this repository with **Contents: read and write**, and add it as an Actions secret named `RELEASE_TAG_TOKEN`.
2. On crates.io: mirador → Settings → Trusted Publishing → add GitHub repository `jchultarsky/mirador`, workflow file `publish-crates.yml` (no environment).

## How it was tested

- All four gates pass locally: `cargo test` (838 tests — the docs guard verifies the CLAUDE.md edits, cited paths included), `cargo fmt --check`, `cargo clippy -D warnings`, and rustdoc with `-D warnings`.
- The workflows themselves cannot run until they are on `main` with the secrets in place, so their guards were desk-checked rather than executed: the version extraction was run against the real Cargo.toml, and the `crates-io-auth-action` interface (its `token` output) was read from the pinned commit rather than assumed. The pinned SHA `c6f97d4…` is the `v1.0.5` tag of `rust-lang/crates-io-auth-action`.
- The first real run of each will be the 1.10.0 cut, which is the honest test.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes
- [x] New behaviour has tests, or there is a note below explaining why not — no Rust behaviour changed; the workflows' guards can only be exercised by a real dispatch, noted above
- [x] `CHANGELOG.md` updated under `Unreleased` for any user-visible change
- [x] Documentation updated: README, and `assets/default_config.toml` for any new config option — neither applies; the release process lives in CLAUDE.md, which is updated

## Notes for the reviewer

- The `GITHUB_TOKEN`-doesn't-trigger-workflows constraint is why the PAT exists at all. The alternative — having `cut-release.yml` also do the building — would mean duplicating or hand-editing the generated `release.yml`, which its header forbids.
- Trusted Publishing was chosen over a `CARGO_REGISTRY_TOKEN` secret because it leaves nothing to leak or rotate; the fallback of a token secret works with a two-line change to the publish step if you prefer it.
- Both steps remain runnable by hand from a machine with the right credentials; the workflows add a path, they do not close one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5P5xYSrDkpxg866k8N4Uc

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5P5xYSrDkpxg866k8N4Uc)_