### PR TITLE
A memory panel, and the abridging bug its tests found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A memory panel.** Memory in use as a percentage, a moving braille chart
+  of it, and — on a machine that has swap — a swap meter that `s` hides and
+  shows. It is `cpu`'s sibling in every respect and sits beside it on the
+  instrument row of the default layout, which now holds five panels; the
+  markets grid keeps its width and its change column, and the timer and the
+  two graphs each gave up a little. `[memory]` in the config carries the same
+  `history` and `sample_secs` as `[cpu]`.
+
+### Fixed
+
+- **A readout squeezed below the width of its first value could lose its
+  unit without saying so.** `38` for `38%`, at a width of three cells, in any
+  panel whose first value is a figure beside a unit. The abridging now marks
+  the cut with `…` wherever it falls. Found by the memory panel's own tests
+  on the day it was written.
+
 ## [1.10.2] - 2026-09-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ docs.rs      the guard on *this file* — cited tests, version, paths, and that
              every module below is listed — and on the README's panel
              drawings and key tables, the other documentation nothing compiles
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
-             pomodoro, watchlog, news, cpu, network, calculator
+             pomodoro, watchlog, news, cpu, memory, network, calculator
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -261,7 +261,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 327 of them, including the ones mirador
+    trip through `toml` discards all 335 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -345,6 +345,17 @@ map, that one is the procedure.
     keeps that sweep complete, and
     `every_hand_built_composite_line_in_a_widget_is_accounted_for` counts what
     is left and makes a new one justify itself.
+
+    **`grid::assemble` itself had the bug it exists to prevent, until
+    2026-09-11.** When the *first* part did not fit it truncated span by span
+    and stopped when the room ran out — so a span that fitted exactly left the
+    spans after it dropped in silence: ` 38` for ` 38%` at three columns, the
+    unit gone with no `…`. Every readout built from a figure span and a unit
+    span had it latently. It was found by the new memory panel's readout
+    sweep, a test that asserts the exact text at every width from 1 to 40 and
+    so *can* fail; the whole part is abridged as one string now and handed
+    back to its spans, so the ellipsis lands wherever the cut falls.
+    `a_first_part_abridged_at_a_span_boundary_still_says_so`.
 
     **A render-level sweep at one width cannot check this, and it was tried
     first.** A buffer records what the terminal *kept*, so an overflowing line
@@ -1091,9 +1102,25 @@ persistence story rests on. The known cost is that panels of unlike natural
 height in one row waste space; the mitigation is that arrange mode makes it
 easy to group like with like.
 
-**The default is four rows of thirteen panels**, re-measured at 120x40 on
-2026-08-01 when the calculator joined it: nothing truncates, every panel is
-legible and no frame title is clipped.
+**The default is four rows of fourteen panels**, re-measured at 120x40 on
+2026-09-11 when `memory` joined it: nothing truncates, every panel is legible
+and no frame title is clipped. It was thirteen from 2026-08-01, when the
+calculator arrived, until then.
+
+**`memory` is the fourteenth, and it went where the calculator could not.**
+It is the missing quarter of "what compute is available" — every monitor this
+program borrows from pairs CPU with memory before it shows network — and it is
+`cpu` with a different sample: the same braille history, the same meter, and
+*the same gradient*, deliberately. A `memory_gradient` key would have been a
+line in nineteen theme files for a distinction between two gauges of one
+instrument that nobody would see; the cpu ramp colours both. The instrument
+row now holds five, and the arithmetic that refused the calculator a place
+there still holds: `stocks` keeps its 30 and its change column, and memory's
+cells come from the three panels that scale — pomodoro 24 → 17, cpu 20 → 17,
+network 26 → 20, memory 16. At 120 columns that costs the pomodoro its
+`25m focus · 5m break` line (dropped whole) and nothing else; the border
+counter says whole gigabytes because `64.0 GB` cost the title its last two
+letters. `s` toggles a swap row, drawn only when the machine has swap.
 
 Where the thirteenth went was decided by arithmetic rather than taste, and the
 arithmetic is worth keeping. The instrument row was the obvious home — a

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ overwritten, so resetting twice still leaves the first one recoverable.
 
 ## The panels
 
-Thirteen widgets, each answering one question. Put the ones you want in the
+Fourteen widgets, each answering one question. Put the ones you want in the
 layout and drop the rest — a widget your layout leaves out is never built, and
 nothing will nag you about it.
 
@@ -756,27 +756,29 @@ answers stay: an answer without its sum is still an answer.
 Nothing is kept when you quit. There is no memory key, no percent key and no
 functions — the tape and carrying an answer forward cover what those were for.
 
-### CPU and network
+### CPU, memory and network
 
 CPU shows average load, a moving history graph and a per-core meter row —
-`c` toggles that row when the panel is focused. Network shows receive and
-transmit rates as two graphs, plus a session total and the peak rate seen.
+`c` toggles that row when the panel is focused. Memory shows the share in use,
+the same kind of graph, and a swap meter when the machine has swap — `s`
+toggles that. Network shows receive and transmit rates as two graphs, plus a
+session total and the peak rate seen.
 
-Both draw their history in **braille**, which packs two samples into every
+All three draw their history in **braille**, which packs two samples into every
 character cell and four levels into every row — twice the horizontal
 resolution of a block-element sparkline in the same space. The colour gradient
 runs *vertically by magnitude*, one colour per row, so the profile stays put
 as data scrolls: a graph left on screen all day changes colour when the load
 changes, not merely because time passed.
 
-> These two panels are the one thing this README will not show you in a code
+> These three panels are the one thing this README will not show you in a code
 > block. Braille is missing from several of the fonts GitHub falls back to, so
 > the glyphs render at a width the surrounding box characters do not share and
 > the panel tears itself apart. The recording at the top of this file shows
 > them as they actually look. It is a real terminal, which is the only place
 > the alignment is guaranteed.
 
-Both buffers grow to fill the panel, so `history` is a floor on what is kept
+Every buffer grows to fill its panel, so `history` is a floor on what is kept
 rather than a cap on what a wider panel can draw.
 
 ## Command line
@@ -957,6 +959,7 @@ rather than failing quietly.
 | `pomodoro` | A focus timer: phase, time left, progress, and the set so far |
 | `calculator` | Type a sum, press Enter; an adding machine's tape of what you worked out |
 | `cpu` | Average utilisation, a moving chart, and per-core meters |
+| `memory` | Memory in use, a moving chart, and a swap meter |
 | `network` | Receive and transmit rates as moving charts |
 
 ### External panels (optional)

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -89,13 +89,16 @@ rows = [
   { height = 18, panels = [
     # The timer draws block numerals when it has the width for them and falls
     # back to plain text when it does not.
-    { widget = "pomodoro", width = 24 },
+    { widget = "pomodoro", width = 17 },
     # 30 keeps the change column at 120 columns; below a panel width of 35 the
     # markets grid drops it rather than clipping a number. 35 because the grid
     # needs 29, plus 2 for the selection marker and 4 for the frame.
     { widget = "stocks",   width = 30 },
-    { widget = "cpu",      width = 20 },
-    { widget = "network",  width = 26 },
+    # Memory's cells come from the three panels that scale — the timer and the
+    # two graphs — and none from the markets grid, which cannot give any.
+    { widget = "cpu",      width = 17 },
+    { widget = "memory",   width = 16 },
+    { widget = "network",  width = 20 },
   ] },
 ]
 
@@ -459,6 +462,17 @@ sample_secs   = 2             # seconds between samples. Every sample is a new
 show_per_core = true
 warn_pct      = 70.0
 critical_pct  = 90.0
+
+# ---------------------------------------------------------------------------
+# Memory
+#
+# Memory in use as a percentage, a moving chart of it, and a swap meter when
+# the machine has swap. `s` hides and shows the swap row.
+# ---------------------------------------------------------------------------
+[memory]
+history     = 120             # a floor, not a cap — see the note under [cpu]
+sample_secs = 2               # see the note under [cpu]
+show_swap   = true
 
 # ---------------------------------------------------------------------------
 # Network

--- a/src/app.rs
+++ b/src/app.rs
@@ -2647,7 +2647,7 @@ mod tests {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
-        // One panel out of thirteen, so twelve are unused — the loudest possible
+        // One panel out of fourteen, so thirteen are unused — the loudest possible
         // case for the hint that used to be here.
         let mut app = App::new(config_with(&["clocks"])).unwrap();
         let screen = |app: &mut App, help: bool| -> String {

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -54,7 +54,7 @@ impl Default for Layout {
                 row(
                     18,
                     &[
-                        ("pomodoro", 24),
+                        ("pomodoro", 17),
                         // 30 rather than 28 so the change column survives at
                         // 120 columns. Below a panel width of 35 the grid drops
                         // it rather than clipping a number, which is right — but
@@ -66,8 +66,12 @@ impl Default for Layout {
                         // `839 B` rather than `839 B/s`, which is the very
                         // failure being fixed, one panel over.
                         ("stocks", 30),
-                        ("cpu", 20),
-                        ("network", 26),
+                        // Memory takes its cells from the three panels that
+                        // scale — pomodoro, cpu and network — and none from
+                        // `stocks`, which cannot give any: see above.
+                        ("cpu", 17),
+                        ("memory", 16),
+                        ("network", 20),
                     ],
                 ),
             ],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,8 +49,8 @@ pub use plugins::PluginConfig;
 #[allow(unused_imports)]
 pub use widgets::{
     AgendaConfig, CalculatorConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig,
-    NetworkConfig, NewsConfig, NewsFeed, NotesConfig, PomodoroConfig, StocksConfig, TodoConfig,
-    WeatherConfig,
+    MemoryConfig, NetworkConfig, NewsConfig, NewsFeed, NotesConfig, PomodoroConfig, StocksConfig,
+    TodoConfig, WeatherConfig,
 };
 
 /// Top-level configuration.
@@ -81,6 +81,7 @@ pub struct Config {
     pub pomodoro: PomodoroConfig,
     pub calculator: CalculatorConfig,
     pub cpu: CpuConfig,
+    pub memory: MemoryConfig,
     pub network: NetworkConfig,
 }
 

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -370,6 +370,28 @@ impl Default for CpuConfig {
     }
 }
 
+/// Memory chart settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct MemoryConfig {
+    /// Number of samples retained in the moving chart — a floor, as for `cpu`.
+    pub history: usize,
+    /// Seconds between samples. See the note on `CpuConfig::sample_secs`.
+    pub sample_secs: u64,
+    /// Draw a swap row under the graph, when the machine has any.
+    pub show_swap: bool,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            history: 120,
+            sample_secs: 2,
+            show_swap: true,
+        }
+    }
+}
+
 /// Network chart settings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -581,15 +581,43 @@ pub fn assemble(parts: Vec<Vec<Span<'static>>>, width: u16) -> Line<'static> {
         if used + part_width > width {
             // Nothing has been placed and this part is too wide for the line:
             // show as much of it as fits, ellipsised, rather than nothing.
+            //
+            // Abridged as one value, not span by span. The first version
+            // truncated each span into the room left and stopped when the room
+            // ran out — so when a span fitted *exactly*, the spans after it
+            // were dropped and nothing said so: ` 38` where ` 38%` was meant,
+            // the `%` gone without an ellipsis, at three columns. The memory
+            // panel's readout sweep found it. The whole part is truncated as
+            // one string and then handed back to its spans in order, so the
+            // `…` lands wherever the cut falls, boundary or not.
             if spans.is_empty() {
-                let mut room = width;
+                let whole: String = part.iter().map(|s| s.content.as_ref()).collect();
+                let mut abridged = truncate(&whole, width);
                 for span in part {
-                    if room == 0 {
+                    if abridged.is_empty() {
                         break;
                     }
-                    let text = truncate(&span.content, room);
-                    room -= display_width(&text);
-                    spans.push(Span::styled(text, span.style));
+                    // This span's share is its own width, or whatever is left
+                    // of the abridged text — the ellipsis included — if the cut
+                    // fell inside or at the end of it.
+                    let take = display_width(&span.content).min(display_width(&abridged));
+                    let mut cells = 0;
+                    let split = abridged
+                        .char_indices()
+                        .find(|(_, c)| {
+                            let w = display_width(&c.to_string());
+                            if cells + w > take {
+                                return true;
+                            }
+                            cells += w;
+                            false
+                        })
+                        .map_or(abridged.len(), |(i, _)| i);
+                    let rest = abridged.split_off(split);
+                    spans.push(Span::styled(
+                        std::mem::replace(&mut abridged, rest),
+                        span.style,
+                    ));
                 }
             }
             break;
@@ -631,6 +659,50 @@ fn fit(text: &str, width: u16, align: Align) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The first part of a line that does not fit is abridged *as a value*:
+    /// however its spans are cut, the result ends in `…`. Span by span, a span
+    /// that fitted exactly left the ones after it dropped in silence —
+    /// ` 38` for ` 38%` at three columns, the unit gone and nothing marking it —
+    /// which is the one thing this function exists to prevent.
+    #[test]
+    fn a_first_part_abridged_at_a_span_boundary_still_says_so() {
+        use ratatui::style::Style;
+        let part = || {
+            vec![
+                Span::styled(" 38", Style::default()),
+                Span::styled("%", Style::default()),
+            ]
+        };
+        let text = |line: &Line<'static>| -> String {
+            line.spans.iter().map(|s| s.content.as_ref()).collect()
+        };
+
+        // Exactly at the boundary between the spans.
+        let cut = assemble(vec![part()], 3);
+        assert_eq!(
+            text(&cut),
+            " 3\u{2026}",
+            "the cut at the span boundary is marked"
+        );
+        assert_eq!(display_width(&text(&cut)), 3);
+
+        // Inside the first span.
+        assert_eq!(text(&assemble(vec![part()], 2)), " \u{2026}");
+
+        // Fits whole: untouched, both spans intact.
+        let whole = assemble(vec![part()], 4);
+        assert_eq!(text(&whole), " 38%");
+        assert_eq!(
+            whole.spans.len(),
+            2,
+            "no spans are merged when nothing is cut"
+        );
+
+        // Nothing at all.
+        assert_eq!(text(&assemble(vec![part()], 0)), "");
+    }
+
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::widgets::{Paragraph, Wrap};

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 327;
+        const CITED: usize = 335;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/widgets/memory.rs
+++ b/src/widgets/memory.rs
@@ -1,0 +1,414 @@
+//! Memory in use, as a live readout plus a scrolling history chart.
+//!
+//! The fourth quarter of "what compute is available": `cpu` and `network` had
+//! answered the question for a year with the middle of every system monitor
+//! missing. Built as `cpu` is — the same sampler cadence, the same braille
+//! history, the same meter — because a reader who has learned one should not
+//! have to learn the other. It draws from the cpu gradient rather than a ramp
+//! of its own: the two are one instrument reading two gauges, and a fourth
+//! gradient key would have been a line in nineteen theme files for a
+//! distinction nobody would see.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::Paragraph;
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
+
+use crate::chart::{BrailleGraph, meter_spans};
+use crate::config::MemoryConfig;
+use crate::frame::Binding;
+use crate::panel::{Panel, RenderContext};
+
+/// The memory panel.
+pub struct MemoryPanel {
+    config: MemoryConfig,
+    system: System,
+    /// Recent used-percentage samples, oldest first.
+    history: VecDeque<u64>,
+    /// The most recent reading, in bytes.
+    reading: Reading,
+    /// `None` until the first sample, so it fires immediately.
+    last_sample: Option<Instant>,
+    /// Cells the graph was last drawn into, so the history can grow to fill it.
+    graph_cells: usize,
+}
+
+/// One sample of the machine's memory, in bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Reading {
+    used: u64,
+    total: u64,
+    swap_used: u64,
+    swap_total: u64,
+}
+
+impl Reading {
+    /// Used memory as a whole percentage of the total. A machine reporting no
+    /// memory at all — a sandbox, a container with the file unmounted — reads
+    /// as `0` rather than dividing by zero.
+    fn used_pct(self) -> u64 {
+        percent(self.used, self.total)
+    }
+}
+
+/// `part` as a whole percentage of `whole`, saturating at 100 and reading `0`
+/// for a whole of zero.
+fn percent(part: u64, whole: u64) -> u64 {
+    if whole == 0 {
+        return 0;
+    }
+    ((u128::from(part.min(whole)) * 100) / u128::from(whole)) as u64
+}
+
+/// Bytes as gibibytes to one decimal, which is how memory is sold and how
+/// every other monitor states it.
+fn gib(bytes: u64) -> String {
+    format!("{:.1}", bytes as f64 / 1_073_741_824.0)
+}
+
+/// Bytes as whole gibibytes, rounded, for the border counter.
+fn whole_gib(bytes: u64) -> u64 {
+    (bytes as f64 / 1_073_741_824.0).round() as u64
+}
+
+// `sysinfo::System` is deliberately opaque, so derive(Debug) is unavailable.
+impl std::fmt::Debug for MemoryPanel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryPanel")
+            .field("reading", &self.reading)
+            .field("samples", &self.history.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl MemoryPanel {
+    /// Build the panel and take a first sample.
+    pub fn new(config: MemoryConfig) -> Self {
+        let mut system = System::new_with_specifics(
+            RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+        );
+        system.refresh_memory();
+        let reading = Self::read(&system);
+
+        Self {
+            history: VecDeque::with_capacity(config.history.max(1)),
+            config,
+            system,
+            reading,
+            last_sample: None,
+            graph_cells: 0,
+        }
+    }
+
+    /// A panel holding `reading`, with no `sysinfo` behind it, for tests in
+    /// other modules — a reading is a reading, whichever machine took it.
+    #[cfg(test)]
+    pub(crate) fn with_reading(config: MemoryConfig, used: u64, total: u64) -> Self {
+        let mut panel = Self::new(config);
+        panel.reading = Reading {
+            used,
+            total,
+            swap_used: 0,
+            swap_total: 0,
+        };
+        panel.history.clear();
+        panel.history.push_back(panel.reading.used_pct());
+        panel
+    }
+
+    fn read(system: &System) -> Reading {
+        Reading {
+            used: system.used_memory(),
+            total: system.total_memory(),
+            swap_used: system.used_swap(),
+            swap_total: system.total_swap(),
+        }
+    }
+
+    /// Take a sample if enough time has passed since the last one. Returns
+    /// whether it did, so a tick that changed nothing costs no repaint.
+    fn sample(&mut self) -> bool {
+        let interval = Duration::from_secs(self.config.sample_secs.max(1));
+        if self.last_sample.is_some_and(|at| at.elapsed() < interval) {
+            return false;
+        }
+        self.system.refresh_memory();
+        self.reading = Self::read(&self.system);
+        self.last_sample = Some(Instant::now());
+
+        let capacity = crate::samples::capacity(self.config.history, self.graph_cells);
+        crate::samples::push_bounded(&mut self.history, self.reading.used_pct(), capacity);
+        true
+    }
+}
+
+/// Keys this panel responds to.
+const BINDINGS: &[Binding] = &[Binding::primary("s", "swap")];
+
+impl Panel for MemoryPanel {
+    fn title(&self) -> String {
+        "Memory".to_string()
+    }
+
+    fn counter(&self) -> Option<String> {
+        // Whole gigabytes: `64.0 GB` cost the title its last letters at 120
+        // columns (`┤Memo…├`), and the decimal is in the readout below for
+        // anyone who wants it.
+        (self.reading.total > 0).then(|| format!("{} GB", whole_gib(self.reading.total)))
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        Duration::from_millis(500)
+    }
+
+    fn tick(&mut self) -> bool {
+        self.sample()
+    }
+
+    fn handle_key(&mut self, key: ratatui::crossterm::event::KeyEvent) -> crate::panel::KeyOutcome {
+        use ratatui::crossterm::event::KeyCode;
+        if matches!(key.code, KeyCode::Char('s')) {
+            self.config.show_swap = !self.config.show_swap;
+            return crate::panel::KeyOutcome::Consumed;
+        }
+        crate::panel::KeyOutcome::Ignored
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        let theme = ctx.theme;
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+
+        let gradient = &ctx.gradients.cpu;
+        let track = Style::default().fg(theme.track);
+        // Swap is worth a row only when the machine has some and the panel has
+        // the height; a machine without swap has nothing to say about it.
+        let show_swap = self.config.show_swap && self.reading.swap_total > 0 && area.height >= 5;
+
+        let rows = Layout::vertical([
+            Constraint::Length(1),                        // readout
+            Constraint::Min(1),                           // graph
+            Constraint::Length(u16::from(show_swap) * 2), // swap label + meter
+        ])
+        .split(area);
+
+        let pct = self.reading.used_pct();
+        let colour = gradient.at(i64::try_from(pct).unwrap_or(100));
+        // Three parts, dropped from the end: the figure and its `%` are one
+        // value; the word USED goes next; the absolute figures go first, since
+        // a percentage in a panel titled Memory says the most in the least.
+        frame.render_widget(
+            Paragraph::new(crate::grid::assemble(
+                vec![
+                    vec![
+                        Span::styled(
+                            format!("{pct:>3}"),
+                            Style::default().fg(colour).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled("%", Style::default().fg(theme.muted)),
+                    ],
+                    vec![Span::styled(
+                        format!(" {}", crate::glyphs::utility("used")),
+                        Style::default()
+                            .fg(theme.label)
+                            .add_modifier(Modifier::BOLD),
+                    )],
+                    vec![Span::styled(
+                        format!(
+                            "   {} / {} GB",
+                            gib(self.reading.used),
+                            gib(self.reading.total)
+                        ),
+                        Style::default().fg(theme.muted),
+                    )],
+                ],
+                rows[0].width,
+            )),
+            rows[0],
+        );
+
+        // Recorded so the next tick can size the buffer to the panel.
+        self.graph_cells = rows[1].width as usize;
+
+        if rows[1].height > 0 {
+            let data: Vec<u64> = self.history.iter().copied().collect();
+            BrailleGraph::new(&data, 100, gradient)
+                .track_style(track)
+                .render(rows[1], frame.buffer_mut());
+        }
+
+        if show_swap && rows[2].height >= 2 {
+            let swap_pct = percent(self.reading.swap_used, self.reading.swap_total);
+            frame.render_widget(
+                Paragraph::new(crate::grid::assemble(
+                    vec![
+                        vec![Span::styled(
+                            crate::glyphs::utility("swap"),
+                            Style::default()
+                                .fg(theme.label)
+                                .add_modifier(Modifier::BOLD),
+                        )],
+                        vec![Span::styled(
+                            format!(
+                                "   {} / {} GB",
+                                gib(self.reading.swap_used),
+                                gib(self.reading.swap_total)
+                            ),
+                            Style::default().fg(theme.muted),
+                        )],
+                    ],
+                    rows[2].width,
+                )),
+                Rect::new(rows[2].x, rows[2].y, rows[2].width, 1),
+            );
+            let y = rows[2].y + 1;
+            for (index, (glyph, style)) in
+                meter_spans(swap_pct, 100, rows[2].width, gradient, track)
+                    .iter()
+                    .enumerate()
+            {
+                let x = rows[2].x + u16::try_from(index).unwrap_or(u16::MAX);
+                if x >= rows[2].x + rows[2].width {
+                    break;
+                }
+                frame.buffer_mut()[(x, y)]
+                    .set_char(*glyph)
+                    .set_style(*style);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_percentage_saturates_and_never_divides_by_zero() {
+        assert_eq!(percent(0, 0), 0, "no memory at all reads as nothing used");
+        assert_eq!(percent(5, 0), 0);
+        assert_eq!(percent(1, 4), 25);
+        assert_eq!(percent(4, 4), 100);
+        assert_eq!(
+            percent(9, 4),
+            100,
+            "used past total saturates rather than overflowing"
+        );
+        assert_eq!(
+            percent(u64::MAX, u64::MAX),
+            100,
+            "the widest inputs multiply without overflow"
+        );
+    }
+
+    #[test]
+    fn gibibytes_are_stated_to_one_decimal() {
+        assert_eq!(gib(0), "0.0");
+        assert_eq!(gib(1_073_741_824), "1.0");
+        assert_eq!(gib(17_179_869_184), "16.0");
+        assert_eq!(gib(6_657_199_308), "6.2");
+    }
+
+    /// Every line the panel builds by hand is assembled, so a narrow panel
+    /// drops the absolute figures before the word and the word before the
+    /// percentage — never a fragment of any of them. Swept against the sizes
+    /// a narrow instrument row actually hands it.
+    #[test]
+    fn the_readout_drops_whole_values_and_never_a_fragment() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut panel =
+            MemoryPanel::with_reading(MemoryConfig::default(), 6_657_199_308, 17_179_869_184);
+
+        for width in 1..=40u16 {
+            let mut terminal = Terminal::new(TestBackend::new(width, 6)).unwrap();
+            terminal
+                .draw(|frame| {
+                    panel.render(
+                        frame,
+                        frame.area(),
+                        RenderContext {
+                            theme: &config.theme,
+                            gradients: &gradients,
+                            focused: true,
+                            watch: &crate::watch::WatchLog::default(),
+                        },
+                    );
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer().clone();
+            let readout: String = (0..width).map(|x| buffer[(x, 0)].symbol()).collect();
+            let readout = readout.trim_end();
+            // `assemble` abridges a first part that cannot fit at all with
+            // `…`, which is the marked cut invariant 19 asks for; everything
+            // else is whole values or nothing. What must never appear is an
+            // unmarked fragment like `38` or `6.2 / 16`.
+            let readout = readout.trim();
+            assert!(
+                readout.is_empty()
+                    || readout.ends_with('\u{2026}')
+                    || readout == "38%"
+                    || readout == "38% USED"
+                    || readout == "38% USED   6.2 / 16.0 GB",
+                "at width {width} the readout was {readout:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_border_carries_the_total_and_nothing_when_there_is_none() {
+        let panel = MemoryPanel::with_reading(MemoryConfig::default(), 1, 17_179_869_184);
+        assert_eq!(panel.counter().as_deref(), Some("16 GB"));
+        let odd = MemoryPanel::with_reading(MemoryConfig::default(), 1, 8_267_366_400);
+        assert_eq!(
+            odd.counter().as_deref(),
+            Some("8 GB"),
+            "7.7 GB rounds to the nearest whole"
+        );
+        let none = MemoryPanel::with_reading(MemoryConfig::default(), 0, 0);
+        assert_eq!(none.counter(), None);
+    }
+
+    #[test]
+    fn s_toggles_the_swap_row_and_is_documented() {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut panel = MemoryPanel::with_reading(MemoryConfig::default(), 1, 2);
+        let before = panel.config.show_swap;
+        let outcome = panel.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(outcome, crate::panel::KeyOutcome::Consumed);
+        assert_ne!(panel.config.show_swap, before);
+        assert!(
+            BINDINGS.iter().any(|b| b.key == "s"),
+            "the key the panel takes is the key it advertises"
+        );
+    }
+
+    #[test]
+    fn the_history_is_bounded_by_what_the_panel_can_draw() {
+        let mut panel = MemoryPanel::with_reading(
+            MemoryConfig {
+                history: 4,
+                ..MemoryConfig::default()
+            },
+            1,
+            2,
+        );
+        panel.graph_cells = 0;
+        for i in 0..50 {
+            crate::samples::push_bounded(&mut panel.history, i, crate::samples::capacity(4, 0));
+        }
+        assert!(panel.history.len() <= 8, "bounded: {}", panel.history.len());
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -9,6 +9,7 @@ pub mod calculator;
 pub mod calendar;
 pub mod clocks;
 pub mod cpu;
+pub mod memory;
 pub mod network;
 pub mod news;
 pub mod notes;
@@ -36,6 +37,7 @@ pub const WIDGET_NAMES: &[&str] = &[
     "watchlog",
     "news",
     "cpu",
+    "memory",
     "network",
     "calculator",
 ];
@@ -77,6 +79,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
         )),
         "pomodoro" => Box::new(pomodoro::PomodoroPanel::new(config.pomodoro.clone())),
         "cpu" => Box::new(cpu::CpuPanel::new(config.cpu.clone())),
+        "memory" => Box::new(memory::MemoryPanel::new(config.memory.clone())),
         "network" => Box::new(network::NetworkPanel::new(config.network.clone())),
         "calculator" => Box::new(calculator::CalculatorPanel::new(config.calculator)),
         _ => {
@@ -187,18 +190,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Every panel, built with nothing behind it that leaves the process, and
-    /// with enough on screen to be worth measuring: seeded tasks and notes, a
-    /// canned watchlist and reading, three headlines, a calendar with events
-    /// tomorrow.
-    ///
-    /// Named alongside `WIDGET_NAMES` and checked against it, so a new widget
-    /// cannot be left out of the sweep without this failing to compile the
-    /// list it expects.
-    fn offline_panels(
-        dir: &std::path::Path,
-        config: &Config,
-    ) -> Vec<(&'static str, Box<dyn Panel>)> {
+    /// A calendar with events tomorrow and three headlines, written and built
+    /// for the sweep so the agenda and news panels have something to measure.
+    fn sample_data(dir: &std::path::Path) -> (std::path::PathBuf, Vec<crate::feed::Story>) {
         let today = jiff::Zoned::now().date();
         let tomorrow = today.tomorrow().unwrap_or(today);
         let ics = dir.join("sample.ics");
@@ -232,6 +226,23 @@ mod tests {
                 "A very long headline that has to wrap on any panel narrower than it",
             ),
         ];
+
+        (ics, stories)
+    }
+
+    /// Every panel, built with nothing behind it that leaves the process, and
+    /// with enough on screen to be worth measuring: seeded tasks and notes, a
+    /// canned watchlist and reading, three headlines, a calendar with events
+    /// tomorrow.
+    ///
+    /// Named alongside `WIDGET_NAMES` and checked against it, so a new widget
+    /// cannot be left out of the sweep without this failing to compile the
+    /// list it expects.
+    fn offline_panels(
+        dir: &std::path::Path,
+        config: &Config,
+    ) -> Vec<(&'static str, Box<dyn Panel>)> {
+        let (ics, stories) = sample_data(dir);
 
         let panels: Vec<(&'static str, Box<dyn Panel>)> = vec![
             (
@@ -282,6 +293,14 @@ mod tests {
                 Box::new(news::NewsPanel::offline(&config.news, stories)),
             ),
             ("cpu", Box::new(cpu::CpuPanel::new(config.cpu.clone()))),
+            (
+                "memory",
+                Box::new(memory::MemoryPanel::with_reading(
+                    config.memory.clone(),
+                    6_657_199_308,
+                    17_179_869_184,
+                )),
+            ),
             (
                 "network",
                 Box::new(network::NetworkPanel::new(config.network.clone())),


### PR DESCRIPTION
The fourteenth widget, and the one clear hole against the project's own filter: "what compute is available" had `cpu` and `network` with the middle of every system monitor missing.

## The panel

Memory in use as a percentage, a moving braille chart, and — on a machine that has swap — a swap meter that `s` hides and shows. It is `cpu`'s sibling in every respect: same sampler cadence, same history buffer that grows to the panel, same meter. **It draws from the cpu gradient rather than a ramp of its own**, deliberately — the two are one instrument reading two gauges, and a `memory_gradient` key would have been a line in nineteen theme files for a distinction nobody would see.

Placement follows the arithmetic recorded in `CLAUDE.md`. The instrument row now holds five; `stocks` keeps its 30 and its change column, and memory's cells come from the three panels that scale — pomodoro 24 → 17, cpu 20 → 17, network 26 → 20, memory 16. At 120×40 that costs the pomodoro its `25m focus · 5m break` line (dropped whole) and nothing else:

```
╭┤Pomodoro├──┤ready├╮╭┤Markets├──────────────┤7 · yahoo├╮╭┤CPU├───┤18 cores├╮╭┤Memory├──┤64 GB├╮╭┤Network├────────┤all├╮
│       FOCUS       ││   SYMBOL         LAST       CHG  ││   4.2% LOAD      ││  40% USED       ││ ↓ 271 B/s ↑ 194 B/s  │
```

The border says whole gigabytes because `64.0 GB` cost the title its last two letters. Both default layouts (`Layout::default()` and the shipped `[layout]`) carry it, `[memory]` is documented in the shipped config, and the README's widget table and the CPU section name it. The offline sweep builds it from a fixed reading.

## The bug the panel's tests found

`the_readout_drops_whole_values_and_never_a_fragment` asserts the readout's exact text at every width from 1 to 40, and at width 3 it read `38` — the `%` gone, no ellipsis. The fault is in **`grid::assemble`**: when the *first* part does not fit, it truncated span by span and stopped when the room ran out, so a span that fitted exactly left the spans after it dropped in silence. That is the one thing the function exists to prevent, and every readout built from a figure span and a unit span (`cpu`'s included) had it latently. The whole part is abridged as one string now and handed back to its spans, so `…` lands wherever the cut falls, boundary or not. `a_first_part_abridged_at_a_span_boundary_still_says_so` pins it; checked red with the old logic restored.

## Housekeeping the addition forced

Fourteen panels means: the architecture map, the "four rows of thirteen" paragraph (now fourteen, with the memory arithmetic beside it), README's widget count, a comment in `app.rs`, the shipped config's comment count (327 → 335, in both the test and invariant 16), and the sweep's `offline_panels` split so it stays under clippy's hundred lines. The demo GIF still shows thirteen panels and the old instrument row — it wants re-recording, which is a separate step.

Gates: 863 tests, clippy, fmt, rustdoc, `cargo +1.95.0 check --locked --all-targets` — clean. Driven in a real terminal at 120×40 and 160×40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)