### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-09-11
+
 ### Added
 
 - **Three more bundled themes, completing two pairs.** `everforest` is the
@@ -1838,7 +1840,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.10.2...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/jchultarsky/mirador/compare/v1.10.2...v1.11.0
 [1.10.2]: https://github.com/jchultarsky/mirador/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/jchultarsky/mirador/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/jchultarsky/mirador/compare/v1.9.0...v1.10.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2040,13 +2040,18 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.10.2` is released**, as a GitHub release with binaries for macOS
+- **`1.11.0` is released**, as a GitHub release with binaries for macOS
   arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
-  and published on crates.io. It carries what the silent-clip sweep found
-  the day it was written — the clock's small seconds cut to one digit at
-  40 columns, and four narrower cuts — and nothing else user-visible; the
-  test-quality pass behind it (the sweep, fourteen input and form tests,
-  the protocol document as wire corpus) rides along. 1.10.1 carried one
+  and published on crates.io. It is the first feature release since 1.9.0:
+  the `memory` panel — the fourteenth widget, and the missing quarter of
+  "what compute is available" — three bundled themes completing two pairs
+  (`everforest`, `rose-pine`, `rose-pine-moon`; nineteen ship), the
+  `grid::assemble` boundary fix the memory panel's tests found, and a demo
+  re-recorded to show fourteen panels. 1.10.2 carried what the silent-clip
+  sweep found the day it was written — the clock's small seconds cut to one
+  digit at 40 columns, and four narrower cuts — and nothing else
+  user-visible; the test-quality pass behind it (the sweep, fourteen input
+  and form tests, the protocol document as wire corpus) rode along. 1.10.1 carried one
   change — the notes panel stopping repeating the count its border already
   shows, which is the screen-tightening pass finding a panel it had missed. 1.10.0, hours
   earlier, was that pass itself — the silently-cut clock date being the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.10.2"
+version = "1.11.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Bumps `Cargo.toml`, moves the CHANGELOG's Unreleased entries under `1.11.0` with the two link references, and updates `CLAUDE.md`'s released line — one commit, as the two docs guards require.

The first feature release since 1.9.0. In it: the **memory panel** (#244) — the fourteenth widget and the missing quarter of "what compute is available" — with the `grid::assemble` boundary fix its tests found; **three bundled themes** completing two pairs (#245: `everforest`, `rose-pine`, `rose-pine-moon`; nineteen ship); and the **demo re-recorded** for fourteen panels (#246), caption and picture in the same release. Also in since 1.10.2, not user-visible: the README key-table guard (#243).

Step 0 done before opening this: the 1.11.0 release build driven under tmux at 120×40 — the five-panel instrument row with `┤Memory├──┤64 GB├`, the help overlay reading `v1.11.0`, the theme picker listing the new names, focus onto the memory panel and `s`, a clean `q`. All five gates green: 863 tests, clippy, fmt, rustdoc, `cargo +1.95.0 check --locked --all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)