### PR TITLE
The README's task sample still printed the count twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ notes, filtering and full editing without leaving the dashboard.
 
 ```
 ╭┤4 Tasks├───────────────────────────────────────────────────────────┤3 open├╮
-│ 1 overdue   1 due today   3 open   by smart                                │
+│ 1 overdue   1 due today   by smart                                         │
 │   DONE PRI TASK                              TAGS                      DUE │
 │   [ ]  ▮▮▮ Renew the domain                  #admin            2 days late │
 │   [ ]  ▮▮  Reply to the design review        #work                   today │


### PR DESCRIPTION
1.10.0 stopped the tasks summary repeating the open count the border already carries. The README's drawing of that panel was not updated with it, so the picture still showed the duplication the release removed:

```
╭┤4 Tasks├───────────────────────────────────────────────────────────┤3 open├╮
│ 1 overdue   1 due today   3 open   by smart                                │
```

Now `1 overdue   1 due today   by smart`, which is what the program draws.

Found by screenshotting the rendered README on GitHub, not by reading the diff — the sample is a static drawing, so nothing in the build could notice it had stopped describing the program. The prose beneath it is unaffected: it talks about an overdue task being *red and counted*, and the overdue count is still in the summary line.

The width guard added in #231 covers the box; it cannot know what the box says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)