### PR TITLE
Three more bundled themes, completing two pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Three more bundled themes, completing two pairs.** `everforest` is the
+  dark half of `everforest-light`; `rose-pine` and `rose-pine-moon` are the two
+  dark modes of the palette `rose-pine-dawn` is the daylight of. Each mirrors
+  its sibling role for role and cites the upstream values it took. Nineteen
+  themes ship.
+
 - **A memory panel.** Memory in use as a percentage, a moving braille chart
   of it, and — on a machine that has swap — a swap meter that `s` hides and
   shows. It is `cpu`'s sibling in every respect and sits beside it on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,15 +529,20 @@ costs exactly one request. **Requires a browser `User-Agent`** or you get HTTP
 
 ## Named themes — built
 
-`theme = "name"` resolves through `themes.rs`. Sixteen themes are `include_str!`-
+`theme = "name"` resolves through `themes.rs`. Nineteen themes are `include_str!`-
 baked and anything in `<config>/mirador/themes/<name>.toml` is found first, so a
 bundled theme can be replaced without renaming it.
 
 Four are mirador's own (`default`, `default-light`, `high-contrast`, `ansi`).
-Twelve are **ports** of palettes from elsewhere — `nord`, `gruvbox`,
+Fifteen are **ports** of palettes from elsewhere — `nord`, `gruvbox`,
 `gruvbox-light`, `dracula`, `catppuccin-mocha`, `catppuccin-latte`,
 `tokyo-night`, `kanagawa`, `solarized-dark`, `solarized-light`,
-`everforest-light`, `rose-pine-dawn`. The 2026-08-25 batch of six was chosen
+`everforest`, `everforest-light`, `rose-pine`, `rose-pine-moon`,
+`rose-pine-dawn`. The 2026-09-11 batch of three completed two pairs that had
+shipped light-first: `everforest-light` and `rose-pine-dawn` were the daylight
+halves of palettes whose dark modes are the ones people actually run, and a
+port that mirrors its sibling role for role is cheap to add and easy to
+check. The 2026-08-25 batch of six was chosen
 deliberately light-heavy (five light, one dark) because the first six ports
 were all dark and the owner asked for variety. The `t` picker sorts names
 alphabetically — verified by opening it, not assumed from `BUNDLED`'s order —
@@ -548,7 +553,7 @@ if a palette reads badly; never adjust the palette. A light port mirrors its
 dark sibling's mapping role for role, using the palette's own light-mode
 answers (gruvbox's "faded" set, Latte's darker renderings), and its gradients
 *start light* so an idle graph recedes into a pale background — the
-`default-light` rule. All twelve keep `text = "reset"`, so body text still
+`default-light` rule. All fifteen keep `text = "reset"`, so body text still
 follows the terminal's own foreground — invariant 8 is not suspended because
 a theme has a name.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ dashboard.
 Write `assets/themes/<name>.toml` and add it to `BUNDLED` in `src/themes.rs`.
 The `t` picker then lists it — that part needs nothing else. Two prose counts
 do have to follow, though, and nothing pins them: the bundled-count sentence
-("Sixteen ship inside the binary…") in `assets/default_config.toml`, and the
+("Nineteen ship inside the binary…") in `assets/default_config.toml`, and the
 theme table in the README.
 
 Four things will catch you out. The first three have tests rather than

--- a/README.md
+++ b/README.md
@@ -1083,7 +1083,7 @@ Four are mirador's own:
 | `high-contrast` | Bright rooms, projectors, low vision. `muted` is deliberately *not* dim — faint grey is the first thing to vanish on a washed-out screen, so de-emphasis is carried by hue instead |
 | `ansi` | The sixteen ANSI colours and nothing else, so it follows whatever palette your terminal already uses and works with no true-colour support |
 
-Twelve more are ports of palettes you may already be running in your editor,
+Fifteen more are ports of palettes you may already be running in your editor,
 terminal or multiplexer, so mirador can match the rest of your screen — seven
 dark, five light:
 
@@ -1100,7 +1100,10 @@ dark, five light:
 | `solarized-dark` | [Solarized](https://ethanschoonover.com/solarized/) dark — designed against measured contrast rather than by eye, and the calmest of the ports |
 | `solarized-light` | The daylight half of the same design — Solarized shares its accents across both modes and swaps only the greys |
 | `everforest-light` | [Everforest](https://github.com/sainnhe/everforest) light — a green-based comfort palette; even its greys lean toward the forest |
+| `everforest` | The same forest after dark — Everforest's medium dark variant, the palette `everforest-light` is the daylight of |
 | `rose-pine-dawn` | [Rosé Pine](https://rosepinetheme.com/) Dawn — soho vibes at first light; rose for the instruments, pine standing in for green |
+| `rose-pine` | [Rosé Pine](https://rosepinetheme.com/) main — the darkest of the three; rose for the instruments, pine standing in for green |
+| `rose-pine-moon` | Rosé Pine's middle variant — dark but lifted, the rose warmed toward coral, for a terminal that is not quite black |
 
 These are ports, not reinterpretations: the hex values come from each palette's
 own specification, and the theme file cites its source. Body text stays `reset`

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -148,7 +148,7 @@ rows = [
 #
 #     theme = "high-contrast"
 #
-# Sixteen ship inside the binary. Four are mirador's own — `default` (this),
+# Nineteen ship inside the binary. Four are mirador's own — `default` (this),
 # `default-light`, `high-contrast` and `ansi` — and twelve are ports of
 # palettes you may already be running elsewhere: `nord`, `gruvbox`,
 # `gruvbox-light`, `dracula`, `catppuccin-mocha`, `catppuccin-latte`,

--- a/assets/themes/everforest.toml
+++ b/assets/themes/everforest.toml
@@ -1,0 +1,67 @@
+# Everforest — a green-based comfort palette, by Sainnhe Park.
+#
+# The medium dark variant, and the origin of `everforest-light`, which shipped
+# first and mirrors this file role for role. Everforest's whole identity is
+# green, so green carries the focus and title the way orange carries
+# Gruvbox's — and it doubles as `success`, which the palette invites: its
+# green *is* its statement of things being well. Aqua takes the labels to keep
+# two distinct green-family tones in play, and the chrome is the palette's own
+# background ramp, which leafs toward green even in its greys.
+#
+# Values from sainnhe/everforest's autoload/everforest.vim (medium, dark:
+# the bg ramp from palette1 and the foreground set from palette2).
+
+border         = "bg5"
+border_focused = "green"
+rule           = "bg2"
+title          = "green"
+text           = "reset"
+muted          = "grey1"
+label          = "aqua"
+accent         = "green"
+key            = "purple"
+success        = "green"
+warning        = "yellow"
+error          = "red"
+track          = "bg3"
+
+[palette]
+bg2    = "#3d484d"
+bg3    = "#475258"
+bg5    = "#56635f"
+grey1  = "#859289"
+red    = "#e67e80"
+orange = "#e69875"
+yellow = "#dbbc7f"
+green  = "#a7c080"
+aqua   = "#83c092"
+blue   = "#7fbbb3"
+purple = "#d699b6"
+
+# Ramps start in the background ramp's own bg3, so an idle graph is a shade of
+# the forest floor rather than a line drawn on it.
+
+[cpu_gradient]
+start = "#475258"
+mid   = "#dbbc7f"
+end   = "#e67e80"
+
+[rx_gradient]
+start = "#475258"
+mid   = "#83c092"
+end   = "#a7c080"
+
+[tx_gradient]
+start = "#475258"
+mid   = "#7fbbb3"
+end   = "#d699b6"
+
+[gain_gradient]
+start = "#475258"
+mid   = "#a7c080"
+end   = "#a7c080"
+
+[loss_gradient]
+start = "#475258"
+mid   = "#e67e80"
+end   = "#e67e80"

--- a/assets/themes/rose-pine-moon.toml
+++ b/assets/themes/rose-pine-moon.toml
@@ -1,0 +1,61 @@
+# Rosé Pine Moon — the palette's middle variant: dark, a little lifted, the
+# rose warmed toward coral and the pine brightened, for a terminal that is not
+# quite black.
+#
+# The same role-for-role mapping as `rose-pine` and `rose-pine-dawn`; only the
+# values change, as Moon itself only changes values. See `rose-pine.toml` for
+# the reasoning behind the mapping and the one judgement call, `success`.
+#
+# Values from rose-pine/neovim's palette.lua (the canonical role table), moon.
+
+border         = "highlight-high"
+border_focused = "rose"
+rule           = "overlay"
+title          = "rose"
+text           = "reset"
+muted          = "subtle"
+label          = "foam"
+accent         = "rose"
+key            = "iris"
+success        = "pine"
+warning        = "gold"
+error          = "love"
+track          = "highlight-med"
+
+[palette]
+overlay        = "#393552"
+highlight-low  = "#2a283e"
+highlight-med  = "#44415a"
+highlight-high = "#56526e"
+subtle         = "#908caa"
+love           = "#eb6f92"
+gold           = "#f6c177"
+rose           = "#ea9a97"
+pine           = "#3e8fb0"
+foam           = "#9ccfd8"
+iris           = "#c4a7e7"
+
+[cpu_gradient]
+start = "#393552"
+mid   = "#f6c177"
+end   = "#eb6f92"
+
+[rx_gradient]
+start = "#393552"
+mid   = "#9ccfd8"
+end   = "#3e8fb0"
+
+[tx_gradient]
+start = "#393552"
+mid   = "#ea9a97"
+end   = "#c4a7e7"
+
+[gain_gradient]
+start = "#393552"
+mid   = "#3e8fb0"
+end   = "#3e8fb0"
+
+[loss_gradient]
+start = "#393552"
+mid   = "#eb6f92"
+end   = "#eb6f92"

--- a/assets/themes/rose-pine.toml
+++ b/assets/themes/rose-pine.toml
@@ -1,0 +1,68 @@
+# Rosé Pine — "all natural pine, faux fur and a bit of soho vibes", in its
+# main variant: the darkest of the three, and the one `rose-pine-dawn` is the
+# daylight of.
+#
+# Rosé Pine names its colours by role rather than hue, and the roles map onto
+# mirador's almost one to one: their `muted` is mirador's muted, their
+# highlight ramp is the chrome, and rose — the palette's namesake — takes the
+# accent. The one judgement call is `success`: the palette has no green, and
+# pine is what Rosé Pine's own terminal ports assign to green, so pine it is.
+# Gold and love are similarly their yellow and red. Same mapping as dawn,
+# role for role.
+#
+# Values from rose-pine/neovim's palette.lua (the canonical role table), main.
+
+border         = "highlight-high"
+border_focused = "rose"
+rule           = "overlay"
+title          = "rose"
+text           = "reset"
+muted          = "subtle"
+label          = "foam"
+accent         = "rose"
+key            = "iris"
+success        = "pine"
+warning        = "gold"
+error          = "love"
+track          = "highlight-med"
+
+[palette]
+overlay        = "#26233a"
+highlight-low  = "#21202e"
+highlight-med  = "#403d52"
+highlight-high = "#524f67"
+subtle         = "#908caa"
+love           = "#eb6f92"
+gold           = "#f6c177"
+rose           = "#ebbcba"
+pine           = "#31748f"
+foam           = "#9ccfd8"
+iris           = "#c4a7e7"
+
+# Ramps rise out of the overlay tone, the palette's own darkest chrome, so an
+# idle graph sits a shade above the base rather than glowing on it.
+
+[cpu_gradient]
+start = "#26233a"
+mid   = "#f6c177"
+end   = "#eb6f92"
+
+[rx_gradient]
+start = "#26233a"
+mid   = "#9ccfd8"
+end   = "#31748f"
+
+[tx_gradient]
+start = "#26233a"
+mid   = "#ebbcba"
+end   = "#c4a7e7"
+
+[gain_gradient]
+start = "#26233a"
+mid   = "#31748f"
+end   = "#31748f"
+
+[loss_gradient]
+start = "#26233a"
+mid   = "#eb6f92"
+end   = "#eb6f92"

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,8 +52,8 @@ pub(crate) const GLOBAL: &[Binding] = &[
     // happened to the resize keys below: shipped, useful, and undiscoverable.
     Binding::primary("m", "arrange"),
     // Behind `m` for the same reason `m` is behind `w`, and a primary for the
-    // same reason too: sixteen themes ship, and a theme nobody can find is
-    // sixteen files of decoration.
+    // same reason too: nineteen themes ship, and a theme nobody can find is
+    // nineteen files of decoration.
     Binding::primary("t", "theme"),
     // Promoted from `extra` at the owner's request, and the comment on `m`
     // above had already named the reason: shipped, useful, and undiscoverable.

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -89,8 +89,17 @@ const BUNDLED: &[(&str, &str)] = &[
         include_str!("../assets/themes/solarized-light.toml"),
     ),
     (
+        "everforest",
+        include_str!("../assets/themes/everforest.toml"),
+    ),
+    (
         "everforest-light",
         include_str!("../assets/themes/everforest-light.toml"),
+    ),
+    ("rose-pine", include_str!("../assets/themes/rose-pine.toml")),
+    (
+        "rose-pine-moon",
+        include_str!("../assets/themes/rose-pine-moon.toml"),
     ),
     (
         "rose-pine-dawn",


### PR DESCRIPTION
The two half-pairs from the theme review, completed. `everforest` is the dark half of `everforest-light`; `rose-pine` and `rose-pine-moon` are the two dark modes of the palette `rose-pine-dawn` is the daylight of.

Each mirrors its sibling **role for role** — the mapping is the sibling's, only the values change, which is exactly how the upstream variants differ from each other — and each file cites where its hex values came from: `sainnhe/everforest`'s `autoload/everforest.vim` (medium, dark: the bg ramp from palette1, the foreground set from palette2) and `rose-pine/neovim`'s `palette.lua` (main, moon — the same canonical role table the dawn port cites). Gradients start in each palette's own darkest chrome tone (`bg3`, `overlay`), the dark counterpart of the light-first rule, so an idle graph sits a shade above the base rather than glowing on it.

Nineteen themes ship. The count is quoted in the README, CONTRIBUTING, the shipped config and `CLAUDE.md`, and all four moved together; the README's *What ships* table gains three rows.

Every theme test passes without change — name shape, colour keys before `[palette]`, every `Theme::KEYS` set — and the five gates are clean (863 tests).

**Not to be merged on the gates alone.** Themes are judged on sight: rendered `-e` captures of all five palettes, each on its own background, are with the owner. Merge on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)