### PR TITLE
Release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-09-09
+
 ### Changed
 
 - **The notes panel no longer prints its count twice.** The border already
@@ -1792,7 +1794,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/jchultarsky/mirador/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/jchultarsky/mirador/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/jchultarsky/mirador/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/jchultarsky/mirador/compare/v1.7.0...v1.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1872,13 +1872,15 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.10.0` is released**, as a GitHub release with binaries for macOS
+- **`1.10.1` is released**, as a GitHub release with binaries for macOS
   arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
-  and published on crates.io. It is the screen-tightening pass recorded
-  above — the silently-cut clock date being the one defect in it — and
-  the first release cut through `cut-release.yml` rather than from the
-  owner's machine, which is the step those workflows had never actually
-  performed. 1.9.0 made news
+  and published on crates.io. It carries one change — the notes panel
+  stopping repeating the count its border already shows, which is the
+  screen-tightening pass finding a panel it had missed. 1.10.0, hours
+  earlier, was that pass itself — the silently-cut clock date being the
+  one defect in it — and the first release cut through `cut-release.yml`
+  rather than from the owner's machine, which is the step those workflows
+  had never actually performed. 1.9.0 made news
   headlines OSC 8 hyperlinks (#222), the feature 1.8.0's notes still
   called parked, and could not finish the job from the session that cut
   it: a tag could only be pushed from the owner's machine, so its line

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
One user-visible change, already on `main` as #233: the notes panel no longer repeats the count its border carries, so a calm panel gives that row to the list and the note it is pointing at.

Bumps `Cargo.toml`, moves the CHANGELOG's `Unreleased` section under `1.10.1` with its two link references, and updates `CLAUDE.md`'s released line — all in one commit, since `the_released_version_in_the_notes_matches_the_manifest` and `every_released_version_has_a_changelog_link` both fail otherwise.

Step 0 done before opening this: the 1.10.1 release build driven under tmux at 120x40 — the dashboard, the notes panel with a search open and its `┤1/1├` border, the help overlay, the arrange legend, and a clean exit on `q`. All five gates green (835 tests, clippy, fmt, rustdoc, `cargo +1.95.0 check --locked --all-targets`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)