### PR TITLE
Fourteen tests for the paths the coverage data said nothing ran

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2736,6 +2736,252 @@ mod tests {
         );
     }
 
+    /// Two list panels with their files in a scratch directory, so nothing a
+    /// test does can reach the user's own tasks or notes.
+    fn two_lists(name: &str) -> (Config, PathBuf) {
+        let dir = std::env::temp_dir().join(format!("mirador-app-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut config = config_with(&["notes", "todo"]);
+        config.notes.file = Some(dir.join("notes.toml"));
+        config.todo.file = Some(dir.join("todos.toml"));
+        (config, dir)
+    }
+
+    /// The rows of the dashboard as drawn, so a test can read where things are.
+    fn drawn(app: &mut App, width: u16, height: u16) -> Vec<String> {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|frame| app.render_for_test(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| (0..width).map(|x| buffer[(x, y)].symbol()).collect())
+            .collect()
+    }
+
+    /// The screen row carrying the selection marker inside `area`, if any.
+    fn marker_row(rows: &[String], area: Rect) -> Option<u16> {
+        (area.y..area.y + area.height).find(|&y| {
+            let row = &rows[usize::from(y)];
+            row.chars()
+                .skip(usize::from(area.x))
+                .take(usize::from(area.width))
+                .any(|c| c == '▸')
+        })
+    }
+
+    fn at(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    /// `handle_mouse` goes to the panel under the *pointer*, and a scroll must
+    /// move the list it is aimed at without yanking the keyboard away from
+    /// what the user was typing in. Nothing exercised that seam: every mouse
+    /// path in the panels was unexecuted by the suite.
+    ///
+    /// Observed from the outside, since the panel's selection is its own: the
+    /// tasks panel draws its marker only while focused, so focus is moved
+    /// there *afterwards* with Tab and the marker is read from the second row,
+    /// where the scroll left it — against a control that never scrolled and
+    /// finds it on the first.
+    #[test]
+    fn a_scroll_acts_on_the_panel_under_the_pointer_and_leaves_focus_where_it_was() {
+        let (config, _dir) = two_lists("scroll");
+        let mut app = App::new(config.clone()).unwrap();
+        let rows = drawn(&mut app, 120, 30);
+        let todo = app.slots[1].area.expect("the tasks panel was drawn");
+        assert_eq!(app.focus, 0, "notes start focused");
+        assert!(
+            marker_row(&rows, todo).is_none(),
+            "unfocused, the tasks panel draws no marker"
+        );
+
+        let redraw = app.handle_mouse(at(MouseEventKind::ScrollDown, todo.x + 3, todo.y + 3));
+        assert!(redraw, "the wheel over a list is consumed by it");
+        assert_eq!(app.focus, 0, "and focus did not move");
+
+        app.handle_key(KeyEvent::from(KeyCode::Tab));
+        let after = drawn(&mut app, 120, 30);
+        let scrolled = marker_row(&after, todo).expect("focused, the marker shows");
+
+        let mut control = App::new(config).unwrap();
+        drawn(&mut control, 120, 30);
+        control.handle_key(KeyEvent::from(KeyCode::Tab));
+        let untouched = marker_row(&drawn(&mut control, 120, 30), todo).unwrap();
+        assert_eq!(
+            scrolled,
+            untouched + 1,
+            "the scroll moved the selection one row while the panel was not focused"
+        );
+    }
+
+    /// A click focuses the panel it lands in and selects the row it hit.
+    #[test]
+    fn a_click_focuses_the_panel_under_the_pointer_and_selects_the_row_it_hit() {
+        let (config, _dir) = two_lists("click");
+        let mut app = App::new(config).unwrap();
+        let rows = drawn(&mut app, 120, 30);
+        let todo = app.slots[1].area.unwrap();
+        // The third task row: header line, column headings, then tasks.
+        // Columns, not bytes: the frame's `│` is three bytes wide and one
+        // cell, which is invariant 9 reaching into a test.
+        let target = (todo.y..todo.y + todo.height)
+            .filter(|&y| {
+                rows[usize::from(y)]
+                    .chars()
+                    .skip(usize::from(todo.x))
+                    .collect::<String>()
+                    .contains("[ ]")
+            })
+            .nth(2)
+            .expect("three task rows on screen");
+
+        app.handle_mouse(at(
+            MouseEventKind::Down(ratatui::crossterm::event::MouseButton::Left),
+            todo.x + 6,
+            target,
+        ));
+        assert_eq!(app.focus, 1, "the click moved focus to the tasks panel");
+        let after = drawn(&mut app, 120, 30);
+        assert_eq!(
+            marker_row(&after, todo),
+            Some(target),
+            "and selected the row it hit"
+        );
+    }
+
+    /// A panel in a text-entry state has the same absolute veto over the mouse
+    /// that it has over global keys: a stray click must not pull focus out of
+    /// a half-typed task and strand the form.
+    #[test]
+    fn an_open_form_vetoes_a_click_landing_in_another_panel() {
+        let (config, _dir) = two_lists("veto");
+        let mut app = App::new(config).unwrap();
+        drawn(&mut app, 120, 30);
+        let notes = app.slots[0].area.unwrap();
+
+        app.handle_key(KeyEvent::from(KeyCode::Tab));
+        assert_eq!(app.focus, 1);
+        app.handle_key(KeyEvent::from(KeyCode::Char('a')));
+        assert!(app.focus_captures_input(), "the task form is open");
+
+        app.handle_mouse(at(
+            MouseEventKind::Down(ratatui::crossterm::event::MouseButton::Left),
+            notes.x + 2,
+            notes.y + 2,
+        ));
+        assert_eq!(app.focus, 1, "focus stayed with the form");
+        assert!(app.focus_captures_input(), "and the form is still open");
+    }
+
+    /// Invariant 17, at the seam that shipped wrong twice: the *App* gathers
+    /// what every panel reports, compares it against the config once, and
+    /// writes only the difference — so a preference toggled back to what the
+    /// config says leaves the file rather than asserting itself for ever.
+    /// `UiState` has unit tests for the comparison; nothing had ever driven
+    /// the plumbing that calls it.
+    #[test]
+    fn a_preference_moved_off_the_config_is_written_and_moved_back_is_retracted() {
+        let dir = std::env::temp_dir().join(format!("mirador-prefs-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("state.toml");
+        let config = config_with(&["clocks"]);
+        let baseline = crate::state::UiState::from_config(&config);
+        let mut app = App::new(config).unwrap();
+        app.remember_preferences_at(path.clone(), crate::state::UiState::default(), baseline);
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('s')));
+        app.persist_preferences();
+        let written = std::fs::read_to_string(&path).expect("a change was written");
+        assert!(
+            written.contains("clocks_show_seconds = false"),
+            "the toggle is recorded as a difference from the config: {written}"
+        );
+
+        app.handle_key(KeyEvent::from(KeyCode::Char('s')));
+        app.persist_preferences();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !written.contains("clocks_show_seconds"),
+            "toggled back to the config's value, the entry is gone: {written:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The picker's edit reaches the config file as a textual edit that keeps
+    /// the comments, and a file the editor cannot work on is refused and
+    /// reported rather than rewritten. Both halves through the keys, not by
+    /// calling `layout_edit` directly.
+    #[test]
+    fn a_picker_change_is_written_to_the_config_and_an_uneditable_file_is_reported() {
+        let dir = std::env::temp_dir().join(format!("mirador-layout-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // One panel per line, the way the shipped config is written: the
+        // editor rebuilds a row from captured panel *lines*, and a comment
+        // above a panel travels with it.
+        let editable = "[layout]\nrows = [\n  { height = 1, panels = [\n    # keep me\n    { widget = \"clocks\",   width = 1 },\n    { widget = \"calendar\", width = 1 },\n  ] },\n]\n";
+        let path = dir.join("config.toml");
+        std::fs::write(&path, editable).unwrap();
+        let config: Config = toml::from_str(editable).expect("a minimal config parses");
+
+        let mut app = App::new(config.clone()).unwrap();
+        app.write_layout_to(path.clone());
+        app.handle_key(KeyEvent::from(KeyCode::Char('w')));
+        assert!(app.picker.is_some(), "`w` opens the picker");
+        // Down to `calendar` — sixth in `widget_names` — and switch it off.
+        for _ in 0..5 {
+            app.handle_key(KeyEvent::from(KeyCode::Down));
+        }
+        assert_eq!(
+            app.picker.as_ref().map(crate::picker::Picker::selected),
+            Some(5)
+        );
+        app.handle_key(KeyEvent::from(KeyCode::Char(' ')));
+        app.handle_key(KeyEvent::from(KeyCode::Esc));
+
+        assert_eq!(app.layout_error, None, "the edit was accepted");
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !after.contains("calendar"),
+            "calendar left the layout: {after}"
+        );
+        assert!(after.contains("# keep me"), "the comment survived: {after}");
+        assert!(after.contains("\"clocks\""), "clocks stayed: {after}");
+
+        // The other spelling loads but cannot be edited; the file is left
+        // exactly as it was and the failure is on the bar, not swallowed.
+        let sections = "# keep me\n[[layout.rows]]\nheight = 1\n[[layout.rows.panels]]\nwidget = \"clocks\"\nwidth = 1\n[[layout.rows.panels]]\nwidget = \"calendar\"\nwidth = 1\n";
+        let other = dir.join("sections.toml");
+        std::fs::write(&other, sections).unwrap();
+        let mut app = App::new(config).unwrap();
+        app.write_layout_to(other.clone());
+        app.handle_key(KeyEvent::from(KeyCode::Char('w')));
+        for _ in 0..5 {
+            app.handle_key(KeyEvent::from(KeyCode::Down));
+        }
+        app.handle_key(KeyEvent::from(KeyCode::Char(' ')));
+        app.handle_key(KeyEvent::from(KeyCode::Esc));
+        assert!(
+            app.layout_error.is_some(),
+            "a file it cannot edit is reported"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&other).unwrap(),
+            sections,
+            "and left untouched"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn a_click_retires_the_hint_but_the_pointer_merely_passing_over_does_not() {
         use ratatui::crossterm::event::MouseButton;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -193,6 +193,58 @@ mod tests {
         )
     }
 
+    /// The dialog as drawn. `render` was never executed by a test, and it is
+    /// the whole of what `w` shows: a mark per widget saying whether it is on,
+    /// the cursor, and a line saying where the change goes — or, in place of
+    /// that line, why it did not.
+    #[test]
+    fn the_picker_shows_a_mark_per_widget_and_says_where_the_change_goes() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let theme = Theme::default();
+        let draw = |picker: &Picker, error: Option<&str>, w: u16, h: u16| -> String {
+            let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+            terminal
+                .draw(|frame| picker.render(frame, frame.area(), &theme, |n| n == "clocks", error))
+                .unwrap();
+            let buffer = terminal.backend().buffer().clone();
+            (0..h)
+                .map(|y| (0..w).map(|x| buffer[(x, y)].symbol()).collect::<String>())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let picker = Picker::new(vec!["clocks".into(), "weather".into(), "cpu".into()]);
+
+        let calm = draw(&picker, None, 80, 24);
+        assert!(
+            calm.contains("▸ ■ clocks"),
+            "the placed widget is marked and under the cursor:\n{calm}"
+        );
+        assert!(
+            calm.contains("  □ weather"),
+            "an unplaced one is hollow:\n{calm}"
+        );
+        assert!(calm.contains("written to your config on close"), "{calm}");
+        assert!(
+            calm.contains("space") && calm.contains("toggle") && calm.contains("esc"),
+            "{calm}"
+        );
+
+        let failing = draw(&picker, Some("no `[layout]` rows found"), 80, 24);
+        assert!(
+            failing.contains("no `[layout]` rows found"),
+            "the error takes the line:\n{failing}"
+        );
+        assert!(
+            !failing.contains("written to your config"),
+            "and the promise is withdrawn:\n{failing}"
+        );
+
+        // Too small for the dialog: drawn as far as it can be, never a panic.
+        let _ = draw(&picker, None, 12, 4);
+        let _ = draw(&picker, None, 1, 1);
+    }
+
     #[test]
     fn the_cursor_clamps_at_both_ends() {
         let last = crate::widgets::WIDGET_NAMES.len() - 1;

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -591,6 +591,81 @@ mod tests {
 
     /// A list is chosen from, not completed into — `Tab` would be a second
     /// way to do what the arrows already do, and a worse one.
+    /// Path completion, against a real directory: Tab extends what was typed
+    /// to the longest start every match shares, a directory completes with
+    /// its slash so the next Tab goes into it, and no match leaves the text
+    /// alone. `candidates`, `common_prefix` and `expand_tilde` were all
+    /// unexecuted by the suite.
+    #[test]
+    fn tab_completes_a_path_to_the_shared_prefix_and_marks_directories() {
+        let dir = std::env::temp_dir().join(format!("mirador-complete-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("alps")).unwrap();
+        std::fs::write(dir.join("alpha.ics"), "").unwrap();
+        std::fs::write(dir.join("alphabet.ics"), "").unwrap();
+        let base = format!("{}/", dir.display());
+
+        let mut p = Prompt::new("FILE", "help", &format!("{base}al"), Completion::Paths);
+        press(&mut p, KeyCode::Tab);
+        assert_eq!(
+            p.value(),
+            format!("{base}alp"),
+            "the three matches share `alp`"
+        );
+
+        let mut p = Prompt::new("FILE", "help", &format!("{base}alph"), Completion::Paths);
+        press(&mut p, KeyCode::Tab);
+        assert_eq!(p.value(), format!("{base}alpha"), "two files share `alpha`");
+
+        let mut p = Prompt::new("FILE", "help", &format!("{base}alps"), Completion::Paths);
+        press(&mut p, KeyCode::Tab);
+        assert_eq!(
+            p.value(),
+            format!("{base}alps/"),
+            "a directory completes into itself"
+        );
+
+        let mut p = Prompt::new("FILE", "help", &format!("{base}zzz"), Completion::Paths);
+        press(&mut p, KeyCode::Tab);
+        assert_eq!(
+            p.value(),
+            format!("{base}zzz"),
+            "nothing matching changes nothing"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_tilde_means_home_and_nothing_else_is_touched() {
+        let home = dirs::home_dir().expect("a home directory");
+        assert_eq!(expand_tilde("~"), home);
+        assert_eq!(expand_tilde("~/cal.ics"), home.join("cal.ics"));
+        assert_eq!(
+            expand_tilde("/abs/cal.ics"),
+            std::path::PathBuf::from("/abs/cal.ics")
+        );
+        assert_eq!(
+            expand_tilde("rel/cal.ics"),
+            std::path::PathBuf::from("rel/cal.ics")
+        );
+        assert_eq!(expand_tilde(""), std::path::PathBuf::from(""));
+    }
+
+    #[test]
+    fn the_common_prefix_is_measured_in_characters_not_bytes() {
+        let s = |items: &[&str]| items.iter().map(|i| (*i).to_string()).collect::<Vec<_>>();
+        assert_eq!(common_prefix(&s(&[])), None);
+        assert_eq!(common_prefix(&s(&["alpha"])).as_deref(), Some("alpha"));
+        assert_eq!(
+            common_prefix(&s(&["alpha", "alphabet"])).as_deref(),
+            Some("alpha")
+        );
+        assert_eq!(common_prefix(&s(&["a", "b"])).as_deref(), Some(""));
+        // A cut inside `ü` would be a byte offset that is not a char boundary,
+        // and slicing there panics.
+        assert_eq!(common_prefix(&s(&["über", "übel"])).as_deref(), Some("übe"));
+    }
+
     #[test]
     fn tab_does_nothing_when_the_prompt_offers_a_list() {
         let mut p = prompt("Lis");

--- a/src/widgets/agenda.rs
+++ b/src/widgets/agenda.rs
@@ -951,6 +951,85 @@ mod tests {
     use super::*;
     use jiff::civil::date;
 
+    /// `f` asks for a path in place. A path that does not exist is refused
+    /// *inside the prompt*, keeping what was typed; Esc backs out; a path
+    /// that exists is taken and a reload is asked for. None of
+    /// `handle_prompt_key`, `set_path` or `ask_for_reload` had been executed
+    /// by a test.
+    #[test]
+    fn f_asks_for_a_path_and_a_missing_file_is_refused_where_it_was_typed() {
+        let dir =
+            std::env::temp_dir().join(format!("mirador-agenda-prompt-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let ics = dir.join("cal.ics");
+        let mut panel = AgendaPanel::new(&AgendaConfig::default(), ics.clone());
+        let key = |code| KeyEvent::new(code, ratatui::crossterm::event::KeyModifiers::NONE);
+
+        panel.handle_key(key(KeyCode::Char('f')));
+        assert!(panel.asking.is_some(), "`f` opens the prompt");
+        panel.handle_key(key(KeyCode::Enter));
+        let prompt = panel
+            .asking
+            .as_ref()
+            .expect("a missing file keeps the prompt open");
+        assert_eq!(
+            prompt.value(),
+            ics.display().to_string(),
+            "and keeps what was typed"
+        );
+        panel.handle_key(key(KeyCode::Esc));
+        assert!(panel.asking.is_none(), "Esc backs out");
+
+        std::fs::write(&ics, "BEGIN:VCALENDAR\nEND:VCALENDAR\n").unwrap();
+        panel.handle_key(key(KeyCode::Char('f')));
+        panel.handle_key(key(KeyCode::Enter));
+        assert!(panel.asking.is_none(), "a file that exists is taken");
+        assert_eq!(
+            panel.status.as_deref(),
+            Some(RELOADING),
+            "and a reload is under way"
+        );
+        assert_eq!(current_path(&panel.path), ics);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The wheel scrolls the agenda one row at a time and stops at the ends.
+    /// `handle_mouse` here had never been executed by a test.
+    #[test]
+    fn the_wheel_scrolls_the_agenda_and_stops_at_the_last_event() {
+        let mut panel =
+            AgendaPanel::new(&AgendaConfig::default(), PathBuf::from("/nonexistent.ics"));
+        let now = Zoned::now();
+        panel.shown.events = (0..3)
+            .map(|i| ical::Event {
+                summary: format!("event {i}"),
+                location: None,
+                start: now.checked_add(Span::new().hours(i + 1)).unwrap(),
+                end: Some(now.checked_add(Span::new().hours(i + 2)).unwrap()),
+                all_day: false,
+            })
+            .collect();
+        let wheel = |kind| MouseEvent {
+            kind,
+            column: 1,
+            row: 1,
+            modifiers: ratatui::crossterm::event::KeyModifiers::NONE,
+        };
+        for _ in 0..10 {
+            panel.handle_mouse(wheel(MouseEventKind::ScrollDown), Rect::new(0, 0, 40, 10));
+        }
+        assert_eq!(
+            panel.scroll.selected(),
+            Some(2),
+            "down stops at the last event"
+        );
+        for _ in 0..10 {
+            panel.handle_mouse(wheel(MouseEventKind::ScrollUp), Rect::new(0, 0, 40, 10));
+        }
+        assert_eq!(panel.scroll.selected(), Some(0), "up stops at the first");
+    }
+
     fn tz() -> TimeZone {
         TimeZone::get("America/New_York").unwrap()
     }

--- a/src/widgets/notes.rs
+++ b/src/widgets/notes.rs
@@ -1188,6 +1188,70 @@ mod tests {
         (p, TempDir(dir))
     }
 
+    /// The panel as drawn, one row per line.
+    fn rows_of(p: &mut NotesPanel, width: u16, height: u16) -> Vec<String> {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| {
+                p.render(
+                    frame,
+                    frame.area(),
+                    crate::panel::RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| (0..width).map(|x| buffer[(x, y)].symbol()).collect())
+            .collect()
+    }
+
+    /// `render_form` was never executed by a test. The caret is the whole
+    /// point of the form's drawing: it is what tells the writer which field
+    /// the next key lands in, and it has to follow Tab.
+    #[test]
+    fn the_note_form_draws_its_heading_and_puts_the_caret_in_the_active_field() {
+        let (mut p, _g) = panel("form-draw");
+        press(&mut p, KeyCode::Char('a'));
+        let rows = rows_of(&mut p, 60, 12);
+        assert!(rows[0].contains("NEW NOTE"), "{rows:?}");
+        assert!(rows[1].starts_with("title"), "{rows:?}");
+        assert!(
+            rows[1].contains('▏'),
+            "the caret starts in the title: {rows:?}"
+        );
+        assert!(rows[2].starts_with("body"), "{rows:?}");
+
+        press(&mut p, KeyCode::Tab);
+        let rows = rows_of(&mut p, 60, 12);
+        assert!(
+            !rows[1].contains('▏'),
+            "after Tab the title has no caret: {rows:?}"
+        );
+        press(&mut p, KeyCode::Esc);
+
+        add_note(&mut p, "Release checklist", "");
+        press(&mut p, KeyCode::Enter);
+        let rows = rows_of(&mut p, 60, 12);
+        assert!(
+            rows[0].contains("EDIT NOTE"),
+            "opening an existing note says so: {rows:?}"
+        );
+        assert!(
+            rows[1].contains("Release checklist"),
+            "and shows its title: {rows:?}"
+        );
+    }
+
     fn press(p: &mut NotesPanel, code: KeyCode) {
         p.handle_key(KeyEvent::new(code, KeyModifiers::NONE));
     }

--- a/src/widgets/todo.rs
+++ b/src/widgets/todo.rs
@@ -1380,6 +1380,90 @@ mod tests {
         );
     }
 
+    /// The panel as drawn at `width`x`height`, joined into one string.
+    fn screen_of(panel: &mut TodoPanel, width: u16, height: u16) -> String {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| {
+                panel.render(
+                    frame,
+                    frame.area(),
+                    crate::panel::RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The form and the delete prompt had key-handling tests and no drawing
+    /// tests: `render_form` and `render_confirm` were never executed. What the
+    /// reader sees is the contract — every field labelled, the active one
+    /// marked, and a title too long for the box abridged with `…` rather than
+    /// cut by the terminal.
+    #[test]
+    fn the_task_form_and_the_delete_prompt_draw_what_they_say() {
+        let (mut panel, _guard) = panel("form-draw");
+        add_task(&mut panel, "Renew the domain");
+
+        press(&mut panel, KeyCode::Char('a'));
+        let form = screen_of(&mut panel, 80, 24);
+        for label in ["New task", "Title", "Notes", "Due", "Priority", "Tags"] {
+            assert!(form.contains(label), "the form shows `{label}`:\n{form}");
+        }
+        for _ in 0..3 {
+            press(&mut panel, KeyCode::Tab);
+        }
+        let on_priority = screen_of(&mut panel, 80, 24);
+        assert!(
+            on_priority.contains("‹ low ›"),
+            "the active priority field shows its arrows:\n{on_priority}"
+        );
+        press(&mut panel, KeyCode::Esc);
+
+        press(&mut panel, KeyCode::Enter);
+        assert!(
+            screen_of(&mut panel, 80, 24).contains("Edit task"),
+            "editing an existing task says so"
+        );
+        press(&mut panel, KeyCode::Esc);
+
+        let long = "A".repeat(70);
+        add_task(&mut panel, &long);
+        press(&mut panel, KeyCode::Char('G'));
+        press(&mut panel, KeyCode::Char('d'));
+        let confirm = screen_of(&mut panel, 40, 12);
+        assert!(
+            confirm.contains("Delete task"),
+            "the prompt names itself:\n{confirm}"
+        );
+        assert!(confirm.contains("y delete"), "and its keys:\n{confirm}");
+        assert!(
+            confirm.contains('…'),
+            "a title wider than the box is abridged, not cut:\n{confirm}"
+        );
+        assert!(
+            !confirm.contains(&long),
+            "the whole title cannot fit and does not:\n{confirm}"
+        );
+    }
+
     fn press(panel: &mut TodoPanel, code: KeyCode) {
         panel.handle_key(KeyEvent::new(code, KeyModifiers::NONE));
     }

--- a/src/widgets/weather.rs
+++ b/src/widgets/weather.rs
@@ -1175,6 +1175,39 @@ mod tests {
         }
     }
 
+    /// `L` asks for a place. An empty answer is refused in the prompt — there
+    /// is nothing to fetch for — and a real one is written into the shared
+    /// config and the fetch thread is asked to go now. Neither
+    /// `handle_prompt_key` nor `set_location` had been executed by a test.
+    #[test]
+    fn l_asks_for_a_place_and_an_empty_answer_is_refused() {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut panel = WeatherPanel::offline(WeatherConfig {
+            location: "Boston".into(),
+            ..WeatherConfig::default()
+        });
+        let key = |code| KeyEvent::new(code, KeyModifiers::NONE);
+
+        panel.handle_key(key(KeyCode::Char('L')));
+        assert!(panel.asking.is_some(), "`L` opens the prompt");
+        for _ in 0.."Boston".len() {
+            panel.handle_key(key(KeyCode::Backspace));
+        }
+        panel.handle_key(key(KeyCode::Enter));
+        assert!(panel.asking.is_some(), "an empty place is refused in place");
+
+        for c in "Lisbon".chars() {
+            panel.handle_key(key(KeyCode::Char(c)));
+        }
+        panel.handle_key(key(KeyCode::Enter));
+        assert!(panel.asking.is_none(), "a place is taken");
+        assert_eq!(settings(&panel.config).location, "Lisbon");
+        assert!(
+            *panel.refresh.lock().unwrap(),
+            "and the thread is asked to fetch it now"
+        );
+    }
+
     #[test]
     fn every_optional_column_appears_as_soon_as_it_fits() {
         // The rule: a column appears at the first width that seats it while


### PR DESCRIPTION
Recommendation 2 of the test-quality pass. Coverage was 87% of lines and the gaps were not random — mouse handling in every panel and the shell, every form and prompt *as drawn*, the App-level seam of invariant 17, and the picker's render had never been executed by a test. Fourteen tests, each asserting a property rather than a line count.

**Mouse routing, observed from outside.** A scroll over the tasks panel while notes is focused is consumed, leaves focus where it was, and moved the selection — read by Tab-ing focus there afterwards and finding the marker one row below where a control that never scrolled finds it. A click focuses the panel it lands in and selects the row it hit. An open form vetoes a click landing in another panel. Red-on-break: make scroll move focus and the first fails.

**Invariant 17 at the App level.** A preference moved off the config is written to the state file; moved back, it is retracted. Red-on-break by removing `only_changes_from` — the failure that shipped twice.

**The picker's write.** Toggling a widget off reaches the config as a textual edit that keeps the comment above a panel; a file in the `[[layout.rows]]` form is refused and reported, and left byte-for-byte untouched. Both through the keys.

**Drawn, not just handled:** the task form (every label, the active priority's arrows, `Edit task` for an existing one), the delete prompt (abridging a 70-character title with `…` in a 40-column box), the note form (heading, caret following Tab, `EDIT NOTE`), the picker (marks, cursor, the promise line, the error replacing it, and two sizes too small for it without a panic).

**Prompts:** path completion against a real directory — shared prefix, a directory completing with its slash, no match leaving the text alone — plus `expand_tilde` and a `common_prefix` measured in characters (`über`/`übel` → `übe`, where a byte cut would panic); the agenda's `f` refusing a missing file *in the prompt* with the text kept and taking a real one with a reload under way; the weather `L` refusing an empty place and writing a real one through to the fetch thread; the agenda's wheel stopping at both ends.

Two things the tests had to learn, both recorded in the tests themselves: a rendered row sliced by byte index panics on the frame's `│` (invariant 9 reaching into a test — `chars().skip()`), and a `[layout]` fixture with two panels on one line is refused by `layout_edit` (correctly), so fixtures are one panel per line like the shipped config. App tests that involve tasks or notes point those files at a scratch directory; without that they would operate on the owner's real task list.

Gates: 852 tests, clippy, fmt, rustdoc, `cargo +1.95.0 check --locked --all-targets` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)