### PR TITLE
Release 1.10.0: tighten what the screen spends its cells on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-09-09
+
+### Fixed
+
+- **The clock's date was cut without saying so.** On a narrow terminal
+  `WEDNESDAY 09 SEPTEMBER` came out as `WEDNESDAY 09 SEPT` — the line was
+  handed to a paragraph narrower than itself, so the *terminal* did the
+  cutting, and a terminal leaves no mark. It now ends in `…` like every other
+  abridged line on the dashboard, and its width is measured in terminal cells
+  rather than characters, so a `date_format` holding double-width text is
+  placed correctly too.
+
+### Changed
+
+- **The resize keys are drawn rather than spelled: `Ctrl+←→↑↓`.** They are the
+  same four arrows the arrange legend already draws two hints away, so the
+  status bar, the arrange legend, the help overlay and `--help` now show the
+  pair as one idea — plain arrows move a panel, the same arrows with `Ctrl`
+  resize it.
+
+- **The status bar fits in a narrower terminal.** With the drawn arrows and a
+  two-space gap between hints, the whole bar appears from 83 columns where it
+  previously needed 92. Hints still drop whole rather than being cut.
+
+- **The tasks panel no longer prints its open count twice.** The border
+  already carries `4 open`; the summary line now spends its width on what is
+  wrong and how the list is sorted. The count returns to the summary in the
+  one case where the border is saying `unsaved!` instead.
+
+- **The markets panel shows one more symbol.** `via yahoo` has moved into the
+  frame — `┤7 · yahoo├` — instead of holding an interior row open for ever in
+  the panel that has the fewest of them. The row underneath returns whenever
+  there is something to say there, which is where a failing fetch still
+  explains itself.
+
+- **The help overlay's key column is sized to the keys it shows** rather than
+  to a fixed width, so its actions start beside the keys instead of a third of
+  the way across the dialog.
+
+- **A panel too narrow for its own name draws no title** instead of a lone
+  `┤…├`, which spent three cells saying a title had been cut and nothing about
+  which panel it was. A jump key keeps its place: `┤4├` is still an answer.
+
 ### Added
 
 - **Cutting a release no longer needs the owner's machine.** Two dispatchable
@@ -1739,7 +1782,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/jchultarsky/mirador/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/jchultarsky/mirador/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/jchultarsky/mirador/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/jchultarsky/mirador/compare/v1.6.1...v1.7.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -929,6 +929,77 @@ thing on screen exactly where the eye was. Attention runs *down* the panel:
 muted tape, body-weight last entry, brass live answer.
 
 
+**The screen-tightening pass of 2026-09-09, and the one real defect in it.**
+A review of what the dashboard spends its cells on, asked for as a cosmetic
+question and answered mostly that way — six changes, of which one was a bug.
+
+- **`Ctrl+arrows` is drawn rather than spelled: `Ctrl+←→↑↓`.** It was the only
+  spelled-out arrow in a program that draws them everywhere, and it sat *in the
+  same legend line* as `←→↑↓ move`, `Shift+↑↓ move row` and `↑↓ at edge new
+  row`. The pair now reads as one idea — the same arrows, plain to move and
+  with Ctrl to resize. Two cells narrower as a side effect. The four glyphs are
+  East Asian Ambiguous, so a terminal set to wide ambiguous draws them as two
+  where `unicode-width` says one; the legend has shipped them since #100 with
+  nothing reported, and hints drop whole, so the worst that costs is a hint
+  dropped one column early. Six literals had to move together — `GLOBAL`, the
+  arrange legend, `--help`, the README four times, the plugin protocol doc —
+  which is the drift the CHANGELOG already records once.
+
+- **The hint gap is two spaces, not three** (`HINT_GAP` in `app.rs`, named so
+  the bar, the legend and the test that rebuilds the bar cannot disagree).
+  With the arrows, the whole status bar now fits from **83 columns where it
+  needed 92**.
+
+- **The clock's date line was cut silently, and that was the defect.** It was
+  handed to a `Paragraph` in a rect narrower than its text, so the *terminal*
+  did the cutting: `WEDNESDAY 09 SEPTEMBER` arrived at 80 columns as
+  `WEDNESDAY 09 SEPT`, a complete-looking abbreviated month. Every other cut on
+  the same screen said `…`. Invariant 19's prose rule and invariant 9 both, in
+  one three-line block — the width was measured with `chars().count()`, and
+  `date_format` is the reader's, so it can hold any text at all.
+  `the_date_line_says_when_it_has_been_cut` sweeps widths against an ASCII and
+  a double-width format, and asserts that some width in the sweep actually cut
+  something, because the first version of it could not have failed.
+
+- **The tasks panel printed its open count twice** — `┤4 open├` in the border
+  and `4 open` in the summary row two lines below. The drop order made it
+  worse: at 80 columns the summary kept the duplicate and dropped the sort
+  mode, which is written down nowhere else. The count comes back only when a
+  failed save takes the border for `unsaved!`.
+  `the_open_count_is_shown_once_and_by_the_border`.
+
+- **A title cut down to nothing but its ellipsis is no longer drawn.** The CPU
+  panel at 80 columns rendered `╭┤…├─┤18 cores├╮`: three cells saying a title
+  was cut and nothing about which panel this is. The jump key keeps its
+  segment, because `┤4├` still answers a question.
+  `a_title_cut_down_to_its_ellipsis_is_not_drawn`. Note this does *not* reverse
+  the counter-before-title budgeting, which is a separate recorded decision.
+
+- **`via yahoo` moved into the frame** (`┤7 · yahoo├`) and the row under the
+  board is now reserved only when it has something to say. It was a constant
+  string holding a row open for ever in the panel with the fewest — at 80
+  columns, one row in three, above a symbol whose price had already been
+  dropped for want of width. The default 120-column dashboard gained a fourth
+  visible symbol. **The consequence is a footprint that changes**: a failing
+  fetch takes its row back from the board, so a panel sitting exactly at
+  `max_height` scrolls its last symbol out of view while the failure shows.
+  That is a departure from the always-paint-the-track rule the graphs follow,
+  taken deliberately — the alternative was a blank row under every healthy
+  watchlist, which is what invariant 15 refuses, and the list scrolls so
+  nothing becomes unreachable. `max_height` dropped from `rows + 2` to
+  `rows + 1` to match. `a_calm_panel_spends_no_row_on_saying_where_its_prices_came_from`.
+
+- **The help overlay's key column is sized to the keys on show**, not to a
+  hardcoded 12 — which was the width of the longest key in the program, so `q`
+  was followed by eleven spaces in every overlay ever drawn. Still capped at
+  12, because a plugin names its own keys.
+  `the_help_overlay_sizes_its_key_column_to_the_keys_it_shows` measures against
+  the widest key actually present rather than against the number 9, which would
+  pass just as happily if the column went back to being a constant.
+  `render_help` hit clippy's hundred-line limit doing this and was split at
+  `App::help_lines` — the same wall `run()` hit when #177 and #182 landed
+  together.
+
 **The layout grid stays two levels** — `rows: Vec<Row{height, panels}>` — rather
 than becoming recursive splits. Nested splits would make `[layout]` unreadable
 and un-hand-editable, and would break the textual-edit approach the whole
@@ -1784,16 +1855,20 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.9.0` is released**, as a GitHub release with binaries for macOS
+- **`1.10.0` is released**, as a GitHub release with binaries for macOS
   arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
-  and published on crates.io — though the session that cut it could not
-  finish the job: a tag could only be pushed from the owner's machine,
-  so this line landed on `main` claiming a release that did not yet
-  exist. The gap was under seven minutes, because the owner happened to
-  be at that machine — the workflows below remove the happened-to, not
-  the seven minutes. It makes news
+  and published on crates.io. It is the screen-tightening pass recorded
+  above — the silently-cut clock date being the one defect in it — and
+  the first release cut through `cut-release.yml` rather than from the
+  owner's machine, which is the step those workflows had never actually
+  performed. 1.9.0 made news
   headlines OSC 8 hyperlinks (#222), the feature 1.8.0's notes still
-  called parked; 1.8.0 brought the bundled themes to sixteen (the
+  called parked, and could not finish the job from the session that cut
+  it: a tag could only be pushed from the owner's machine, so its line
+  landed on `main` claiming a release that did not yet exist. The gap was
+  under seven minutes, because the owner happened to be at that machine —
+  the workflows below remove the happened-to, not the seven minutes.
+  1.8.0 brought the bundled themes to sixteen (the
   light-first batch, owner-approved on rendered captures) and put NetBSD
   in the README's badge, 1.7.0 wired the gain/loss ramps and the doc
   catch-up, 1.6.1 fixed the address-family fallback confirmed on NetBSD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Some settings you change with a keystroke are remembered across restarts:
 | Agenda file | `f` | Agenda |
 | Which panels are shown | `w` | — |
 | Where the panels are | `m` | — |
-| Panel sizes | `Ctrl+arrows` | — |
+| Panel sizes | `Ctrl+←→↑↓` | — |
 
 They go to three different places, and the split is deliberate.
 
@@ -317,7 +317,7 @@ widget mirador has and which of them your layout places:
 disappears the moment you toggle it, and the change is written to your config
 when you close the dialog — as a one-line edit, with your comments untouched.
 A new panel joins the row carrying the fewest panels; `m` moves it wherever you
-want it afterwards, and `Ctrl+arrows` move the
+want it afterwards, and `Ctrl+←→↑↓` move the
 space around, and that is written too.
 
 The last panel cannot be switched off, because a layout with nothing in it is
@@ -484,7 +484,7 @@ is not. Columns drop as the panel narrows, in the order that costs you least.
 A watchlist with the last price, the day's change, and an intraday sparkline.
 
 ```
-╭┤Markets├────────────────────────────────────────────────────────────────┤7├╮
+╭┤Markets├────────────────────────────────────────────────────────┤7 · yahoo├╮
 │   SYMBOL         LAST       CHG        % TODAY                             │
 │ ▸ ^GSPC       7413.18     +1.20   +0.02% ▇▄▃▃▂▃▂▁▂▂▃▃                      │
 │   ^DJI       52210.08   +262.83   +0.51% ▇▅▃▃▂▂▂▂▂▂▃▄                      │
@@ -493,7 +493,6 @@ A watchlist with the last price, the day's change, and an intraday sparkline.
 │   ^NDX       28039.21    -89.13   -0.32% ▇▄▃▃▂▃▂▂▃▂▄▄                      │
 │   AAPL         336.91     +3.89   +1.17% ▂▄▅▇▅▅▃▃▂▂▂▄                      │
 │   MSFT         389.10     +7.40   +1.94% ▃▄▂▆▃▃▄▅▇▇▆▂                      │
-│ via yahoo                                                                  │
 ╰─────────────────────── a add · d remove · r refresh ───────────────────────╯
 ```
 
@@ -816,7 +815,7 @@ about configuration, `--factory-reset` about everything mirador has written.
 | `w` | Choose which panels are shown |
 | `m` | Rearrange the panels — see below |
 | `t` | Choose a theme, previewing as you move — see below |
-| `Ctrl+arrows` | Resize the focused panel against its neighbour |
+| `Ctrl+←→↑↓` | Resize the focused panel against its neighbour |
 | `q` / `Ctrl+C` | Quit |
 
 ### Rearranging the dashboard
@@ -840,7 +839,7 @@ at the edge stops rather than spawning a row per keypress.
 
 The panels themselves move as you press, so what you see is what you will get.
 `Enter` keeps the arrangement and `Esc` puts everything back exactly as it was.
-`Tab` picks a different panel to move without leaving the mode, and `Ctrl+arrows`
+`Tab` picks a different panel to move without leaving the mode, and `Ctrl+←→↑↓`
 still resize while you are in there.
 
 A panel keeps the width you gave it when it moves, and the row weights always

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -4,7 +4,7 @@
 # default, so you can delete anything you do not want to override.
 #
 # mirador edits this file surgically and never reserialises it: switching a
-# panel on with `w`, or resizing one with Ctrl+arrows, rewrites the one line it
+# panel on with `w`, or resizing one with Ctrl+←→↑↓, rewrites the one line it
 # has to and leaves your comments, spacing and ordering exactly as they were.
 # So it stays safe to hand-edit and to keep in version control.
 #

--- a/docs/plugin-protocol.md
+++ b/docs/plugin-protocol.md
@@ -347,7 +347,7 @@ decide whether a global key is safe.
   `Ctrl+x` for its own cancel or interrupt action.
 
 A passive plugin cannot claim or advertise the shell's `q`, `Tab`, `BackTab`,
-`?`, `w`, `m`, `t`, `1` through `9`, `Ctrl+arrows`, or `Ctrl+C` bindings. The
+`?`, `w`, `m`, `t`, `1` through `9`, `Ctrl+←→↑↓`, or `Ctrl+C` bindings. The
 refusal matches on the key itself regardless of modifiers — `Alt+q` and
 `Shift+BackTab` are refused along with the bare chords — while uppercase `Q`
 is a different key and is not reserved. Binding declarations are validated as

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,19 @@ use crate::panel::{KeyOutcome, Panel, RenderContext};
 use crate::state::UiState;
 use crate::theme::Gradients;
 
+/// The gap between two hints on the status bar and the arrange legend.
+///
+/// Three spaces once, which is what a hint list wants when it is not competing
+/// for the row — but this row is the one place on the dashboard where width is
+/// always short, and six of them were being spent to separate seven hints. Two
+/// is still twice the single space inside a hint, so `q quit` still reads as
+/// one thing rather than two.
+///
+/// Named rather than repeated, because the test that proves the bar never
+/// draws half a hint rebuilds the bar from this same table and would otherwise
+/// hold its own private copy of the gap.
+const HINT_GAP: &str = "  ";
+
 /// Global bindings, used for both the status bar and the help overlay.
 const GLOBAL: &[Binding] = &[
     Binding::primary("Tab", "focus"),
@@ -48,7 +61,20 @@ const GLOBAL: &[Binding] = &[
     // status bar and needs 120 columns before either appears, where the
     // collapsed form fits from 92. Which arrow does which axis is the one
     // thing nobody has to be told.
-    Binding::primary("Ctrl+arrows", "resize"),
+    //
+    // Drawn rather than spelled, because the arrange legend already draws
+    // `←→↑↓ move` two hints away and the pair now reads as one idea: the same
+    // arrows, plain to move and with Ctrl to resize. The word `arrows` was the
+    // only spelled-out arrow left in a program that draws them everywhere
+    // else. Two cells narrower as well, so the full bar fits from 90 rather
+    // than 92 — the smaller half of the reason.
+    //
+    // These four are East Asian Ambiguous: `unicode-width` calls them one cell
+    // and a terminal configured for wide ambiguous draws them as two, which is
+    // invariant 10's trap seen from the other side. The legend has shipped
+    // them since #100 with nothing reported, and the bar drops hints whole, so
+    // the worst such a terminal costs is a hint dropped one column early.
+    Binding::primary("Ctrl+←→↑↓", "resize"),
     Binding::extra("Shift+Tab", "focus back"),
     Binding::extra("1-9", "jump to panel"),
     Binding::extra("Ctrl+C", "quit"),
@@ -918,7 +944,7 @@ impl App {
         // the shifted key moves the thing it sits in. Claimed before the plain
         // arrows below, or `Shift+Down` would fall through and merge the panel.
         //
-        // Not `Ctrl+arrows`, which #100 proposed: those already resize inside
+        // Not `Ctrl+←→↑↓`, which #100 proposed: those already resize inside
         // this mode, advertised in the legend and pinned by
         // `ctrl_arrows_still_resize_inside_arrange_mode`.
         let shifted = key.modifiers.contains(KeyModifiers::SHIFT);
@@ -1609,7 +1635,7 @@ impl App {
                 ("Enter", "keep"),
                 ("Esc", "cancel"),
                 ("Shift+↑↓", "move row"),
-                ("Ctrl+arrows", "resize"),
+                ("Ctrl+←→↑↓", "resize"),
                 ("↑↓ at edge", "new row"),
             ] {
                 // Dropped whole rather than clipped: half a hint reads as a
@@ -1617,7 +1643,7 @@ impl App {
                 // terminal. The gap leads the hint it introduces, so a dropped
                 // hint takes its gap with it.
                 parts.push(vec![
-                    Span::styled("   ", muted),
+                    Span::styled(HINT_GAP, muted),
                     Span::styled(key, key_style),
                     Span::styled(format!(" {action}"), muted),
                 ]);
@@ -1645,7 +1671,7 @@ impl App {
         let mut parts = vec![spans];
         for binding in GLOBAL.iter().filter(|b| b.primary) {
             parts.push(vec![
-                Span::styled("   ", muted),
+                Span::styled(HINT_GAP, muted),
                 Span::styled(binding.key.clone(), key_style),
                 Span::styled(format!(" {}", binding.action), muted),
             ]);
@@ -1757,9 +1783,16 @@ impl App {
         Some(format!("mirador {latest} is out   mirador --update "))
     }
 
-    fn render_help(&mut self, frame: &mut ratatui::Frame, area: Rect) {
-        let theme = self.config.theme.clone();
-        let theme = &theme;
+    /// The overlay's text: the global keys, then the focused panel's own.
+    ///
+    /// Split out from `render_help` because that function reached clippy's
+    /// hundred-line limit — the same wall `run()` hit when #177 and #182 landed
+    /// together. The seam is a real one either way: this half decides what the
+    /// overlay *says*, the other half where it sits.
+    fn help_lines(
+        panel: Option<(&str, &[Binding])>,
+        theme: &crate::theme::Theme,
+    ) -> Vec<Line<'static>> {
         let key_style = Style::default().fg(theme.key).add_modifier(Modifier::BOLD);
         let muted = Style::default().fg(theme.muted);
 
@@ -1771,11 +1804,26 @@ impl App {
                     .add_modifier(Modifier::BOLD),
             ))
         };
+
+        let panel_keys: &[Binding] = panel.map_or(&[], |(_, keys)| keys);
+        // Sized to the widest key on show rather than to a constant. The
+        // constant was 12, the width of the longest key the program has, so
+        // `q` was followed by eleven spaces in every overlay ever drawn and the
+        // actions began a third of the way across a 46-cell popup. Still capped
+        // at 12: a plugin names its own keys, and one long enough to push the
+        // actions off the edge would be a plugin deciding how this dialog is
+        // laid out.
+        let key_column = GLOBAL
+            .iter()
+            .chain(panel_keys)
+            .map(|binding| crate::grid::display_width(&binding.key).min(12))
+            .max()
+            .unwrap_or(1);
         let entry = |binding: &Binding| {
-            let key = crate::grid::truncate(&binding.key, 12);
-            let padding = " ".repeat(12usize.saturating_sub(crate::grid::display_width(&key)));
+            let key = crate::grid::truncate(&binding.key, key_column);
+            let padding = " ".repeat(key_column.saturating_sub(crate::grid::display_width(&key)));
             Line::from(vec![
-                Span::styled(format!("  {key}{padding}"), key_style),
+                Span::styled(format!("  {key}{padding}  "), key_style),
                 Span::styled(binding.action.to_string(), muted),
             ])
         };
@@ -1785,14 +1833,26 @@ impl App {
 
         // Bindings are grouped by the panel they belong to, so it is always
         // clear which panel a key acts on.
-        if let Some(slot) = self.slots.get(self.focus) {
-            let panel_keys = slot.panel.bindings();
-            if !panel_keys.is_empty() {
-                lines.push(Line::from(""));
-                lines.push(section(&slot.panel.title()));
-                lines.extend(panel_keys.iter().map(entry));
-            }
+        if let Some((title, keys)) = panel.filter(|(_, keys)| !keys.is_empty()) {
+            lines.push(Line::from(""));
+            lines.push(section(title));
+            lines.extend(keys.iter().map(entry));
         }
+        lines
+    }
+
+    fn render_help(&mut self, frame: &mut ratatui::Frame, area: Rect) {
+        let theme = self.config.theme.clone();
+        let theme = &theme;
+
+        let panel_title = self.slots.get(self.focus).map(|slot| slot.panel.title());
+        let lines = Self::help_lines(
+            self.slots
+                .get(self.focus)
+                .zip(panel_title.as_deref())
+                .map(|(slot, title)| (title, slot.panel.bindings())),
+            theme,
+        );
 
         // The footer is rendered separately and pinned to the last row, rather
         // than being the last line of the scrolling text. A hint saying how to
@@ -2117,14 +2177,14 @@ mod tests {
         let mut app = App::new(resizable()).expect("builds");
         let bar = status_bar_at(&mut app, 120);
         assert!(
-            bar.contains("Ctrl+arrows resize"),
+            bar.contains("Ctrl+←→↑↓ resize"),
             "resize must be advertised where someone looking for it will look: {bar}"
         );
     }
 
     /// The bar is built from one table, so a hint cannot be worded differently
     /// in two places — but it *can* be worded differently from the legend and
-    /// `--help`, which are separate strings. All three say `Ctrl+arrows`.
+    /// `--help`, which are separate strings. All three say `Ctrl+←→↑↓`.
     #[test]
     fn the_resize_hint_is_worded_the_way_arrange_mode_words_it() {
         let mut app = App::new(resizable()).expect("builds");
@@ -2132,7 +2192,7 @@ mod tests {
         app.handle_key(KeyEvent::from(KeyCode::Char('m')));
         let legend = status_bar_at(&mut app, 120);
         assert!(
-            plain.contains("Ctrl+arrows resize") && legend.contains("Ctrl+arrows resize"),
+            plain.contains("Ctrl+←→↑↓ resize") && legend.contains("Ctrl+←→↑↓ resize"),
             "the same key must read the same in both bars:\n  {plain}\n  {legend}"
         );
     }
@@ -2140,7 +2200,10 @@ mod tests {
     /// Every width must show whole hints or none — never a fragment. This is
     /// the property the arrange legend has always had and this bar did not:
     /// while every primary was one character the shortfall never showed, and
-    /// promoting `Ctrl+arrows` made it show at 80 columns as `Ctrl+←`.
+    /// promoting the resize hint made it show at 80 columns as `Ctrl+←`.
+    /// Now that the hint is itself four arrows, a fragment of it would read as
+    /// a plausible narrower binding, which is the same fault wearing a
+    /// better disguise.
     ///
     /// Asserted by construction rather than by looking for a fragment: the
     /// drawn bar has to be one of the prefixes that end on a hint boundary,
@@ -2153,7 +2216,7 @@ mod tests {
         let mut acc = String::from(" mirador");
         whole.push(acc.clone());
         for binding in GLOBAL.iter().filter(|b| b.primary) {
-            acc.push_str("   ");
+            acc.push_str(HINT_GAP);
             acc.push_str(&binding.key);
             acc.push(' ');
             acc.push_str(&binding.action);
@@ -2618,6 +2681,59 @@ mod tests {
                 "the help overlay still nags about unused widgets: found `{banned}`"
             );
         }
+    }
+
+    /// The key column was a hardcoded 12 — the width of the longest key the
+    /// program has — so every overlay ever drawn put eleven spaces after `q`
+    /// and began its actions a third of the way across a 46-cell popup.
+    ///
+    /// Asserted against the widest key actually on show, not against a number:
+    /// a test that pinned 9 would have to be edited by whoever next renames a
+    /// binding, and would pass just as happily if the column went back to being
+    /// a constant that happened to equal 9.
+    #[test]
+    fn the_help_overlay_sizes_its_key_column_to_the_keys_it_shows() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = App::new(config_with(&["clocks"])).unwrap();
+        app.handle_key(KeyEvent::from(KeyCode::Char('?')));
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal.draw(|frame| app.render_for_test(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let rows: Vec<String> = (0..40)
+            .map(|y| {
+                (0..120)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect();
+
+        let widest = GLOBAL
+            .iter()
+            .chain(app.slots[app.focus].panel.bindings())
+            .map(|binding| crate::grid::display_width(&binding.key))
+            .max()
+            .expect("there are bindings");
+        assert!(
+            widest < 12,
+            "no key is 12 cells wide any more, so a column of 12 is padding: {widest}"
+        );
+
+        // `q quit` is the shortest key in the overlay and so the one the old
+        // constant punished hardest. Its action must start where every other
+        // action starts.
+        let row = rows
+            .iter()
+            .find(|row| row.contains(" q ") && row.contains("quit"))
+            .expect("the overlay lists `q quit`");
+        let key_at = row.find('q').expect("the key is on the row");
+        let action_at = row.find("quit").expect("the action is on the row");
+        assert_eq!(
+            action_at - key_at,
+            widest + 2,
+            "the action starts one column past the widest key plus its gap: {row:?}"
+        );
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -193,6 +193,14 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, theme: &Theme, spec: &FrameS
     // flush against each other.
     let title_budget = available.saturating_sub(counter_width + index_width + 3);
     let title = crate::grid::truncate(spec.title, title_budget);
+    // `truncate` at one cell has nothing to spend on the name and returns the
+    // ellipsis alone. `┤…├` is three cells that say a title was cut without
+    // saying anything about which panel this is — the reader learns less than
+    // from a plain border, and pays for it. The jump key beside it is a
+    // different matter and stays: `┤4├` is still an answer to a question
+    // somebody has.
+    let title_is_gone = title == "…";
+    let title = if title_is_gone { String::new() } else { title };
 
     // The jump key rides in the title, so panel switching is discoverable
     // without spending a legend row on it.
@@ -204,7 +212,9 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, theme: &Theme, spec: &FrameS
                 .fg(if spec.focused { theme.key } else { theme.muted })
                 .add_modifier(Modifier::BOLD),
         ));
-        title_spans.push(Span::styled(" ", border_style));
+        if !title_is_gone {
+            title_spans.push(Span::styled(" ", border_style));
+        }
     }
     title_spans.push(Span::styled(
         title,
@@ -226,8 +236,10 @@ pub fn draw(frame: &mut ratatui::Frame, area: Rect, theme: &Theme, spec: &FrameS
 
     // A panel too narrow for even one character of its name goes without one.
     // An empty `┤├` is not a smaller title, it is a mark on the border that
-    // means nothing.
-    if title_budget > 0 {
+    // means nothing — and neither is a lone `┤…├`, which is why a title cut
+    // down to nothing but its ellipsis leaves the segment to the jump key or
+    // drops it altogether.
+    if title_budget > 0 && !(title_is_gone && spec.index > 9) {
         block = block.title_top(Line::from(title_spans));
     }
 
@@ -305,6 +317,12 @@ mod tests {
 
     /// The top border of a panel, as drawn.
     fn top_border(width: u16, title: &str, counter: Option<&str>) -> String {
+        top_border_indexed(width, title, counter, 9)
+    }
+
+    /// The same, for a panel past the ninth — which has no jump key, so its
+    /// title segment has nothing else in it to fall back on.
+    fn top_border_indexed(width: u16, title: &str, counter: Option<&str>, index: usize) -> String {
         let mut terminal = Terminal::new(TestBackend::new(width, 3)).expect("backend");
         terminal
             .draw(|frame| {
@@ -317,7 +335,7 @@ mod tests {
                         counter: counter.map(str::to_string),
                         focused: false,
                         bindings: &[],
-                        index: 9,
+                        index,
                     },
                 );
             })
@@ -343,6 +361,42 @@ mod tests {
                 "every segment opens and closes, at width {width}: {border}"
             );
         }
+    }
+
+    /// `╭┤…├─┤18 cores├╮` is what the CPU panel drew at 80 columns: three cells
+    /// spent saying a title was cut, and nothing at all about which panel this
+    /// is. A bare border says the same for free, and the counter beside it was
+    /// already doing the identifying.
+    ///
+    /// The jump key is the exception and keeps its segment, because `┤4├` still
+    /// answers a question somebody has.
+    #[test]
+    fn a_title_cut_down_to_its_ellipsis_is_not_drawn() {
+        let mut ever_tight = false;
+        for width in 6..40u16 {
+            let unnumbered = top_border_indexed(width, "CPU", Some("18 cores"), 11);
+            assert!(
+                !unnumbered.contains("┤…├"),
+                "a lone ellipsis is not a title, at width {width}: {unnumbered}"
+            );
+
+            let numbered = top_border_indexed(width, "CPU", Some("18 cores"), 4);
+            assert!(
+                !numbered.contains("┤…├"),
+                "nor when there is a jump key beside it, at width {width}: {numbered}"
+            );
+            if numbered.contains("┤4├") {
+                ever_tight = true;
+                assert!(
+                    !numbered.contains('…'),
+                    "the key is kept and the ellipsis dropped, at width {width}: {numbered}"
+                );
+            }
+        }
+        assert!(
+            ever_tight,
+            "no width in the sweep was tight enough to reach the case under test"
+        );
     }
 
     /// The whole border still has to fit, and a title long enough to push the

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ KEYS:
     w                      Choose which panels are shown
     m                      Rearrange the panels
     t                      Choose a theme
-    Ctrl+arrows            Resize the focused panel
+    Ctrl+←→↑↓              Resize the focused panel
     ?                      Show all key bindings, and the version
     q / Ctrl+C             Quit
 

--- a/src/widgets/calculator.rs
+++ b/src/widgets/calculator.rs
@@ -436,7 +436,7 @@ impl Panel for CalculatorPanel {
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> KeyOutcome {
-        // Ctrl and Alt belong to the shell — Ctrl+arrows resize, Ctrl+C quits.
+        // Ctrl and Alt belong to the shell — Ctrl+←→↑↓ resize, Ctrl+C quits.
         if key.modifiers.contains(KeyModifiers::CONTROL)
             || key.modifiers.contains(KeyModifiers::ALT)
         {

--- a/src/widgets/clocks.rs
+++ b/src/widgets/clocks.rs
@@ -467,7 +467,7 @@ impl Panel for ClocksPanel {
                 self.status = Some(self.zones.path().display().to_string());
             }
             // Shift moves the clock rather than the cursor, which is the same
-            // shape as `Ctrl+arrows` resizing a panel rather than moving focus.
+            // shape as `Ctrl+←→↑↓` resizing a panel rather than moving focus.
             // `J`/`K` do it too, because this panel already offers arrows and
             // `j`/`k` as equals for the selection and it would be strange for
             // only one of the pair to gain the modifier.
@@ -618,9 +618,21 @@ impl Panel for ClocksPanel {
 
         // The date sits directly under the numerals in the utility face, so
         // the two read as one object rather than as two separate facts.
+        //
+        // Truncated here rather than left to the rect, and measured in cells
+        // rather than in `chars()`. Both halves were wrong and the pair of them
+        // produced the one silent cut on the dashboard: a `Paragraph` in a rect
+        // narrower than its text is clipped by the terminal, which cannot tell
+        // a value from a fragment, so `WEDNESDAY 09 SEPTEMBER` came out at 80
+        // columns as `WEDNESDAY 09 SEPT` — a complete-looking abbreviated month
+        // that is not what the day is called. Every other cut on the same
+        // screen says `…`; this one did not. `date_format` is the reader's, so
+        // it can hold any text at all, which is why `chars()` was the second
+        // fault rather than a theoretical one.
         if cursor < area.y + area.height && !self.config.date_format.is_empty() {
             let date = glyphs::utility(&local.strftime(&self.config.date_format).to_string());
-            let width = u16::try_from(date.chars().count()).unwrap_or(0);
+            let date = crate::grid::truncate(&date, usize::from(area.width));
+            let width = u16::try_from(crate::grid::display_width(&date)).unwrap_or(0);
             let x = area.x + (area.width.saturating_sub(width)) / 2;
             frame.render_widget(
                 Paragraph::new(Span::styled(
@@ -927,6 +939,123 @@ mod tests {
                 crate::grid::display_width(&widest) <= usize::from(width),
                 "`{widest}` needs {} cells and the column is {width}",
                 crate::grid::display_width(&widest)
+            );
+        }
+    }
+
+    /// The date line was the one thing on the dashboard that was cut without
+    /// saying so. It was handed to a `Paragraph` in a rect narrower than the
+    /// text, so the *terminal* did the cutting, and a terminal cannot tell a
+    /// value from a fragment: `WEDNESDAY 09 SEPTEMBER` arrived at 80 columns as
+    /// `WEDNESDAY 09 SEPT`, which reads as a whole abbreviated month.
+    ///
+    /// Two properties, because the old code got two things wrong. Anything cut
+    /// has to say `…`, and nothing may be drawn wider than the space it was
+    /// given — which the old `chars().count()` could not know, since
+    /// `date_format` is the reader's and may hold any text at all.
+    #[test]
+    fn the_date_line_says_when_it_has_been_cut() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+
+        // Literal text passes through `strftime` untouched, so the whole line
+        // is known without depending on what today happens to be. The second
+        // is double-width throughout: eight cells to six `chars()`, which is
+        // the gap the old measurement fell into.
+        for format in [
+            "MIDWEEK LONG DATE LINE",
+            "\u{6c34}\u{66dc}\u{65e5} \u{4e5d}\u{6708}",
+        ] {
+            let full = crate::glyphs::utility(format);
+            let mut ever_cut = false;
+
+            for width in 4..48u16 {
+                let (mut panel, _guard) = panel_from_named(
+                    "date-cut",
+                    ClocksConfig {
+                        date_format: format.to_string(),
+                        ..ClocksConfig::default()
+                    },
+                );
+                let mut terminal = Terminal::new(TestBackend::new(width, 20)).unwrap();
+                terminal
+                    .draw(|frame| {
+                        panel.render(
+                            frame,
+                            frame.area(),
+                            RenderContext {
+                                theme: &config.theme,
+                                gradients: &gradients,
+                                focused: true,
+                                watch: &crate::watch::WatchLog::default(),
+                            },
+                        );
+                    })
+                    .unwrap();
+                // Read the buffer rather than `TestBackend`'s `Display`, which
+                // wraps every row in quotation marks — two cells that are not
+                // on anybody's screen, and enough to fail a width assertion
+                // that is doing its job.
+                let buffer = terminal.backend().buffer().clone();
+                let rows: Vec<String> = (0..buffer.area.height)
+                    .map(|y| {
+                        // Walk by each glyph's measured width, the way
+                        // `link::linkify` has to: the cell a double-width glyph
+                        // covers holds a space, indistinguishable from a real
+                        // one, so reading every cell turns `水曜` into `水 曜 `
+                        // and inflates the row by a cell per wide glyph.
+                        let mut row = String::new();
+                        let mut x = 0u16;
+                        while x < buffer.area.width {
+                            let Some(cell) = buffer.cell((x, y)) else {
+                                break;
+                            };
+                            let symbol = cell.symbol();
+                            row.push_str(symbol);
+                            x += u16::try_from(crate::grid::display_width(symbol).max(1))
+                                .unwrap_or(1);
+                        }
+                        row
+                    })
+                    .collect();
+
+                // The date row is the one carrying the *first* character of the
+                // format — one character, not two, because a cut short enough
+                // to lose the second is exactly the case being tested and a
+                // two-character head would quietly skip it. The zone rows are
+                // excluded by their colons, and the numerals above are block
+                // glyphs. A width too narrow to hold even the first character
+                // draws no date at all, which is a row not drawn rather than a
+                // row drawn wrong.
+                let head: String = full.chars().take(1).collect();
+                let Some(row) = rows
+                    .iter()
+                    .find(|line| line.contains(&head) && !line.contains(':'))
+                else {
+                    continue;
+                };
+                let drawn = row.trim();
+
+                assert!(
+                    crate::grid::display_width(drawn) <= usize::from(width),
+                    "the date overflowed {width} cells: {drawn:?}"
+                );
+                if drawn == full {
+                    continue;
+                }
+                ever_cut = true;
+                assert!(
+                    drawn.ends_with('\u{2026}'),
+                    "the date was cut at {width} without saying so: {drawn:?}"
+                );
+            }
+
+            assert!(
+                ever_cut,
+                "no width in the sweep actually cut `{full}`, so this proves nothing"
             );
         }
     }

--- a/src/widgets/stocks.rs
+++ b/src/widgets/stocks.rs
@@ -547,31 +547,45 @@ impl StocksPanel {
     /// access is refused in tests` look like the same complete sentence. One
     /// cell of `…` is the whole difference between a message the reader knows
     /// is abridged and one they do not.
-    fn status_line(&self, theme: &Theme, board: &Board, width: u16) -> Line<'static> {
-        let line = self.status_text(theme, board);
-        crate::grid::assemble(vec![line.spans], width)
+    fn status_line(&self, theme: &Theme, board: &Board, width: u16) -> Option<Line<'static>> {
+        let line = self.status_text(theme, board)?;
+        Some(crate::grid::assemble(vec![line.spans], width))
     }
 
-    fn status_text(&self, theme: &Theme, board: &Board) -> Line<'static> {
+    /// What the row under the board has to say, or `None` when it has nothing.
+    ///
+    /// `None` used to be `via yahoo`. The provenance is real and worth showing,
+    /// but it is constant, and it was holding a row open for ever in the one
+    /// panel on the dashboard that never has enough of them — at 80 columns it
+    /// was a third of the interior, above a symbol whose price had been dropped
+    /// for want of width. It rides in the border now, which costs no rows at
+    /// all, and the row it used to hold appears when something needs saying.
+    ///
+    /// The footprint therefore changes when a fetch starts failing. That is a
+    /// departure from the always-paint-the-track rule the graphs follow, and it
+    /// is deliberate: the alternative was a permanently blank row, and the
+    /// moment the row appears is a moment the panel's contents have changed
+    /// anyway.
+    fn status_text(&self, theme: &Theme, board: &Board) -> Option<Line<'static>> {
         match (&self.mode, &self.status) {
-            (Mode::ConfirmRemove { symbol }, _) => Line::from(Span::styled(
+            (Mode::ConfirmRemove { symbol }, _) => Some(Line::from(Span::styled(
                 format!("remove {symbol}?  y / n"),
                 Style::default()
                     .fg(theme.error)
                     .add_modifier(Modifier::BOLD),
-            )),
-            (Mode::Add(field), _) => Line::from(vec![
+            ))),
+            (Mode::Add(field), _) => Some(Line::from(vec![
                 Span::styled("symbol  ", Style::default().fg(theme.accent)),
                 Span::styled(
                     field.value().to_uppercase(),
                     Style::default().fg(theme.text),
                 ),
                 Span::styled("▏", Style::default().fg(theme.accent)),
-            ]),
-            (_, Some((message, is_error))) => Line::from(Span::styled(
+            ])),
+            (_, Some((message, is_error))) => Some(Line::from(Span::styled(
                 message.clone(),
                 Style::default().fg(if *is_error { theme.error } else { theme.muted }),
-            )),
+            ))),
             _ => {
                 // With nothing else to say, surface the first failure rather
                 // than leaving a row showing `–` with no explanation anywhere.
@@ -586,13 +600,7 @@ impl StocksPanel {
                         None => format!("{symbol}: {why}"),
                     })
                 });
-                match failure {
-                    Some(text) => Line::from(Span::styled(text, Style::default().fg(theme.error))),
-                    None => Line::from(Span::styled(
-                        format!("via {}", self.source_name),
-                        Style::default().fg(theme.muted),
-                    )),
-                }
+                failure.map(|text| Line::from(Span::styled(text, Style::default().fg(theme.error))))
             }
         }
     }
@@ -705,8 +713,12 @@ impl Panel for StocksPanel {
         if self.watchlist.last_error.is_some() {
             return Some("unsaved!".into());
         }
+        // The source rides here rather than in a row of its own: the frame is
+        // the widget bus, and `via yahoo` was spending an interior row on a
+        // string that never changes. Dropped whole if the border cannot hold
+        // it, which is the same rule every other counter follows.
         let n = self.watchlist.symbols().len();
-        (n > 0).then(|| n.to_string())
+        (n > 0).then(|| format!("{n} · {}", self.source_name))
     }
 
     fn tick(&mut self) -> bool {
@@ -727,11 +739,19 @@ impl Panel for StocksPanel {
     }
 
     fn max_height(&self) -> Option<u16> {
-        // Header, a row per symbol, and the status line. A watchlist is a
-        // handful of rows and does not scroll to fill a screen — measured
-        // rather than assumed: the panel is complete at exactly this height,
-        // and every row above it is blank space between the last symbol and
-        // the status line, which is what invariant 15 exists to refuse.
+        // Header and a row per symbol. A watchlist is a handful of rows and
+        // does not scroll to fill a screen — measured rather than assumed: the
+        // panel is complete at exactly this height, and every row above it is
+        // blank space under the last symbol, which is what invariant 15 exists
+        // to refuse.
+        //
+        // No row is reserved for the status line, because there no longer is
+        // one on a calm day. The consequence is deliberate: a fetch that starts
+        // failing takes its row from the board, so a panel sitting exactly at
+        // its cap scrolls its last symbol out of view while the failure is on
+        // screen. Reserving against that would put a blank row under every
+        // healthy watchlist for ever, which is the trade invariant 15 refuses —
+        // and the list scrolls, so nothing becomes unreachable.
         //
         // Saturating because the sum is not, and `u16::MAX` was already being
         // reached for on the line above. Nothing bounds a watchlist — it is a
@@ -740,7 +760,7 @@ impl Panel for StocksPanel {
         // Same shape as `glyphs::width_of` overflowing at ten thousand
         // characters: unreachable in practice, one line to close.
         let rows = u16::try_from(self.watchlist.symbols().len()).unwrap_or(u16::MAX);
-        Some(rows.saturating_add(2).saturating_add(FRAME_HEIGHT))
+        Some(rows.saturating_add(1).saturating_add(FRAME_HEIGHT))
     }
 
     fn bindings(&self) -> &'static [Binding] {
@@ -805,10 +825,14 @@ impl Panel for StocksPanel {
 
         let board = self.snapshot();
 
+        // Computed before the split, because whether the row exists is decided
+        // by whether it has anything to say. On a calm day it does not, and the
+        // board gets the row.
+        let status = self.status_line(theme, &board, area.width);
         let rows = Layout::vertical([
-            Constraint::Length(1), // header
-            Constraint::Min(1),    // board
-            Constraint::Length(1), // status
+            Constraint::Length(1),                           // header
+            Constraint::Min(1),                              // board
+            Constraint::Length(u16::from(status.is_some())), // status
         ])
         .split(area);
 
@@ -820,10 +844,9 @@ impl Panel for StocksPanel {
                 )),
                 rows[1],
             );
-            frame.render_widget(
-                Paragraph::new(self.status_line(theme, &board, rows[2].width)),
-                rows[2],
-            );
+            if let Some(status) = status {
+                frame.render_widget(Paragraph::new(status), rows[2]);
+            }
             return;
         }
 
@@ -872,10 +895,9 @@ impl Panel for StocksPanel {
             });
         frame.render_stateful_widget(list, rows[1], &mut self.list_state);
 
-        frame.render_widget(
-            Paragraph::new(self.status_line(theme, &board, rows[2].width)),
-            rows[2],
-        );
+        if let Some(status) = status {
+            frame.render_widget(Paragraph::new(status), rows[2]);
+        }
     }
 
     fn shutdown(&mut self) {
@@ -1133,11 +1155,11 @@ mod tests {
                     .join("\n")
             };
 
-            // Rows are counted, not matched on text. The status line reads
-            // `via yahoo` only until a fetch reports something — and these
-            // panels really do reach the network, so a Windows runner got far
-            // enough to render `SYM0: no such symbol` and failed an assertion
-            // looking for `via `. Rows are what the cap is about anyway.
+            // Rows are counted, not matched on text. These panels really do
+            // reach the network, so a runner can get far enough to render
+            // `SYM0: no such symbol` in a status row that is otherwise absent —
+            // which is why the counts below are lower bounds on a healthy panel
+            // rather than equalities. Rows are what the cap is about anyway.
             let filled = |text: &str| text.lines().filter(|line| !line.trim().is_empty()).count();
 
             let at_cap = draw(&mut p, interior);
@@ -1150,17 +1172,15 @@ mod tests {
             assert!(at_cap.contains("SYMBOL"), "no header at the cap:\n{at_cap}");
             assert_eq!(
                 filled(&at_cap),
-                n + 2,
-                "the cap should fill header + {n} symbols + status exactly:\n{at_cap}"
+                n + 1,
+                "the cap should fill header + {n} symbols exactly:\n{at_cap}"
             );
 
             // One row short must lose something, or the cap is too generous.
-            // "Something" is not only a symbol: with a single symbol it is the
-            // status line that goes, and a check that looked for a missing
-            // symbol alone called the cap too generous when it was exact.
+            // With no status row to give up first, what goes is a symbol.
             let under = draw(&mut p, interior - 1);
             assert!(
-                filled(&under) < n + 2,
+                filled(&under) < n + 1,
                 "the cap reserves a row the panel does not use at {n} symbols:\n{under}"
             );
         }
@@ -1515,6 +1535,46 @@ mod tests {
         assert_eq!(colour, Some(theme.muted));
     }
 
+    /// `via yahoo` is true, constant, and was holding an interior row open for
+    /// ever in the panel with the fewest of them. At 80 columns it was one row
+    /// in three, above a symbol whose price had already been dropped for want
+    /// of width. It belongs in the frame, which costs no rows at all.
+    ///
+    /// Both directions matter: the row must be gone on a calm day and back the
+    /// moment there is something to say, since that row is also where a failure
+    /// explains itself.
+    #[test]
+    fn a_calm_panel_spends_no_row_on_saying_where_its_prices_came_from() {
+        let (p, _g) = panel("provenance", &["AAPL"]);
+        let theme = Theme::default();
+        let quote = Quote {
+            symbol: "AAPL".into(),
+            price: 213.50,
+            previous_close: 211.00,
+            currency: Some("USD".into()),
+            series: vec![211.0, 213.5],
+            delayed: false,
+        };
+
+        let calm: Board = vec![("AAPL".into(), ready(quote))];
+        assert!(
+            p.status_line(&theme, &calm, 80).is_none(),
+            "a healthy board has nothing to say under it"
+        );
+
+        let counter = p.counter().expect("the border carries the count");
+        assert!(
+            counter.contains(&p.source_name),
+            "and now the source too: {counter}"
+        );
+
+        let failing: Board = vec![("AAPL".into(), failed("HTTP 429"))];
+        assert!(
+            p.status_line(&theme, &failing, 80).is_some(),
+            "a failure takes the row back, which is what it was reserved for"
+        );
+    }
+
     #[test]
     fn a_failure_is_surfaced_in_the_status_line_rather_than_only_as_a_dash() {
         let (p, _g) = panel("failure", &["AAPL"]);
@@ -1523,6 +1583,7 @@ mod tests {
 
         let text: String = p
             .status_line(&theme, &board, 80)
+            .expect("a failure has something to say")
             .spans
             .iter()
             .map(|s| s.content.as_ref())
@@ -1647,6 +1708,7 @@ mod tests {
         // is, and the row is muted rather than coloured by direction.
         let status: String = p
             .status_line(&theme, &snapshot, 80)
+            .expect("a stale price has something to say")
             .spans
             .iter()
             .map(|s| s.content.as_ref())

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -680,10 +680,13 @@ impl TodoPanel {
         Some(badge)
     }
 
-    /// The summary line: how much is open, and how it is sorted.
+    /// The summary line: what is wrong, and how the list is sorted.
     ///
     /// Assembled in priority order and cut at whole items, so a narrow panel
     /// loses the sort mode before the overdue count and never shows `4 op`.
+    ///
+    /// It does *not* carry the open count, which the border already shows two
+    /// rows above — see the note beside the one case that puts it back.
     fn header(&self, theme: &Theme, width: u16) -> Line<'static> {
         let Counts {
             open,
@@ -711,7 +714,17 @@ impl TodoPanel {
                 Style::default().fg(theme.warning),
             ));
         }
-        items.push((format!("{open} open"), Style::default().fg(theme.muted)));
+        // The border already says `N open`, and said it two rows above this
+        // one — so this line was printing the same fact twice, and under a
+        // narrow panel it printed the *duplicate* while dropping the sort mode,
+        // which appears nowhere else. It is kept only for the one case where
+        // the border is saying something more urgent instead: a failed save
+        // replaces the counter with `unsaved!`, and the count would otherwise
+        // vanish from the panel exactly when the reader is being told their
+        // work is not reaching the disk.
+        if self.store.last_error.is_some() {
+            items.push((format!("{open} open"), Style::default().fg(theme.muted)));
+        }
         items.push((
             format!("by {}", self.sort.label()),
             Style::default().fg(theme.muted),
@@ -1307,6 +1320,64 @@ mod tests {
         std::fs::write(&path, "").unwrap();
         let panel = TodoPanel::new(TodoConfig::default(), path).unwrap();
         (panel, TempDir(dir))
+    }
+
+    /// The border and this line were both saying `4 open`, and the drop order
+    /// made it worse rather than harmless: at 80 columns the summary kept the
+    /// duplicate and dropped the sort mode, which is written down nowhere else.
+    ///
+    /// The count comes back for the one case where the border stops carrying
+    /// it. A failed save takes the counter for `unsaved!`, and that is the
+    /// worst possible moment for the panel to also stop saying how much is on
+    /// the list.
+    #[test]
+    fn the_open_count_is_shown_once_and_by_the_border() {
+        let dir = std::env::temp_dir().join(format!("mirador-todo-{}-count", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _guard = TempDir(dir.clone());
+        // Seeded rather than empty: the examples are what a first run shows,
+        // and one of them is overdue, so the summary has something to lead with
+        // besides the count under test.
+        let mut panel = TodoPanel::new(TodoConfig::default(), dir.join("todos.toml")).unwrap();
+
+        let theme = Theme::default();
+        let text = |panel: &TodoPanel| -> String {
+            panel
+                .header(&theme, 120)
+                .spans
+                .iter()
+                .map(|span| span.content.to_string())
+                .collect()
+        };
+
+        let counter = panel.counter().expect("the border carries a counter");
+        assert!(
+            counter.contains("open"),
+            "the border is where the count lives: {counter}"
+        );
+        assert!(
+            !text(&panel).contains("open"),
+            "and so the summary line must not repeat it: {}",
+            text(&panel)
+        );
+        assert!(
+            text(&panel).contains("by "),
+            "the sort mode is what the line keeps instead: {}",
+            text(&panel)
+        );
+
+        panel.store.last_error = Some("read-only file system".to_string());
+        assert_eq!(
+            panel.counter().as_deref(),
+            Some("unsaved!"),
+            "a failed save outranks the count in the border"
+        );
+        assert!(
+            text(&panel).contains("open"),
+            "so the summary line takes it back: {}",
+            text(&panel)
+        );
     }
 
     fn press(panel: &mut TodoPanel, code: KeyCode) {


### PR DESCRIPTION
A review of what the dashboard spends its cells on, asked for as a cosmetic question and answered mostly that way — six changes, of which one was a bug. Bundled with the 1.10.0 bump, since the whole set is one story.

## The bug

**The clock's date line was cut without saying so.** It was handed to a `Paragraph` in a rect narrower than its text, so the *terminal* did the cutting and a terminal leaves no mark: `WEDNESDAY 09 SEPTEMBER` arrived at 80 columns as `WEDNESDAY 09 SEPT`, which reads as a whole abbreviated month. Every other cut on the same screen said `…`. Invariant 19's prose rule and invariant 9 both, in one three-line block — the width was measured with `chars().count()`, and `date_format` is the reader's, so it can hold any text at all.

## The rest

- **`Ctrl+arrows` is drawn rather than spelled: `Ctrl+←→↑↓`.** It was the only spelled-out arrow in a program that draws them everywhere, and it sat in the *same legend line* as `←→↑↓ move`, `Shift+↑↓ move row` and `↑↓ at edge new row`. Six literals had to move together — `GLOBAL`, the arrange legend, `--help`, the README four times, the plugin protocol doc.
- **The hint gap is two spaces, not three** (`HINT_GAP`, named so the bar, the legend and the test that rebuilds the bar cannot disagree). With the arrows, the whole status bar fits from **83 columns where it needed 92**.
- **The tasks panel no longer prints its open count twice.** The border carries `┤4 open├`; the summary row printed `4 open` again two lines below, and under pressure it kept the duplicate and dropped the sort mode, which is written down nowhere else. The count returns only when a failed save takes the border for `unsaved!`.
- **A title cut down to nothing but its ellipsis is not drawn.** The CPU panel at 80 columns rendered `╭┤…├─┤18 cores├╮`. The jump key keeps its segment, because `┤4├` still answers a question. This does not reverse the counter-before-title budgeting.
- **`via yahoo` moved into the frame** (`┤7 · yahoo├`), and the row under the board is reserved only when it has something to say. The default 120-column dashboard gained a fourth visible symbol. Consequence taken deliberately: a failing fetch takes the row back from the board, so `max_height` dropped from `rows + 2` to `rows + 1` — see the note in `CLAUDE.md`.
- **The help overlay's key column is sized to the keys on show**, not to a hardcoded 12 — the width of the longest key in the program, so `q` was followed by eleven spaces in every overlay ever drawn. `render_help` hit clippy's hundred-line limit doing this and was split at `App::help_lines`.

## Verification

All five gates green: 833 tests, clippy, fmt, rustdoc, and `cargo +1.95.0 check --locked --all-targets`. Four new tests, each checked by breaking the fix on purpose and watching it go red; each one also asserts that its sweep actually reached the case under test, so none of them can pass vacuously.

Driven in a real terminal under tmux at 120x40, 100, 80, 74 and 68 columns before the bump: the focus ring, the task form, the theme and panel pickers, `Ctrl+←→↑↓` resizing, arrange mode, the help overlay, and a clean exit on `q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)