### PR TITLE
Release 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-09-10
+
 ### Fixed
 
 - **The clock's small seconds could be cut to one digit.** When the panel is
@@ -16,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   down to `2`. The pair is now sized together, and where even that does not
   fit the clock steps straight down to plain text with every digit intact
   rather than to numerals with the seconds silently missing.
+
+- **Four more places were cut by the terminal at narrow widths**, found by
+  the same sweep: the clock's plain-text fallback, the notes' `written …
+  edited …` line, the agenda's day headings and event rows, and the cpu
+  panel's `PER CORE` label. Each now abridges with `…` or drops a whole value
+  rather than leaving a fragment. The cpu panel's per-core strip, which drew
+  one mark per column and stopped at the edge, ends in `…` when there are
+  more cores than columns.
 
 ## [1.10.1] - 2026-09-09
 
@@ -1804,7 +1814,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.10.2...HEAD
+[1.10.2]: https://github.com/jchultarsky/mirador/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/jchultarsky/mirador/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/jchultarsky/mirador/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/jchultarsky/mirador/compare/v1.8.0...v1.9.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1995,11 +1995,15 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.10.1` is released**, as a GitHub release with binaries for macOS
+- **`1.10.2` is released**, as a GitHub release with binaries for macOS
   arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
-  and published on crates.io. It carries one change — the notes panel
-  stopping repeating the count its border already shows, which is the
-  screen-tightening pass finding a panel it had missed. 1.10.0, hours
+  and published on crates.io. It carries what the silent-clip sweep found
+  the day it was written — the clock's small seconds cut to one digit at
+  40 columns, and four narrower cuts — and nothing else user-visible; the
+  test-quality pass behind it (the sweep, fourteen input and form tests,
+  the protocol document as wire corpus) rides along. 1.10.1 carried one
+  change — the notes panel stopping repeating the count its border already
+  shows, which is the screen-tightening pass finding a panel it had missed. 1.10.0, hours
   earlier, was that pass itself — the silently-cut clock date being the
   one defect in it — and the first release cut through `cut-release.yml`
   rather than from the owner's machine, which is the step those workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Bumps `Cargo.toml`, moves the CHANGELOG's Unreleased section under `1.10.2` with its two link references (and adds the four narrower cuts and the per-core strip to the entry, since they ship here too), and updates `CLAUDE.md`'s released line — all in one commit, as `the_released_version_in_the_notes_matches_the_manifest` and `every_released_version_has_a_changelog_link` require.

User-visible in this release: the clock's small seconds no longer cut to one digit at ~40 columns (#239), plus four narrower silent cuts fixed at the source and the cpu per-core strip ending in `…` when there are more cores than columns. Behind it, not user-visible: the silent-clip sweep itself, fourteen input/forms tests (#240), and the protocol document as wire corpus (#241).

Step 0 done before opening this: the 1.10.2 release build driven under tmux at 120x40 — status bar, help overlay reading `v1.10.2`, the task form, arrange mode, a clean `q` — and the clock panel at a frame leaving 42 interior cells (numerals with `24` intact beside them) and 38 (plain text with every digit). All five gates green: 854 tests, clippy, fmt, rustdoc, `cargo +1.95.0 check --locked --all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)