### PR TITLE
A temperature panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A battery panel, for laptops.** The charge in block numerals with the
+  meter beneath it, a label for which way things are going, the time left or
+  to full in the border, and a line of detail — health, cycles, power draw.
+  Amber below 20%
+  and red below 10% only while running on the battery, and below 10% the
+  status bar carries an alert. Not placed in the default layout, since a
+  desktop would open on `No battery`; `w` switches it on. `[battery]` in the
+  config sets the two thresholds and the sample interval.
+
 ## [1.11.0] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status bar carries an alert. Not placed in the default layout, since a
   desktop would open on `No battery`; `w` switches it on. `[battery]` in the
   config sets the two thresholds and the sample interval.
+- **A temperature panel.** The hottest sensor with its history in the CPU
+  panel's face, and a table of every sensor group's current and peak
+  reading. The platform's list is grouped the way a person would write it —
+  Apple silicon's fourteen die readings become one `CPU die` row, and
+  sensors reporting impossible values are dropped. `u` toggles Celsius and
+  Fahrenheit, and the choice is remembered. Above `alert_above_c` the status
+  bar says so. Also not in the default layout: on Windows the sensors need
+  elevation, and a VM or a container has none, so the panel says so rather
+  than drawing an empty graph.
 
 ## [1.11.0] - 2026-09-11
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,8 @@ docs.rs      the guard on *this file* — cited tests, version, paths, and that
              every module below is listed — and on the README's panel
              drawings and key tables, the other documentation nothing compiles
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
-             pomodoro, watchlog, news, cpu, memory, network, calculator
+             pomodoro, watchlog, news, cpu, memory, network, battery,
+             calculator
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -261,7 +262,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 335 of them, including the ones mirador
+    trip through `toml` discards all 344 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -438,6 +439,30 @@ time you spend at the dashboard rather than about something outside it. That
 makes it the one panel where a nagging design would do real damage, which is
 why the chime defaults off and a paused timer greys out instead of blinking.
 The filter still holds for anything not asked for by name.
+
+**The battery panel was asked for by name on 2026-09-11**, the same route as
+the pomodoro, and it is worth three decisions being written down. First, **it
+is the first widget not placed in the default layout**: a desktop would open on
+`No battery`, and the default is a dashboard for any machine, so
+`the_default_layout_places_every_widget` now carries an excused list with the
+reason beside each name — the rule that every widget is placed still holds for
+everything not on it. Second, **it is the first widget that reads something
+`sysinfo` does not**, and it does so through `starship-battery` (ISC, MSRV
+1.89, pure-Rust bindings, NetBSD supported) rather than a polled process per
+platform: `pmset -g batt`, sysfs and a PowerShell query are three code paths to
+keep honest for one fact, and the crate's macOS bindings were already in the
+tree under `sysinfo`. Third, **the face is the pomodoro's** — label, numerals,
+meter, detail — and it is calm on purpose: brass while there is plenty, amber
+and red only when the charge is low *and* the machine is running on it, and
+charging told by the label rather than by flooding the panel green. The first
+capture said `PLUGGED IN` in the border and again inside, and `holding at 80%`
+under a five-row `80`; that is the tasks-panel duplication of 1.10.0 arriving
+in a new panel, and the rule from that pass holds here — the time lives in the
+border and nowhere else, the label has the state, the numerals have the
+charge, the detail row has what is left (health, cycles, watts). The alert
+fires only for the one battery fact that gets worse if nobody acts: running
+down and nearly gone. macOS reports "plugged in, holding at 80%" as `Unknown`
+with no energy moving, which the panel names `PLUGGED IN`.
 
 **The filter governs what mirador *ships*, which after discussion #191 is
 narrower than it used to be.** If external panels happen, "does this answer one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ docs.rs      the guard on *this file* — cited tests, version, paths, and that
              drawings and key tables, the other documentation nothing compiles
 widgets/     clocks, weather, todo, notes, stocks, calendar, agenda,
              pomodoro, watchlog, news, cpu, memory, network, battery,
-             calculator
+             temperature, calculator
 ```
 
 `Panel` has two input hooks. `handle_key` goes to the *focused* panel;
@@ -262,7 +262,7 @@ map, that one is the procedure.
     nothing. Both are whole-panel measurements, frame and padding included.
 16. **The config is edited, never reserialised.** This is the real form of the
     "never rewrites the config" rule, which was always about comments: a round
-    trip through `toml` discards all 344 of them, including the ones mirador
+    trip through `toml` discards all 354 of them, including the ones mirador
     wrote to explain its own options. `migrate.rs` established the alternative
     and `layout_edit.rs` follows it — find the line, change that line, leave
     everything else alone. Adding a panel is a one-line diff.
@@ -463,6 +463,25 @@ charge, the detail row has what is left (health, cycles, watts). The alert
 fires only for the one battery fact that gets worse if nobody acts: running
 down and nearly gone. macOS reports "plugged in, holding at 80%" as `Unknown`
 with no energy moving, which the panel names `PLUGGED IN`.
+
+**The temperature panel followed the same day, by the same route**, and it
+is the second on the excused list, for a different reason: it reads what the
+platform reports, and on Windows that is nothing without elevation, in a VM
+or a container nothing at all. Two things about it are worth keeping. **The
+panel's real work is `group`**, not drawing — `sysinfo::Components` on Apple
+silicon returns twenty-five entries for what a person would call three
+sensors: fourteen `PMU tdie` readings for one die, a `PMU tcal` calibration
+reference that is not a temperature of anything, and eight `PMU tdev` entries
+at −9201°C. Trailing digits come off, a short rename table maps the Apple and
+Linux hwmon labels it knows, a plausibility range drops the impossible, and
+the peak is the panel's memory rather than the platform's, because
+`Component::max` is not kept everywhere. Unknown labels keep their own name
+minus the digits — `iwlwifi` — which is honest if plain. And **it shares the
+cpu ramp on purpose**: degrees Celsius and load percent both run 0–100 and
+both mean "how hard is this machine working", so the two graphs change colour
+together. The face is the cpu panel's with the table where the per-core strip
+would be; the table takes at most half the panel and only when it can show a
+header and a row.
 
 **The filter governs what mirador *ships*, which after discussion #191 is
 narrower than it used to be.** If external panels happen, "does this answer one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,11 @@ touch:
    `Default for Layout` in `src/config/layout.rs` and the `[layout]` block in
    `assets/default_config.toml` describe the same dashboard by different
    routes, and two tests (`the_default_layout_places_every_widget` and the
-   shipped-layout comparison) fail until both know your widget.
+   shipped-layout comparison) fail until both know your widget. The one
+   alternative is to leave it out *on purpose*: if the panel would be empty on
+   most machines — the battery is the case — add it to the excused list in
+   that test with the reason beside it, and say so in the README. An excuse
+   without a reason is the thing the test refuses.
 6. Document the widget in `assets/default_config.toml` and in the README's
    widget table.
 7. Add tests for the logic that is not drawing — parsing, formatting,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "objc2",
 ]
 
@@ -756,6 +766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,9 +843,15 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "memchr"
@@ -891,6 +913,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "starship-battery",
  "sysinfo",
  "toml",
  "unicode-width",
@@ -908,6 +931,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -980,7 +1015,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -1006,7 +1043,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2",
  "libc",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -1194,6 +1235,19 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plist"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
+dependencies = [
+ "base64 0.23.1",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1640,6 +1694,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "starship-battery"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e919b7ecd99f2d5ed9efdc8d242ae93d91684181a782dadcbcd72079930155f9"
+dependencies = [
+ "cfg-if",
+ "lazycell",
+ "libc",
+ "mach2",
+ "nix 0.31.3",
+ "num-traits",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "plist",
+ "uom",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,7 +1851,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -1855,6 +1928,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1862,6 +1936,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "toml"
@@ -1948,6 +2032,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a739f83872836c82a4f2527d4e54b37007b3de68cafe7edde95fd695968bf4b9"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "ureq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ quick-xml = "0.42.0"
 ratatui = "0.30.2"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
+# Batteries. `sysinfo` does not read them; this does, on every shipped target
+# including NetBSD, through pure-Rust bindings — the IOKit and Core Foundation
+# crates it uses on macOS are already in the tree under `sysinfo`.
+starship-battery = "0.11.1"
 sysinfo = "0.39.6"
 toml = "1.1.3"
 unicode-width = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -795,6 +795,24 @@ status bar says so.
 It is **not in the default layout**: a desktop would open on `No battery`, and
 the default is a dashboard for any machine. Press `w` and switch it on.
 
+### Temperature
+
+The hottest thing in the machine, in the same face as the CPU panel: a
+readout, a braille history, and a table of every sensor with its current and
+peak reading, hottest first. The platform's list is grouped the way a person
+would write it — Apple silicon's fourteen `PMU tdie` readings become one
+`CPU die` row, a calibration reference and eight sensors reporting minus nine
+thousand degrees are dropped — and the same colour ramp as the CPU graph runs
+from cool to hot, so the two panels change colour together. `u` toggles
+Celsius and Fahrenheit. Above `alert_above_c` (95 by default) the hottest
+sensor reaches the status bar, since a die past its limit is the one reading
+here that gets worse if nobody acts.
+
+Also **not in the default layout**, for a different reason: the panel reads
+what the platform reports, and on Windows that needs elevation, while a VM or
+a container reports nothing. Where there is nothing to read it says so rather
+than drawing an empty graph. Press `w` and switch it on.
+
 ## Command line
 
 Every flag is optional; with none of them mirador opens the dashboard.
@@ -976,6 +994,7 @@ rather than failing quietly.
 | `memory` | Memory in use, a moving chart, and a swap meter |
 | `network` | Receive and transmit rates as moving charts |
 | `battery` | Charge, which way it is going, and how long that gives you — laptops; not placed by default |
+| `temperature` | The hottest sensor with its history, and every sensor's now and peak — where the platform reports them; not placed by default |
 
 ### External panels (optional)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A *mirador* is a lookout — the tower you climb to see everything at once.
 
 ![All fourteen mirador panels on a wide terminal, in use: a block-numeral clock, two months of calendar, weather with an hourly forecast, the task list, an agenda of upcoming events, notes, a news panel of headlines, a watch log, a calculator, a pomodoro timer, and a market watchlist beside live CPU, memory and network graphs. Focus moves between panels, a task is typed in and added to the list, the panel picker switches a panel off and the grid reflows around it, arrange mode moves the task panel along its row and up into the row above until it takes a row of its own, the help overlay opens and scrolls, three sums are typed into the calculator and feed up its tape, and the pomodoro timer starts counting down](https://raw.githubusercontent.com/jchultarsky/mirador/main/docs/demo.gif)
 
-*All fourteen panels on a first run, at 200x50 — wide enough that nothing has to fall
+*The fourteen default panels on a first run, at 200x50 — wide enough that nothing has to fall
 back. The lit frame is the focused panel, with its own keys in its bottom
 border; every other panel is dimmed, so exactly one thing is at full brightness.*
 
@@ -781,6 +781,20 @@ changes, not merely because time passed.
 Every buffer grows to fill its panel, so `history` is a floor on what is kept
 rather than a cap on what a wider panel can draw.
 
+### Battery
+
+For laptops. The charge in block numerals with the meter drawn beneath it, a
+label saying which way things are going — `ON BATTERY`, `CHARGING`, `PLUGGED
+IN`, `FULL` — the time left, or to full, in the border, and a line of detail:
+health, cycle count, power draw. Nothing is said twice. Brass while there is
+plenty; amber below 20% and red below 10% only while running on the battery,
+since a low battery on mains is nothing to be told about. Below 10% and
+discharging it is the one battery fact that gets worse if nobody acts, so the
+status bar says so.
+
+It is **not in the default layout**: a desktop would open on `No battery`, and
+the default is a dashboard for any machine. Press `w` and switch it on.
+
 ## Command line
 
 Every flag is optional; with none of them mirador opens the dashboard.
@@ -961,6 +975,7 @@ rather than failing quietly.
 | `cpu` | Average utilisation, a moving chart, and per-core meters |
 | `memory` | Memory in use, a moving chart, and a swap meter |
 | `network` | Receive and transmit rates as moving charts |
+| `battery` | Charge, which way it is going, and how long that gives you — laptops; not placed by default |
 
 ### External panels (optional)
 

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -489,6 +489,22 @@ warn_below_pct  = 20
 alert_below_pct = 10
 
 # ---------------------------------------------------------------------------
+# Temperature
+#
+# The hottest sensor with its history, and a table of every sensor group's
+# current and peak reading. Sensors are grouped the way a person would list
+# them: fourteen die readings become one `CPU die` row. Not in the default
+# layout, because the panel reads what the platform reports — on Windows that
+# needs elevation, and a VM or a container reports nothing. `w` switches it
+# on; `u` toggles the units.
+# ---------------------------------------------------------------------------
+[temperature]
+history       = 120           # a floor, not a cap — see the note under [cpu]
+sample_secs   = 5
+units         = "celsius"     # or "fahrenheit"
+alert_above_c = 95            # the status bar says so above this; 0 disables
+
+# ---------------------------------------------------------------------------
 # Network
 #
 # Leave `interfaces` empty to aggregate every non-loopback interface, or name

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -475,6 +475,20 @@ sample_secs = 2               # see the note under [cpu]
 show_swap   = true
 
 # ---------------------------------------------------------------------------
+# Battery
+#
+# Charge, which way it is going, and how long that gives you. Not in the
+# default layout, because a desktop would open on an empty panel — press `w`
+# and switch it on. Below `warn_below_pct` the figure turns amber while running
+# on the battery; below `alert_below_pct` it turns red and the status bar says
+# so. Neither applies while plugged in.
+# ---------------------------------------------------------------------------
+[battery]
+sample_secs     = 30
+warn_below_pct  = 20
+alert_below_pct = 10
+
+# ---------------------------------------------------------------------------
 # Network
 #
 # Leave `interfaces` empty to aggregate every non-loopback interface, or name

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -20,6 +20,7 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
+use ratatui::text::Span;
 
 /// Number of entries in a baked gradient: one per percentage point.
 const STEPS: usize = 101;
@@ -283,6 +284,22 @@ impl<'a> BrailleGraph<'a> {
 /// bar at 40% shows the cool end of the ramp and a bar at 95% runs the whole
 /// way to hot. The unfilled tail keeps the same glyph in the track colour, so
 /// the meter's footprint never changes as the value moves.
+/// A flat meter: `percent` of `width` cells filled in one colour, the rest in
+/// the track colour. The pomodoro's progress bar and the battery's charge bar
+/// are both this; the graded version, coloured by level, is [`meter_spans`].
+pub fn meter_line(percent: u16, width: u16, fill: Color, track: Color) -> Vec<Span<'static>> {
+    let width = usize::from(width);
+    let filled = usize::from(percent.min(100)) * width / 100;
+    (0..width)
+        .map(|i| {
+            Span::styled(
+                "■",
+                Style::default().fg(if i < filled { fill } else { track }),
+            )
+        })
+        .collect()
+}
+
 pub fn meter_spans(
     value: u64,
     max: u64,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,7 +50,7 @@ pub use plugins::PluginConfig;
 pub use widgets::{
     AgendaConfig, BatteryConfig, CalculatorConfig, CalendarConfig, ClockZone, ClocksConfig,
     CpuConfig, MemoryConfig, NetworkConfig, NewsConfig, NewsFeed, NotesConfig, PomodoroConfig,
-    StocksConfig, TodoConfig, WeatherConfig,
+    StocksConfig, TemperatureConfig, TodoConfig, WeatherConfig,
 };
 
 /// Top-level configuration.
@@ -84,6 +84,7 @@ pub struct Config {
     pub memory: MemoryConfig,
     pub network: NetworkConfig,
     pub battery: BatteryConfig,
+    pub temperature: TemperatureConfig,
 }
 
 /// Global behaviour.
@@ -301,6 +302,12 @@ impl Config {
                 self.weather.units
             );
         }
+        if !matches!(self.temperature.units.as_str(), "celsius" | "fahrenheit") {
+            anyhow::bail!(
+                "`[temperature].units` is `{}`; expected `celsius` or `fahrenheit`.",
+                self.temperature.units
+            );
+        }
         // A zero-length phase would end on the tick it started and spin the
         // timer through the cycle; a zero-round set would divide by zero
         // deciding when the long break falls. Both are caught here rather than
@@ -446,6 +453,11 @@ impl Config {
             && matches!(units.as_str(), "metric" | "imperial")
         {
             self.weather.units.clone_from(units);
+        }
+        if let Some(units) = &state.temperature_units
+            && matches!(units.as_str(), "celsius" | "fahrenheit")
+        {
+            self.temperature.units.clone_from(units);
         }
         if let Some(sort) = &state.todo_sort
             && sort.parse::<crate::task::SortMode>().is_ok()
@@ -832,10 +844,17 @@ mod tests {
         // The default is a dashboard for any machine; a panel that is empty on
         // most of them would be a poor first run for everyone to save a
         // discovery step for some. `w` places them, and the README names them.
-        const UNPLACED_BY_DEFAULT: &[(&str, &str)] = &[(
-            "battery",
-            "laptops only — a desktop would open on `No battery`",
-        )];
+        const UNPLACED_BY_DEFAULT: &[(&str, &str)] = &[
+            (
+                "battery",
+                "laptops only — a desktop would open on `No battery`",
+            ),
+            (
+                "temperature",
+                "reads what the platform reports, which on Windows without \
+                 elevation and in most VMs and containers is nothing",
+            ),
+        ];
         // first run, and this is exactly how notes and stocks went unseen.
         let layout = Layout::default();
         let placed: Vec<&str> = layout

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,9 +48,9 @@ pub use layout::{Layout, LayoutPanel, LayoutRow};
 pub use plugins::PluginConfig;
 #[allow(unused_imports)]
 pub use widgets::{
-    AgendaConfig, CalculatorConfig, CalendarConfig, ClockZone, ClocksConfig, CpuConfig,
-    MemoryConfig, NetworkConfig, NewsConfig, NewsFeed, NotesConfig, PomodoroConfig, StocksConfig,
-    TodoConfig, WeatherConfig,
+    AgendaConfig, BatteryConfig, CalculatorConfig, CalendarConfig, ClockZone, ClocksConfig,
+    CpuConfig, MemoryConfig, NetworkConfig, NewsConfig, NewsFeed, NotesConfig, PomodoroConfig,
+    StocksConfig, TodoConfig, WeatherConfig,
 };
 
 /// Top-level configuration.
@@ -83,6 +83,7 @@ pub struct Config {
     pub cpu: CpuConfig,
     pub memory: MemoryConfig,
     pub network: NetworkConfig,
+    pub battery: BatteryConfig,
 }
 
 /// Global behaviour.
@@ -827,6 +828,14 @@ mod tests {
         // A widget nobody can see is a widget nobody knows exists. The startup
         // hint names what is missing, but the default should have nothing to
         // name: shipping a dashboard that hides a third of itself is a poor
+        // Widgets deliberately left out of the default, each with its reason.
+        // The default is a dashboard for any machine; a panel that is empty on
+        // most of them would be a poor first run for everyone to save a
+        // discovery step for some. `w` places them, and the README names them.
+        const UNPLACED_BY_DEFAULT: &[(&str, &str)] = &[(
+            "battery",
+            "laptops only — a desktop would open on `No battery`",
+        )];
         // first run, and this is exactly how notes and stocks went unseen.
         let layout = Layout::default();
         let placed: Vec<&str> = layout
@@ -835,7 +844,20 @@ mod tests {
             .flat_map(|r| r.panels.iter().map(|p| p.widget.as_str()))
             .collect();
 
+        for (widget, _) in UNPLACED_BY_DEFAULT {
+            assert!(
+                crate::widgets::WIDGET_NAMES.contains(widget),
+                "`{widget}` is excused from the default layout but is not a widget"
+            );
+            assert!(
+                !placed.contains(widget),
+                "`{widget}` is placed after all; drop it from the excused list"
+            );
+        }
         for widget in crate::widgets::WIDGET_NAMES {
+            if UNPLACED_BY_DEFAULT.iter().any(|(name, _)| name == widget) {
+                continue;
+            }
             assert!(
                 placed.contains(widget),
                 "the default layout does not place `{widget}`"

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -392,6 +392,29 @@ impl Default for MemoryConfig {
     }
 }
 
+/// Battery panel settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BatteryConfig {
+    /// Seconds between readings. A battery moves slowly; thirty is plenty.
+    pub sample_secs: u64,
+    /// Below this charge, running on the battery, the figure turns amber.
+    pub warn_below_pct: u16,
+    /// Below this charge, running on the battery, the figure turns red and the
+    /// status bar carries an alert.
+    pub alert_below_pct: u16,
+}
+
+impl Default for BatteryConfig {
+    fn default() -> Self {
+        Self {
+            sample_secs: 30,
+            warn_below_pct: 20,
+            alert_below_pct: 10,
+        }
+    }
+}
+
 /// Network chart settings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]

--- a/src/config/widgets.rs
+++ b/src/config/widgets.rs
@@ -415,6 +415,31 @@ impl Default for BatteryConfig {
     }
 }
 
+/// Temperature panel settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TemperatureConfig {
+    /// Samples to keep; a floor, since the buffer grows to the panel's width.
+    pub history: usize,
+    /// Seconds between readings.
+    pub sample_secs: u64,
+    /// `celsius` or `fahrenheit`; `u` toggles it in the panel.
+    pub units: String,
+    /// Above this, in Celsius, the hottest sensor is an alert. Zero disables.
+    pub alert_above_c: u16,
+}
+
+impl Default for TemperatureConfig {
+    fn default() -> Self {
+        Self {
+            history: 120,
+            sample_secs: 5,
+            units: "celsius".into(),
+            alert_above_c: 95,
+        }
+    }
+}
+
 /// Network chart settings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1167,6 +1167,7 @@ mod tests {
         ("clocks", crate::widgets::clocks::COLUMNS),
         ("notes", crate::widgets::notes::COLUMNS),
         ("stocks", crate::widgets::stocks::COLUMNS),
+        ("temperature", crate::widgets::temperature::COLUMNS),
         ("todo", crate::widgets::todo::COLUMNS),
         ("weather", crate::widgets::weather::COLUMNS),
     ];

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 344;
+        const CITED: usize = 354;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/layout_edit.rs
+++ b/src/layout_edit.rs
@@ -1401,7 +1401,7 @@ rows = [
     /// `CLAUDE.md` has to move with it.
     #[test]
     fn the_comment_count_the_docs_quote_is_the_one_in_the_file() {
-        const CITED: usize = 335;
+        const CITED: usize = 344;
         let actual = crate::config::DEFAULT_CONFIG
             .lines()
             .filter(|line| line.trim_start().starts_with('#'))

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,6 +49,9 @@ pub struct UiState {
     /// `u` in the weather panel.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weather_units: Option<String>,
+    /// `u` in the temperature panel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature_units: Option<String>,
     /// `s` in the task panel.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub todo_sort: Option<String>,
@@ -113,6 +116,11 @@ impl UiState {
             } else {
                 "imperial".into()
             }),
+            temperature_units: Some(if config.temperature.units == "fahrenheit" {
+                "fahrenheit".into()
+            } else {
+                "celsius".into()
+            }),
             todo_sort: Some(sort.label().to_string()),
             todo_show_completed: Some(config.todo.show_completed),
             clocks_show_seconds: Some(config.clocks.show_seconds),
@@ -168,6 +176,7 @@ impl UiState {
         }
         keep_if_changed!(
             weather_units,
+            temperature_units,
             weather_location,
             agenda_file,
             todo_sort,
@@ -354,6 +363,7 @@ mod tests {
         let (path, _g) = dir("roundtrip");
         let state = UiState {
             weather_units: Some("metric".into()),
+            temperature_units: Some("fahrenheit".into()),
             weather_location: Some("Lisbon, Portugal".into()),
             agenda_file: Some("/tmp/work.ics".into()),
             todo_sort: Some("due".into()),

--- a/src/widgets/battery.rs
+++ b/src/widgets/battery.rs
@@ -109,6 +109,22 @@ impl BatteryPanel {
         }
     }
 
+    /// A laptop three hours from empty, for the sweep and the dump.
+    #[cfg(test)]
+    pub(crate) fn canned(config: BatteryConfig) -> Self {
+        Self::with_reading(
+            config,
+            Some(Reading {
+                charge_pct: 80,
+                flow: Flow::Discharging,
+                remaining: Some(Duration::from_mins(192)),
+                health_pct: Some(100),
+                cycles: Some(3),
+                watts: 12.4,
+            }),
+        )
+    }
+
     /// Read the first battery the machine reports.
     fn sample(&mut self) -> bool {
         let interval = Duration::from_secs(self.config.sample_secs.max(1));

--- a/src/widgets/battery.rs
+++ b/src/widgets/battery.rs
@@ -1,0 +1,651 @@
+//! The battery: how much is left, which way it is going, and how long that
+//! gives you.
+//!
+//! Asked for by name, which is the filter's own rule for what ships, and the
+//! first panel that reads something `sysinfo` does not: `starship-battery`
+//! does, on every shipped target including NetBSD, through pure-Rust bindings.
+//! The alternative was a polled process per platform (`pmset -g batt`, sysfs,
+//! a PowerShell query), which is three code paths to keep honest for one fact.
+//!
+//! The face is the pomodoro's: a label, the figure in block numerals, a meter,
+//! a line of detail. Calm by default — brass while there is plenty, and the
+//! signal colours only when the charge is low and the machine is running on
+//! it. Charging is a state, not an alarm, and is told by the label rather than
+//! by flooding the panel green.
+
+use std::time::{Duration, Instant};
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use crate::chart::meter_line;
+use crate::config::BatteryConfig;
+use crate::frame::Binding;
+use crate::glyphs::{self, BigText};
+use crate::panel::{Panel, RenderContext};
+
+/// The tallest the numerals are drawn.
+const MAX_SCALE: u16 = 2;
+
+/// Which way the charge is going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Flow {
+    /// Running on the battery.
+    Discharging,
+    Charging,
+    /// On mains and full.
+    Full,
+    /// On mains, not charging, not full — macOS holding at 80% is the common
+    /// case. The library reports this as unknown with no energy moving, which
+    /// is exactly what "plugged in" looks like from the outside.
+    Holding,
+    Unknown,
+}
+
+/// One reading of the battery.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Reading {
+    pub charge_pct: u16,
+    pub flow: Flow,
+    /// To empty when discharging, to full when charging, otherwise `None`.
+    pub remaining: Option<Duration>,
+    pub health_pct: Option<u16>,
+    pub cycles: Option<u32>,
+    /// Power moving in or out, in watts.
+    pub watts: f32,
+}
+
+/// The battery panel.
+pub struct BatteryPanel {
+    config: BatteryConfig,
+    manager: Option<starship_battery::Manager>,
+    /// `None` until the first sample, or when the machine has no battery.
+    reading: Option<Reading>,
+    /// Why the last read failed, if it did.
+    error: Option<String>,
+    last_sample: Option<Instant>,
+}
+
+impl std::fmt::Debug for BatteryPanel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatteryPanel")
+            .field("reading", &self.reading)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BatteryPanel {
+    /// Build the panel and take a first reading.
+    pub fn new(config: BatteryConfig) -> Self {
+        let (manager, error) = match starship_battery::Manager::new() {
+            Ok(manager) => (Some(manager), None),
+            Err(e) => (None, Some(e.to_string())),
+        };
+        let mut panel = Self {
+            config,
+            manager,
+            reading: None,
+            error,
+            last_sample: None,
+        };
+        panel.sample();
+        panel
+    }
+
+    /// A panel holding `reading`, with nothing behind it, for tests in other
+    /// modules and for the sweep.
+    #[cfg(test)]
+    pub(crate) fn with_reading(config: BatteryConfig, reading: Option<Reading>) -> Self {
+        Self {
+            config,
+            manager: None,
+            reading,
+            error: None,
+            last_sample: Some(Instant::now()),
+        }
+    }
+
+    /// Read the first battery the machine reports.
+    fn sample(&mut self) -> bool {
+        let interval = Duration::from_secs(self.config.sample_secs.max(1));
+        if self.last_sample.is_some_and(|at| at.elapsed() < interval) {
+            return false;
+        }
+        self.last_sample = Some(Instant::now());
+        let Some(manager) = &self.manager else {
+            return false;
+        };
+        let before = self.reading;
+        match manager.batteries() {
+            Err(e) => {
+                self.error = Some(e.to_string());
+                self.reading = None;
+            }
+            Ok(batteries) => {
+                self.error = None;
+                self.reading = batteries.flatten().next().map(|b| read(&b));
+            }
+        }
+        before != self.reading
+    }
+
+    /// Brass while there is plenty; the signal colours only when the charge is
+    /// low *and* the machine is running on it. A low battery on mains is
+    /// nothing to be told about.
+    fn colour(&self, reading: Reading, theme: &crate::theme::Theme) -> Color {
+        match reading.flow {
+            Flow::Charging | Flow::Full => theme.success,
+            Flow::Discharging if reading.charge_pct < self.config.alert_below_pct => theme.error,
+            Flow::Discharging if reading.charge_pct < self.config.warn_below_pct => theme.warning,
+            _ => theme.accent,
+        }
+    }
+}
+
+fn read(b: &starship_battery::Battery) -> Reading {
+    use starship_battery::State;
+    use starship_battery::units::power::watt;
+    use starship_battery::units::ratio::percent;
+    use starship_battery::units::time::second;
+
+    let pct = |ratio: starship_battery::units::Ratio| -> u16 {
+        // `round` before the cast, and clamp: a ratio slightly over one is a
+        // battery reporting 100.4%, not a panel reporting 101.
+        ratio.get::<percent>().round().clamp(0.0, 100.0) as u16
+    };
+    let secs =
+        |t: starship_battery::units::Time| Duration::from_secs(t.get::<second>().max(0.0) as u64);
+    let watts = b.energy_rate().get::<watt>();
+    let flow = match b.state() {
+        State::Charging => Flow::Charging,
+        State::Discharging | State::Empty => Flow::Discharging,
+        State::Full => Flow::Full,
+        State::Unknown if watts.abs() < 0.05 => Flow::Holding,
+        State::Unknown => Flow::Unknown,
+    };
+    let remaining = match flow {
+        Flow::Discharging => b.time_to_empty().map(secs),
+        Flow::Charging => b.time_to_full().map(secs),
+        _ => None,
+    };
+    Reading {
+        charge_pct: pct(b.state_of_charge()),
+        flow,
+        remaining,
+        health_pct: Some(pct(b.state_of_health())),
+        cycles: b.cycle_count(),
+        watts,
+    }
+}
+
+/// `3h 12m`, `42m`, or `under a minute` — how someone says it, not `03:12:00`.
+pub(crate) fn describe_remaining(left: Duration) -> String {
+    let minutes = left.as_secs() / 60;
+    match (minutes / 60, minutes % 60) {
+        (0, 0) => "under a minute".to_string(),
+        (0, m) => format!("{m}m"),
+        (h, 0) => format!("{h}h"),
+        (h, m) => format!("{h}h {m}m"),
+    }
+}
+
+/// The label over the numerals, in the utility face.
+fn label_for(flow: Flow) -> &'static str {
+    match flow {
+        Flow::Discharging => "on battery",
+        Flow::Charging => "charging",
+        Flow::Full => "full",
+        Flow::Holding => "plugged in",
+        Flow::Unknown => "battery",
+    }
+}
+
+/// Keys this panel responds to: none. It has nothing to set.
+const BINDINGS: &[Binding] = &[];
+
+impl Panel for BatteryPanel {
+    fn title(&self) -> String {
+        "Battery".to_string()
+    }
+
+    fn counter(&self) -> Option<String> {
+        // The one fact worth a glance at the frame: how long. It lives here
+        // and nowhere inside the panel, the way the task count lives in its
+        // border — the label says which way, the numerals say how much, and
+        // nothing is said twice.
+        let reading = self.reading?;
+        match (reading.flow, reading.remaining) {
+            (Flow::Discharging, Some(left)) => Some(format!("{} left", describe_remaining(left))),
+            (Flow::Charging, Some(left)) => Some(format!("{} to full", describe_remaining(left))),
+            _ => None,
+        }
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn tick(&mut self) -> bool {
+        self.sample()
+    }
+
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        // The one battery fact that gets worse if nobody acts in the next few
+        // minutes: it is running down and it is nearly gone. A low battery on
+        // mains, or one that is low and charging, is not that.
+        let reading = self.reading?;
+        if reading.flow != Flow::Discharging || reading.charge_pct >= self.config.alert_below_pct {
+            return None;
+        }
+        let left = reading
+            .remaining
+            .map(|left| format!(" — {} left", describe_remaining(left)))
+            .unwrap_or_default();
+        Some(crate::panel::Alert::soon(format!(
+            "Battery at {}%{left}",
+            reading.charge_pct
+        )))
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        let theme = ctx.theme;
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let Some(reading) = self.reading else {
+            self.draw_empty(frame, area, theme);
+            return;
+        };
+
+        let colour = self.colour(reading, theme);
+        let muted = Style::default().fg(theme.muted);
+        let bottom = area.y + area.height;
+
+        // The face, top to bottom: label, numerals, meter, detail — centred as a
+        // block the way the pomodoro centres its clock, so a tall panel does not
+        // pin the whole thing to its top edge. Two cells are reserved beside the
+        // numerals for the small `%`, as the clock reserves them for its small
+        // seconds.
+        let digits = reading.charge_pct.to_string();
+        let scale = glyphs::fitting_scale(
+            &digits,
+            area.width.saturating_sub(2),
+            area.height.saturating_sub(3).max(1),
+            MAX_SCALE,
+        );
+        let numeral_rows = scale.map_or(1, |s| BigText::new(&digits, s).height);
+        let mut cursor = area.y + area.height.saturating_sub(3 + numeral_rows) / 2;
+
+        // 1. The label.
+        if cursor < bottom {
+            let label = glyphs::utility(label_for(reading.flow));
+            draw_centred(frame, area, cursor, &label, colour);
+            cursor += 1;
+        }
+
+        // 2. The figure.
+        cursor += match scale {
+            Some(scale) => draw_figure(frame, area, cursor, &digits, scale, colour, muted),
+            None if cursor < bottom => {
+                draw_centred(
+                    frame,
+                    area,
+                    cursor,
+                    &format!("{}%", reading.charge_pct),
+                    colour,
+                );
+                1
+            }
+            None => 0,
+        };
+
+        // 3. The meter: the charge, as a bar. This *is* the battery, drawn.
+        if cursor < bottom && area.width > 4 {
+            let meter = meter_line(reading.charge_pct, area.width, colour, theme.track);
+            frame.render_widget(
+                Paragraph::new(Line::from(meter)),
+                Rect::new(area.x, cursor, area.width, 1),
+            );
+            cursor += 1;
+        }
+
+        // 4. The detail.
+        if cursor < bottom {
+            let parts = detail_parts(reading, muted);
+            if !parts.is_empty() {
+                frame.render_widget(
+                    Paragraph::new(crate::grid::assemble(parts, area.width)).centered(),
+                    Rect::new(area.x, cursor, area.width, 1),
+                );
+            }
+        }
+    }
+}
+
+impl BatteryPanel {
+    /// A desktop, or a battery the platform will not show us. Say which,
+    /// centred, and stop: an empty meter would read as a broken one.
+    fn draw_empty(&self, frame: &mut Frame, area: Rect, theme: &crate::theme::Theme) {
+        let muted = theme.muted;
+        let (first, second) = match &self.error {
+            Some(why) => ("No battery readable", why.as_str()),
+            None => ("No battery", "Mains powered"),
+        };
+        let top = area.y + area.height.saturating_sub(2) / 2;
+        for (i, text) in [first, second].into_iter().enumerate() {
+            let y = top + u16::try_from(i).unwrap_or(0);
+            if y < area.y + area.height {
+                let text = crate::grid::truncate(text, usize::from(area.width));
+                frame.render_widget(
+                    Paragraph::new(Span::styled(text, Style::default().fg(muted))).centered(),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+            }
+        }
+    }
+}
+
+/// One bold line, centred, ellipsised to the width.
+fn draw_centred(frame: &mut Frame, area: Rect, y: u16, text: &str, colour: Color) {
+    frame.render_widget(
+        Paragraph::new(Span::styled(
+            crate::grid::truncate(text, usize::from(area.width)),
+            Style::default().fg(colour).add_modifier(Modifier::BOLD),
+        ))
+        .centered(),
+        Rect::new(area.x, y, area.width, 1),
+    );
+}
+
+/// The charge in block numerals with a small `%` on their baseline — a
+/// subscript rather than another glyph, since the face has no `%`. Returns
+/// the rows used.
+fn draw_figure(
+    frame: &mut Frame,
+    area: Rect,
+    top: u16,
+    digits: &str,
+    scale: u16,
+    colour: Color,
+    muted: Style,
+) -> u16 {
+    let bottom = area.y + area.height;
+    let big = BigText::new(digits, scale);
+    let x = area.x + area.width.saturating_sub(big.width + 2) / 2;
+    for (i, row) in big.rows.iter().enumerate() {
+        let y = top + u16::try_from(i).unwrap_or(0);
+        if y >= bottom {
+            break;
+        }
+        frame.render_widget(
+            Paragraph::new(Span::styled(row.clone(), Style::default().fg(colour))),
+            Rect::new(x, y, big.width.min(area.width), 1),
+        );
+    }
+    let y = top + big.height.saturating_sub(1);
+    let sx = x + big.width + 1;
+    if sx < area.x + area.width && y < bottom {
+        frame.render_widget(
+            Paragraph::new(Span::styled("%", muted)),
+            Rect::new(sx, y, 1, 1),
+        );
+    }
+    big.height
+}
+
+/// The detail line as parts for `grid::assemble`: the context under the
+/// figure, in the order someone would ask for it, each dropping whole. The
+/// time is not here — it is in the border — and neither is the charge, which
+/// is the figure. The gap travels with the part it introduces, so a dropped
+/// part takes its gap with it.
+fn detail_parts(reading: Reading, muted: Style) -> Vec<Vec<Span<'static>>> {
+    let mut texts: Vec<String> = Vec::new();
+    if let Some(health) = reading.health_pct {
+        texts.push(format!("health {health}%"));
+    }
+    if let Some(cycles) = reading.cycles {
+        texts.push(format!("{cycles} cycles"));
+    }
+    if reading.watts.abs() >= 0.05 {
+        texts.push(format!("{:.1} W", reading.watts.abs()));
+    }
+    texts
+        .into_iter()
+        .enumerate()
+        .map(|(i, text)| {
+            let gap = if i == 0 { "" } else { "   " };
+            vec![Span::styled(format!("{gap}{text}"), muted)]
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reading(charge_pct: u16, flow: Flow, remaining: Option<u64>) -> Reading {
+        Reading {
+            charge_pct,
+            flow,
+            remaining: remaining.map(Duration::from_secs),
+            health_pct: Some(100),
+            cycles: Some(3),
+            watts: 12.4,
+        }
+    }
+
+    fn panel(reading: Option<Reading>) -> BatteryPanel {
+        BatteryPanel::with_reading(BatteryConfig::default(), reading)
+    }
+
+    fn screen(panel: &mut BatteryPanel, width: u16, height: u16) -> Vec<String> {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| {
+                panel.render(
+                    frame,
+                    frame.area(),
+                    RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn remaining_time_reads_the_way_someone_says_it() {
+        assert_eq!(describe_remaining(Duration::from_secs(0)), "under a minute");
+        assert_eq!(
+            describe_remaining(Duration::from_secs(59)),
+            "under a minute"
+        );
+        assert_eq!(describe_remaining(Duration::from_mins(42)), "42m");
+        assert_eq!(describe_remaining(Duration::from_hours(3)), "3h");
+        assert_eq!(
+            describe_remaining(Duration::from_mins(3 * 60 + 12)),
+            "3h 12m"
+        );
+    }
+
+    /// The counter carries the one fact worth a glance at the frame — how
+    /// long — and nothing the panel already says: the label has the state
+    /// and the numerals have the charge.
+    #[test]
+    fn the_border_says_how_long_and_nothing_the_panel_already_says() {
+        assert_eq!(
+            panel(Some(reading(80, Flow::Discharging, Some(11520))))
+                .counter()
+                .as_deref(),
+            Some("3h 12m left")
+        );
+        assert_eq!(
+            panel(Some(reading(40, Flow::Charging, Some(2520))))
+                .counter()
+                .as_deref(),
+            Some("42m to full")
+        );
+        assert_eq!(
+            panel(Some(reading(80, Flow::Holding, None))).counter(),
+            None
+        );
+        assert_eq!(panel(Some(reading(100, Flow::Full, None))).counter(), None);
+        assert_eq!(
+            panel(Some(reading(40, Flow::Charging, None))).counter(),
+            None
+        );
+        assert_eq!(
+            panel(Some(reading(63, Flow::Discharging, None))).counter(),
+            None,
+            "no estimate, nothing to say — the charge is the figure"
+        );
+        assert_eq!(panel(None).counter(), None, "no battery, no counter");
+    }
+
+    /// Calm by default: brass while there is plenty, and the signal colours
+    /// only when the charge is low *and* the machine is running on it.
+    #[test]
+    fn the_colour_is_calm_unless_the_battery_is_low_and_in_use() {
+        let theme = crate::theme::Theme::default();
+        let p = panel(None);
+        assert_eq!(
+            p.colour(reading(80, Flow::Discharging, None), &theme),
+            theme.accent
+        );
+        assert_eq!(
+            p.colour(reading(15, Flow::Discharging, None), &theme),
+            theme.warning
+        );
+        assert_eq!(
+            p.colour(reading(7, Flow::Discharging, None), &theme),
+            theme.error
+        );
+        assert_eq!(
+            p.colour(reading(7, Flow::Charging, None), &theme),
+            theme.success,
+            "low but charging is fine"
+        );
+        assert_eq!(
+            p.colour(reading(7, Flow::Holding, None), &theme),
+            theme.accent,
+            "low on mains is nothing to shout about"
+        );
+        assert_eq!(
+            p.colour(reading(100, Flow::Full, None), &theme),
+            theme.success
+        );
+    }
+
+    /// The bar for "will this get worse if nobody acts": running down and
+    /// nearly gone. Charging at the same level is not that.
+    #[test]
+    fn the_alert_fires_only_when_running_down_and_nearly_gone() {
+        assert_eq!(
+            panel(Some(reading(8, Flow::Discharging, Some(14 * 60))))
+                .alert()
+                .map(|a| a.text),
+            Some("Battery at 8% — 14m left".to_string())
+        );
+        assert_eq!(
+            panel(Some(reading(8, Flow::Discharging, None)))
+                .alert()
+                .map(|a| a.text),
+            Some("Battery at 8%".to_string())
+        );
+        assert!(
+            panel(Some(reading(8, Flow::Charging, None)))
+                .alert()
+                .is_none()
+        );
+        assert!(
+            panel(Some(reading(10, Flow::Discharging, None)))
+                .alert()
+                .is_none(),
+            "the threshold is exclusive"
+        );
+        assert!(panel(None).alert().is_none());
+    }
+
+    /// Every row of the face is present at an ordinary size, in the order the
+    /// eye reads it, and nothing is drawn as a fragment at any width.
+    #[test]
+    fn the_face_reads_label_figure_meter_detail_and_never_a_fragment() {
+        let mut p = panel(Some(reading(80, Flow::Discharging, Some(11520))));
+        let rows = screen(&mut p, 34, 9);
+        let text: Vec<&str> = rows
+            .iter()
+            .map(|r| r.trim())
+            .filter(|r| !r.is_empty())
+            .collect();
+        assert_eq!(text[0], "ON BATTERY", "{rows:?}");
+        assert!(
+            text.iter().any(|r| r.contains('█')),
+            "the figure is drawn in numerals: {rows:?}"
+        );
+        assert!(
+            text.iter().any(|r| r.contains('█') && r.ends_with('%')),
+            "with the small percent beside the numerals: {rows:?}"
+        );
+        assert!(
+            text.iter().any(|r| r.starts_with('■')),
+            "then the meter: {rows:?}"
+        );
+        assert_eq!(
+            *text.last().unwrap(),
+            "health 100%   3 cycles   12.4 W",
+            "then the detail — and not the time, which the border has: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|r| r.contains("left")),
+            "the time is said once, by the border: {rows:?}"
+        );
+
+        for width in 1..=40u16 {
+            for height in 1..=9u16 {
+                let rows = screen(&mut p, width, height);
+                for row in &rows {
+                    let t = row.trim();
+                    // No fragment of any detail value: whole or absent.
+                    for bad in ["healt", "cycle", "12."] {
+                        assert!(!t.ends_with(bad), "fragment {t:?} at {width}x{height}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_machine_without_a_battery_says_so_rather_than_drawing_an_empty_meter() {
+        let mut p = panel(None);
+        let rows = screen(&mut p, 24, 5);
+        let text = rows.join("\n");
+        assert!(text.contains("No battery"), "{rows:?}");
+        assert!(text.contains("Mains powered"), "{rows:?}");
+        assert!(!text.contains('■'), "no meter for nothing: {rows:?}");
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -16,6 +16,7 @@ pub mod news;
 pub mod notes;
 pub mod pomodoro;
 pub mod stocks;
+pub mod temperature;
 pub mod todo;
 pub mod watchlog;
 pub mod weather;
@@ -41,6 +42,7 @@ pub const WIDGET_NAMES: &[&str] = &[
     "memory",
     "network",
     "battery",
+    "temperature",
     "calculator",
 ];
 
@@ -84,6 +86,9 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
         "memory" => Box::new(memory::MemoryPanel::new(config.memory.clone())),
         "network" => Box::new(network::NetworkPanel::new(config.network.clone())),
         "battery" => Box::new(battery::BatteryPanel::new(config.battery.clone())),
+        "temperature" => Box::new(temperature::TemperaturePanel::new(
+            config.temperature.clone(),
+        )),
         "calculator" => Box::new(calculator::CalculatorPanel::new(config.calculator)),
         _ => {
             let Some(plugin) = config.plugin(name) else {
@@ -310,16 +315,12 @@ mod tests {
             ),
             (
                 "battery",
-                Box::new(battery::BatteryPanel::with_reading(
-                    config.battery.clone(),
-                    Some(battery::Reading {
-                        charge_pct: 80,
-                        flow: battery::Flow::Discharging,
-                        remaining: Some(std::time::Duration::from_mins(192)),
-                        health_pct: Some(100),
-                        cycles: Some(3),
-                        watts: 12.4,
-                    }),
+                Box::new(battery::BatteryPanel::canned(config.battery.clone())),
+            ),
+            (
+                "temperature",
+                Box::new(temperature::TemperaturePanel::canned(
+                    config.temperature.clone(),
                 )),
             ),
             (

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -5,6 +5,7 @@
 //! Mirador and are started only when the layout actually places them.
 
 pub mod agenda;
+pub mod battery;
 pub mod calculator;
 pub mod calendar;
 pub mod clocks;
@@ -39,6 +40,7 @@ pub const WIDGET_NAMES: &[&str] = &[
     "cpu",
     "memory",
     "network",
+    "battery",
     "calculator",
 ];
 
@@ -81,6 +83,7 @@ pub fn build(name: &str, config: &Config) -> Result<Option<Box<dyn Panel>>> {
         "cpu" => Box::new(cpu::CpuPanel::new(config.cpu.clone())),
         "memory" => Box::new(memory::MemoryPanel::new(config.memory.clone())),
         "network" => Box::new(network::NetworkPanel::new(config.network.clone())),
+        "battery" => Box::new(battery::BatteryPanel::new(config.battery.clone())),
         "calculator" => Box::new(calculator::CalculatorPanel::new(config.calculator)),
         _ => {
             let Some(plugin) = config.plugin(name) else {
@@ -304,6 +307,20 @@ mod tests {
             (
                 "network",
                 Box::new(network::NetworkPanel::new(config.network.clone())),
+            ),
+            (
+                "battery",
+                Box::new(battery::BatteryPanel::with_reading(
+                    config.battery.clone(),
+                    Some(battery::Reading {
+                        charge_pct: 80,
+                        flow: battery::Flow::Discharging,
+                        remaining: Some(std::time::Duration::from_mins(192)),
+                        health_pct: Some(100),
+                        cycles: Some(3),
+                        watts: 12.4,
+                    }),
+                )),
             ),
             (
                 "calculator",

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -19,6 +19,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+use crate::chart::meter_line;
 use crate::config::PomodoroConfig;
 use crate::frame::{Binding, FRAME_HEIGHT, FRAME_WIDTH};
 use crate::glyphs::{self, BigText};
@@ -621,21 +622,6 @@ fn draw_clock(
 /// arithmetic on `Rect` fields. The measurement itself is `grid::display_width`.
 fn display_width(text: &str) -> u16 {
     u16::try_from(crate::grid::display_width(text)).unwrap_or(u16::MAX)
-}
-
-/// One row of meter: filled cells in `fill`, the rest in `track`, same glyph
-/// throughout so the footprint never moves.
-fn meter_line(percent: u16, width: u16, fill: Color, track: Color) -> Vec<Span<'static>> {
-    let width = usize::from(width);
-    let filled = usize::from(percent.min(100)) * width / 100;
-    (0..width)
-        .map(|i| {
-            Span::styled(
-                "■",
-                Style::default().fg(if i < filled { fill } else { track }),
-            )
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/widgets/temperature.rs
+++ b/src/widgets/temperature.rs
@@ -1,0 +1,725 @@
+//! Temperatures: the hottest thing in the machine, its history, and the rest
+//! of the sensors under it.
+//!
+//! Read through `sysinfo::Components`, which is already in the tree for the
+//! cpu and memory panels. What it hands back is the platform's own list — on
+//! Apple silicon that is fourteen `PMU tdie` readings for one die, a
+//! calibration reference that is not a temperature at all, and eight `tdev`
+//! entries reporting minus nine thousand degrees — so the panel's real work is
+//! [`group`]: turning the platform's list into the one a person would write.
+//!
+//! The face is the cpu panel's: a readout, a braille history, and a table
+//! where the per-core strip would be. Same ramp, because a temperature in
+//! degrees Celsius and a load in percent both run 0–100 and both mean "how
+//! hard is this machine working" — the panels change colour together.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::Paragraph;
+
+use crate::chart::BrailleGraph;
+use crate::config::TemperatureConfig;
+use crate::frame::Binding;
+use crate::grid::{Column, Grid};
+use crate::panel::{Panel, RenderContext};
+
+/// The table under the graph: every sensor group, hottest first.
+pub const COLUMNS: &[Column] = &[
+    Column::flex("sensor", 1),
+    Column::fixed("now", 5).right(),
+    Column::fixed("peak", 5).right().drops_below(26),
+];
+
+/// Readings outside this range are a sensor that is not connected or a
+/// platform reporting a placeholder, not a temperature. Apple's `PMU tdev`
+/// entries sit at −9201; a value like that in the table would be the panel
+/// reporting a thermometer that does not exist.
+const PLAUSIBLE_C: std::ops::RangeInclusive<f32> = -40.0..=150.0;
+
+/// Platform labels renamed to what they are. Each entry is a prefix matched
+/// case-insensitively against the label with its trailing digits stripped, so
+/// `PMU tdie1` through `PMU tdie14` all become one row called `CPU die`.
+/// Anything not here keeps its own name, minus the trailing digits — honest,
+/// if less pretty, and the rows still group.
+const RENAMES: &[(&str, &str)] = &[
+    // Apple silicon, via IOKit. `tdie` is the die; `tcal` is a calibration
+    // reference and is dropped below rather than renamed.
+    ("PMU tdie", "CPU die"),
+    ("NAND CH", "SSD"),
+    ("gas gauge battery", "Battery"),
+    // Linux hwmon, as `sysinfo` labels it: driver name, then the sensor.
+    ("coretemp Package id", "CPU package"),
+    ("coretemp Core", "CPU core"),
+    ("k10temp Tctl", "CPU (Tctl)"),
+    ("k10temp Tccd", "CPU die"),
+    ("nvme Composite", "SSD"),
+    ("amdgpu edge", "GPU"),
+    ("acpitz", "Motherboard"),
+];
+
+/// Labels that are not temperatures of anything, whatever they read.
+const DROPPED: &[&str] = &["PMU tcal"];
+
+/// One row of the table: a group of sensors under one name.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Sensor {
+    pub name: String,
+    /// Degrees Celsius, the hottest in the group.
+    pub now: f32,
+    /// The hottest the group has reported since the panel started.
+    pub peak: f32,
+}
+
+/// The temperature panel.
+pub struct TemperaturePanel {
+    config: TemperatureConfig,
+    components: Option<sysinfo::Components>,
+    /// Hottest first.
+    sensors: Vec<Sensor>,
+    /// The hottest reading at each sample, whole degrees Celsius, oldest first.
+    history: VecDeque<u64>,
+    /// Cells the graph was last drawn into, so the history can grow to fill it.
+    graph_cells: usize,
+    last_sample: Option<Instant>,
+    /// `u` toggles this; the config seeds it.
+    celsius: bool,
+}
+
+// `sysinfo::Components` has no `Debug`.
+impl std::fmt::Debug for TemperaturePanel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TemperaturePanel")
+            .field("sensors", &self.sensors)
+            .field("samples", &self.history.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TemperaturePanel {
+    /// Build the panel and take a first reading.
+    pub fn new(config: TemperatureConfig) -> Self {
+        let mut panel = Self {
+            celsius: config.units != "fahrenheit",
+            history: VecDeque::with_capacity(config.history.max(1)),
+            config,
+            components: Some(sysinfo::Components::new_with_refreshed_list()),
+            sensors: Vec::new(),
+            graph_cells: 0,
+            last_sample: None,
+        };
+        panel.sample();
+        panel
+    }
+
+    /// A panel holding `sensors` and `history`, reading nothing, for tests in
+    /// other modules and for the sweep.
+    #[cfg(test)]
+    pub(crate) fn with_sensors(
+        config: TemperatureConfig,
+        sensors: Vec<Sensor>,
+        history: &[u64],
+    ) -> Self {
+        Self {
+            celsius: config.units != "fahrenheit",
+            history: history.iter().copied().collect(),
+            config,
+            components: None,
+            sensors,
+            graph_cells: 0,
+            last_sample: Some(Instant::now()),
+        }
+    }
+
+    /// An Apple silicon laptop at work, for the sweep and the dump.
+    #[cfg(test)]
+    pub(crate) fn canned(config: TemperatureConfig) -> Self {
+        let sensor = |name: &str, now: f32, peak: f32| Sensor {
+            name: name.into(),
+            now,
+            peak,
+        };
+        Self::with_sensors(
+            config,
+            vec![
+                sensor("CPU die", 47.3, 61.0),
+                sensor("SSD", 34.0, 36.0),
+                sensor("Battery", 29.0, 31.0),
+            ],
+            &[41, 43, 47, 52, 49, 47],
+        )
+    }
+
+    /// Read every sensor if enough time has passed since the last reading.
+    /// Returns whether anything was read.
+    fn sample(&mut self) -> bool {
+        let interval = Duration::from_secs(self.config.sample_secs.max(1));
+        if self.last_sample.is_some_and(|at| at.elapsed() < interval) {
+            return false;
+        }
+        self.last_sample = Some(Instant::now());
+        let Some(components) = self.components.as_mut() else {
+            return false;
+        };
+        components.refresh(true);
+        let raw = components
+            .iter()
+            .map(|c| (c.label().to_string(), c.temperature(), c.max()))
+            .collect::<Vec<_>>();
+        self.sensors = group(raw, &self.sensors);
+        if let Some(hottest) = self.sensors.first() {
+            let capacity = crate::samples::capacity(self.config.history, self.graph_cells);
+            crate::samples::push_bounded(
+                &mut self.history,
+                hottest.now.clamp(0.0, 150.0).round() as u64,
+                capacity,
+            );
+        }
+        true
+    }
+
+    /// A reading in the display units.
+    fn shown(&self, celsius: f32) -> f32 {
+        if self.celsius {
+            celsius
+        } else {
+            celsius * 9.0 / 5.0 + 32.0
+        }
+    }
+
+    fn unit(&self) -> &'static str {
+        if self.celsius { "°C" } else { "°F" }
+    }
+
+    /// Say nothing, centred, rather than draw an empty graph over an empty
+    /// table: on Windows the sensors need elevation, and a VM or a container
+    /// has none to report.
+    fn draw_empty(frame: &mut Frame, area: Rect, theme: &crate::theme::Theme) {
+        let hint = if cfg!(windows) {
+            "Run as administrator to read them"
+        } else {
+            "This machine reports none"
+        };
+        let top = area.y + area.height.saturating_sub(2) / 2;
+        for (i, text) in ["No temperature sensors", hint].into_iter().enumerate() {
+            let y = top + u16::try_from(i).unwrap_or(0);
+            if y < area.y + area.height {
+                frame.render_widget(
+                    Paragraph::new(Span::styled(
+                        crate::grid::truncate(text, usize::from(area.width)),
+                        Style::default().fg(theme.muted),
+                    ))
+                    .centered(),
+                    Rect::new(area.x, y, area.width, 1),
+                );
+            }
+        }
+    }
+}
+
+/// The platform's sensor list as a person would write it.
+///
+/// Each raw entry is a label, a reading and the platform's own running
+/// maximum. Readings that are not plausible temperatures are dropped, so are
+/// labels that are not temperatures of anything, trailing digits come off
+/// the label so `Core 0` and `Core 7` share a row, known labels are renamed,
+/// and each name keeps the hottest reading in its group. The peak is the
+/// highest the group has shown since the panel started — `previous` carries
+/// it across samples, because the platform's own maximum is not always kept.
+pub(crate) fn group(
+    raw: Vec<(String, Option<f32>, Option<f32>)>,
+    previous: &[Sensor],
+) -> Vec<Sensor> {
+    let mut groups: Vec<Sensor> = Vec::new();
+    for (label, now, max) in raw {
+        let Some(now) = now.filter(|t| PLAUSIBLE_C.contains(t)) else {
+            continue;
+        };
+        let Some(name) = display_name(&label) else {
+            continue;
+        };
+        let peak = max
+            .filter(|t| PLAUSIBLE_C.contains(t))
+            .unwrap_or(now)
+            .max(now);
+        match groups.iter_mut().find(|g| g.name == name) {
+            Some(g) => {
+                g.now = g.now.max(now);
+                g.peak = g.peak.max(peak);
+            }
+            None => groups.push(Sensor { name, now, peak }),
+        }
+    }
+    for g in &mut groups {
+        if let Some(p) = previous.iter().find(|p| p.name == g.name) {
+            g.peak = g.peak.max(p.peak);
+        }
+    }
+    groups.sort_by(|a, b| {
+        b.now
+            .partial_cmp(&a.now)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    groups
+}
+
+/// The row name for a platform label, or `None` for a label that is not a
+/// temperature of anything.
+fn display_name(label: &str) -> Option<String> {
+    let trimmed = label.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let lower = trimmed.to_lowercase();
+    if DROPPED.iter().any(|d| lower.starts_with(&d.to_lowercase())) {
+        return None;
+    }
+    // Peel the label back to the thing it names: trailing digits, the
+    // separators before them, and a trailing `temp`, which says nothing a
+    // temperature panel has not already said — repeated, because
+    // `iwlwifi_1 temp1` has one layer of each.
+    let mut stem = trimmed;
+    loop {
+        let peeled = stem
+            .trim_end_matches(|c: char| c.is_ascii_digit())
+            .trim_end_matches([' ', '_', '-']);
+        let peeled = strip_suffix_ci(peeled, "temp").trim_end_matches([' ', '_', '-']);
+        if peeled == stem {
+            break;
+        }
+        stem = peeled;
+    }
+    if stem.is_empty() {
+        return Some(trimmed.to_string());
+    }
+    let stem_lower = stem.to_lowercase();
+    for (prefix, name) in RENAMES {
+        if stem_lower.starts_with(&prefix.to_lowercase()) {
+            return Some((*name).to_string());
+        }
+    }
+    Some(stem.to_string())
+}
+
+/// `text` without a trailing `suffix`, compared without case; unchanged when
+/// it does not end with one.
+fn strip_suffix_ci<'a>(text: &'a str, suffix: &str) -> &'a str {
+    if text.len() >= suffix.len() && text.is_char_boundary(text.len() - suffix.len()) {
+        let (head, tail) = text.split_at(text.len() - suffix.len());
+        if tail.eq_ignore_ascii_case(suffix) {
+            return head;
+        }
+    }
+    text
+}
+
+/// Keys this panel responds to.
+const BINDINGS: &[Binding] = &[Binding::primary("u", "units")];
+
+impl Panel for TemperaturePanel {
+    fn title(&self) -> String {
+        "Temperature".to_string()
+    }
+
+    fn counter(&self) -> Option<String> {
+        match self.sensors.len() {
+            0 => None,
+            1 => Some("1 sensor".to_string()),
+            n => Some(format!("{n} sensors")),
+        }
+    }
+
+    fn bindings(&self) -> &'static [Binding] {
+        BINDINGS
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        Duration::from_secs(1)
+    }
+
+    fn tick(&mut self) -> bool {
+        self.sample()
+    }
+
+    fn handle_key(&mut self, key: ratatui::crossterm::event::KeyEvent) -> crate::panel::KeyOutcome {
+        use ratatui::crossterm::event::KeyCode;
+        if matches!(key.code, KeyCode::Char('u')) {
+            self.celsius = !self.celsius;
+            return crate::panel::KeyOutcome::Consumed;
+        }
+        crate::panel::KeyOutcome::Ignored
+    }
+
+    fn remember(&self, state: &mut crate::state::UiState) {
+        state.temperature_units = Some(
+            if self.celsius {
+                "celsius"
+            } else {
+                "fahrenheit"
+            }
+            .into(),
+        );
+    }
+
+    fn alert(&self) -> Option<crate::panel::Alert> {
+        // A die past its limit is the one reading here that gets worse if
+        // nobody acts — a throttled machine is the mild outcome, a shutdown
+        // the other. Zero in the config switches it off.
+        let limit = self.config.alert_above_c;
+        let hottest = self.sensors.first()?;
+        (limit > 0 && hottest.now > f32::from(limit)).then(|| {
+            crate::panel::Alert::soon(format!(
+                "{} at {:.0}{}",
+                hottest.name,
+                self.shown(hottest.now),
+                self.unit()
+            ))
+        })
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: RenderContext<'_>) {
+        let theme = ctx.theme;
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+        let Some(hottest) = self.sensors.first().cloned() else {
+            Self::draw_empty(frame, area, theme);
+            return;
+        };
+
+        let gradient = &ctx.gradients.cpu;
+        let track = Style::default().fg(theme.track);
+        let muted = Style::default().fg(theme.muted);
+
+        // The table takes at most half the panel and only when it can show a
+        // header and a row; the graph keeps the rest.
+        let wanted = u16::try_from(self.sensors.len() + 1).unwrap_or(u16::MAX);
+        let table_rows = if area.height >= 5 {
+            wanted.min(area.height / 2)
+        } else {
+            0
+        };
+        let table_rows = if table_rows >= 2 { table_rows } else { 0 };
+
+        let rows = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(table_rows),
+        ])
+        .split(area);
+
+        // The readout: the hottest thing, in the ramp's colour at its Celsius
+        // value, then what it is, then how much history the graph holds. The
+        // figure and its unit are one part; the name and the age drop whole.
+        let colour = gradient.at(hottest.now.clamp(0.0, 100.0).round() as i64);
+        frame.render_widget(
+            Paragraph::new(crate::grid::assemble(
+                vec![
+                    vec![
+                        Span::styled(
+                            format!("{:.1}", self.shown(hottest.now)),
+                            Style::default().fg(colour).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(self.unit(), muted),
+                    ],
+                    vec![Span::styled(
+                        format!(" {}", crate::glyphs::utility(&hottest.name)),
+                        Style::default()
+                            .fg(theme.label)
+                            .add_modifier(Modifier::BOLD),
+                    )],
+                    vec![Span::styled(
+                        format!(
+                            "   {}s",
+                            self.history.len() as u64 * self.config.sample_secs.max(1)
+                        ),
+                        muted,
+                    )],
+                ],
+                rows[0].width,
+            )),
+            rows[0],
+        );
+
+        self.graph_cells = rows[1].width as usize;
+        if rows[1].height > 0 {
+            let data: Vec<u64> = self.history.iter().copied().collect();
+            BrailleGraph::new(&data, 100, gradient)
+                .track_style(track)
+                .render(rows[1], frame.buffer_mut());
+        }
+
+        if table_rows >= 2 {
+            let grid = Grid::new(COLUMNS, rows[2].width);
+            let mut y = rows[2].y;
+            frame.render_widget(
+                Paragraph::new(grid.header(theme)),
+                Rect::new(rows[2].x, y, rows[2].width, 1),
+            );
+            y += 1;
+            for sensor in self.sensors.iter().take(usize::from(table_rows) - 1) {
+                let tone = gradient.at(sensor.now.clamp(0.0, 100.0).round() as i64);
+                let line = grid.row(&[
+                    Span::styled(sensor.name.clone(), Style::default().fg(theme.text)),
+                    Span::styled(
+                        format!("{:.0}°", self.shown(sensor.now)),
+                        Style::default().fg(tone),
+                    ),
+                    Span::styled(format!("{:.0}°", self.shown(sensor.peak)), muted),
+                ]);
+                frame.render_widget(
+                    Paragraph::new(line),
+                    Rect::new(rows[2].x, y, rows[2].width, 1),
+                );
+                y += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn apple() -> Vec<(String, Option<f32>, Option<f32>)> {
+        let mut raw = vec![
+            ("PMU tcal".to_string(), Some(51.8), Some(51.8)),
+            ("NAND CH0 temp".to_string(), Some(32.0), Some(32.0)),
+            ("gas gauge battery".to_string(), Some(29.0), Some(29.0)),
+        ];
+        for i in 1..=14 {
+            raw.push((
+                format!("PMU tdie{i}"),
+                Some(37.0 + i as f32 * 0.2),
+                Some(40.0),
+            ));
+        }
+        for i in 1..=8 {
+            raw.push((format!("PMU tdev{i}"), Some(-9201.1), Some(0.0)));
+        }
+        raw
+    }
+
+    fn sensors() -> Vec<Sensor> {
+        group(apple(), &[])
+    }
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < 0.01
+    }
+
+    fn panel(sensors: Vec<Sensor>) -> TemperaturePanel {
+        TemperaturePanel::with_sensors(TemperatureConfig::default(), sensors, &[38, 39, 40, 41, 40])
+    }
+
+    fn screen(panel: &mut TemperaturePanel, width: u16, height: u16) -> Vec<String> {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let config = crate::config::Config::default();
+        let gradients = config.theme.gradients();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| {
+                panel.render(
+                    frame,
+                    frame.area(),
+                    RenderContext {
+                        theme: &config.theme,
+                        gradients: &gradients,
+                        focused: true,
+                        watch: &crate::watch::WatchLog::default(),
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// Twenty-five platform entries become three rows a person would write:
+    /// fourteen die sensors as one, the calibration reference gone, the
+    /// eight impossible readings gone.
+    #[test]
+    fn apple_silicons_sensor_list_becomes_three_rows() {
+        let rows = sensors();
+        let names: Vec<&str> = rows.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, ["CPU die", "SSD", "Battery"], "{rows:?}");
+        let die = &rows[0];
+        assert!(
+            (die.now - 39.8).abs() < 0.01,
+            "the hottest of the fourteen: {die:?}"
+        );
+        assert!(
+            (die.peak - 40.0).abs() < 0.01,
+            "and the platform's own maximum: {die:?}"
+        );
+        assert!(
+            rows.iter().all(|s| PLAUSIBLE_C.contains(&s.now)),
+            "{rows:?}"
+        );
+    }
+
+    #[test]
+    fn linux_hwmon_labels_group_and_rename() {
+        let raw = vec![
+            ("coretemp Package id 0".to_string(), Some(52.0), Some(70.0)),
+            ("coretemp Core 0".to_string(), Some(48.0), Some(66.0)),
+            ("coretemp Core 1".to_string(), Some(51.0), Some(69.0)),
+            ("nvme Composite".to_string(), Some(41.0), None),
+            ("acpitz temp1".to_string(), Some(27.8), None),
+            ("iwlwifi_1 temp1".to_string(), Some(45.0), None),
+        ];
+        let rows = group(raw, &[]);
+        let names: Vec<&str> = rows.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            ["CPU package", "CPU core", "iwlwifi", "SSD", "Motherboard"],
+            "hottest first, unknown labels kept minus their digits: {rows:?}"
+        );
+        assert!(close(rows[1].now, 51.0), "the hotter core");
+        assert!(close(rows[1].peak, 69.0));
+        assert!(
+            close(rows[3].peak, 41.0),
+            "no platform maximum: the peak is the reading"
+        );
+    }
+
+    /// The peak is the panel's memory, not the platform's: a group that
+    /// cooled since the last sample keeps the higher figure.
+    #[test]
+    fn the_peak_survives_a_sample_that_cooled() {
+        let hot = group(vec![("PMU tdie1".to_string(), Some(80.0), None)], &[]);
+        let cooler = group(vec![("PMU tdie1".to_string(), Some(50.0), None)], &hot);
+        assert!(close(cooler[0].now, 50.0));
+        assert!(close(cooler[0].peak, 80.0));
+    }
+
+    #[test]
+    fn u_switches_units_and_is_remembered() {
+        let mut p = panel(sensors());
+        assert_eq!(p.unit(), "°C");
+        let out = p.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::NONE));
+        assert_eq!(out, crate::panel::KeyOutcome::Consumed);
+        assert_eq!(p.unit(), "°F");
+        assert!((p.shown(100.0) - 212.0).abs() < 0.01);
+        let mut state = crate::state::UiState::default();
+        p.remember(&mut state);
+        assert_eq!(state.temperature_units.as_deref(), Some("fahrenheit"));
+        assert!(
+            BINDINGS.iter().any(|b| b.key == "u"),
+            "the key is documented in the frame"
+        );
+    }
+
+    #[test]
+    fn the_alert_names_the_hottest_thing_past_the_limit_and_can_be_switched_off() {
+        let hot = vec![Sensor {
+            name: "CPU die".into(),
+            now: 97.4,
+            peak: 98.0,
+        }];
+        assert_eq!(
+            panel(hot.clone()).alert().map(|a| a.text),
+            Some("CPU die at 97°C".to_string())
+        );
+        assert!(
+            panel(sensors()).alert().is_none(),
+            "forty degrees is not news"
+        );
+        let off = TemperatureConfig {
+            alert_above_c: 0,
+            ..TemperatureConfig::default()
+        };
+        assert!(
+            TemperaturePanel::with_sensors(off, hot, &[])
+                .alert()
+                .is_none()
+        );
+        assert!(panel(Vec::new()).alert().is_none());
+    }
+
+    #[test]
+    fn the_border_counts_sensor_groups_not_platform_entries() {
+        assert_eq!(panel(sensors()).counter().as_deref(), Some("3 sensors"));
+        assert_eq!(
+            panel(vec![Sensor {
+                name: "SSD".into(),
+                now: 40.0,
+                peak: 40.0
+            }])
+            .counter()
+            .as_deref(),
+            Some("1 sensor")
+        );
+        assert_eq!(panel(Vec::new()).counter(), None);
+    }
+
+    /// Readout, graph, then the table with a header and every group under
+    /// it — and no cell in the table left blank.
+    #[test]
+    fn the_face_reads_readout_graph_table() {
+        let mut p = panel(sensors());
+        let rows = screen(&mut p, 40, 10);
+        assert!(rows[0].starts_with("39.8°C CPU DIE"), "{rows:?}");
+        assert!(
+            rows[0].ends_with("25s"),
+            "five samples at five seconds: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.contains('⣀') || r.contains('⣿') || r.contains('⡀')),
+            "a graph: {rows:?}"
+        );
+        let header = rows
+            .iter()
+            .position(|r| r.starts_with("SENSOR"))
+            .expect("a table header");
+        assert!(
+            rows[header].contains("NOW") && rows[header].ends_with("PEAK"),
+            "{rows:?}"
+        );
+        assert!(
+            rows[header + 1].starts_with("CPU die") && rows[header + 1].ends_with("40°"),
+            "{rows:?}"
+        );
+        assert!(rows[header + 2].starts_with("SSD"), "{rows:?}");
+        assert!(rows[header + 3].starts_with("Battery"), "{rows:?}");
+        for row in &rows[header + 1..header + 4] {
+            assert!(
+                row.matches('°').count() == 2,
+                "now and peak both filled: {row:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_short_panel_keeps_the_graph_and_drops_the_table() {
+        let mut p = panel(sensors());
+        let rows = screen(&mut p, 40, 4);
+        assert!(rows.iter().all(|r| !r.starts_with("SENSOR")), "{rows:?}");
+        assert!(rows[0].starts_with("39.8°C"), "{rows:?}");
+    }
+
+    #[test]
+    fn a_machine_with_no_sensors_says_so() {
+        let mut p = panel(Vec::new());
+        let rows = screen(&mut p, 40, 6);
+        let text = rows.join("\n");
+        assert!(text.contains("No temperature sensors"), "{rows:?}");
+        assert!(!text.contains('⣀'), "no empty graph over nothing: {rows:?}");
+    }
+}


### PR DESCRIPTION
Stacked on #248; the diff here is the temperature panel alone. Merge #248 first, then retarget this to `main`.

## What

A `temperature` widget in the CPU panel's face: a readout of the hottest sensor, a braille history of it, and a table of every sensor group with its current and peak reading, hottest first. `u` toggles Celsius and Fahrenheit, remembered through `UiState.temperature_units` the way the weather panel's units are. Above `alert_above_c` (95, `0` disables) the status bar says `CPU die at 97°C`.

Same colour ramp as the CPU graph, on purpose: degrees Celsius and load percent both run 0–100 and both mean "how hard is this machine working", so the two panels change colour together.

## The real work is `group`

`sysinfo::Components` on this MacBook returns 25 entries for what a person would call three sensors: fourteen `PMU tdie` readings for one die, `PMU tcal` (a calibration reference, not a temperature of anything) and eight `PMU tdev` entries at −9201°C. The panel writes them as `CPU die`, `SSD`, `Battery`:

- trailing digits and a trailing `temp` come off the label, repeatedly (`iwlwifi_1 temp1` → `iwlwifi`);
- a short rename table covers the Apple and Linux hwmon labels it knows; unknown labels keep their own name minus the digits;
- readings outside −40…150 °C are dropped;
- each group keeps the hottest reading, and the peak is the panel's memory across samples rather than the platform's `max`, which is not kept everywhere.

## Placement

Second on the excused list in `the_default_layout_places_every_widget`, for a different reason than the battery: the panel reads what the platform reports, and on Windows that needs elevation while a VM or a container reports nothing. Where there is nothing it says so — with the elevation hint on Windows — rather than drawing an empty graph.

## Verification

- Four gates green; 878 tests. Nine new tests, each broken on purpose and seen red: the plausibility filter, the `tcal` drop, digit stripping, peak memory, units remembered, `0` disabling the alert, the table giving way in a short panel.
- New `COLUMNS` registered in `EVERY_GRID`, so the overflow sweep covers the table; the silent-clip sweep runs over the panel with a canned reading.
- Rendered under tmux with `-e` on this MacBook's real sensors at four sizes, in Fahrenheit, in a laptop instrument row beside the battery, and in two canned hot states; the owner has the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)