### PR TITLE
Pin rust-cache to the v2.9.2 tag commit instead of a master snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # `--locked` on every command: without it cargo will quietly update
       # Cargo.lock to satisfy a resolution, so CI would be testing a dependency
@@ -79,7 +79,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -100,7 +100,7 @@ jobs:
           toolchain: "1.95.0"
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Check
         run: cargo check --locked --all-targets
@@ -117,7 +117,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # Catches broken intra-doc links before they reach docs.rs.
       - name: Build documentation
@@ -137,7 +137,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # Verifies the crate is publishable and that `exclude` in Cargo.toml has
       # not accidentally dropped a file the build needs.


### PR DESCRIPTION
# Summary

Replaces #226. Moves the five `Swatinem/rust-cache` pins in `ci.yml` to `6323deb102c322ba6fcbdcafc7e3dddab59af2b6`, the commit the `v2.9.2` tag points at, with the comment corrected to `# v2.9.2`.

## What changed

The current pin `e18b497` is one commit past the `v2.9.1` tag (a changelog-only commit). Because it is not a tag commit, dependabot treats the action as tracking `master` rather than releases: #226 proposes `f0d9c38`, which is the head of `master` five commits past `v2.9.2`, and leaves the comment reading `# v2.9.1`. Merging it would label a post-2.9.2 master snapshot as 2.9.1, and each monthly run would repeat the same thing.

Pinning to the tagged commit puts the action back on a release. Dependabot then follows tags from here and rewrites the version comment on each bump.

Nothing else in the workflow is touched. `release.yml` is generated by `dist` and does not use this action, so the `plan` guard is unaffected.

## How it was tested

- Confirmed from a clone of `Swatinem/rust-cache` that `v2.9.2^{}` resolves to `6323deb102c322ba6fcbdcafc7e3dddab59af2b6`, that `e18b497` is `v2.9.1-1`, and that #226's `f0d9c38` is `master` head.
- Read the action's source diff between the old pin and `v2.9.2`: changes are confined to cache cleanup, cache-key construction and the bundle layout; no input this workflow uses changed. Expect one cold cache on the first run.
- `ci.yml` parses as YAML with all six jobs present. No other file in the repo references the old hash.
- No CHANGELOG entry: CI-only, not user-visible.

## Checklist

- [x] `cargo fmt --all -- --check` passes (no Rust changed)
- [x] `cargo clippy --all-targets -- -D warnings` passes (no Rust changed)
- [x] `cargo test --all-targets` passes (no Rust changed)
- [x] New behaviour has tests, or there is a note below explaining why not — a workflow pin has no test surface; CI on this PR is the check
- [x] `CHANGELOG.md` updated under `Unreleased` for any user-visible change — not user-visible
- [x] Documentation updated — nothing to document

## Notes for the reviewer

Close #226 once this is in. Dependabot will regenerate it against the new pin only if a newer tag appears, which is the wanted behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkzLtRYHVxX8jcrMYHSRHC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkzLtRYHVxX8jcrMYHSRHC)_