### PR TITLE
Release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-09-11
+
 ### Added
 
 - **A battery panel, for laptops.** The charge in block numerals with the
@@ -1860,7 +1862,8 @@ in an earlier version — they are kept because the reasoning is worth having.
 - Task rows no longer shift horizontally when a task has no due date.
 - Key hints are no longer duplicated between the panel body and its frame.
 
-[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/jchultarsky/mirador/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/jchultarsky/mirador/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/jchultarsky/mirador/compare/v1.10.2...v1.11.0
 [1.10.2]: https://github.com/jchultarsky/mirador/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/jchultarsky/mirador/compare/v1.10.0...v1.10.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2084,9 +2084,13 @@ and had to be added back was the one that did not.
   paths went unexercised. Both have since been run on macOS against a real
   terminal under `tmux` and report sensible figures. Windows has since been run
   too — see the platform note below.
-- **`1.11.0` is released**, as a GitHub release with binaries for macOS
+- **`1.12.0` is released**, as a GitHub release with binaries for macOS
   arm64, macOS x86-64, Linux x86-64, Linux aarch64 and Windows x86-64,
-  and published on crates.io. It is the first feature release since 1.9.0:
+  and published on crates.io. It adds the two panels asked for by name on
+  2026-09-11 — `battery` and `temperature`, the first widgets deliberately
+  left out of the default layout, so the shipped dashboard and the demo are
+  unchanged — and nothing else user-visible. 1.11.0, earlier the same day,
+  was the first feature release since 1.9.0:
   the `memory` panel — the fourteenth widget, and the missing quarter of
   "what compute is available" — three bundled themes completing two pairs
   (`everforest`, `rose-pine`, `rose-pine-moon`; nineteen ship), the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "mirador"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirador"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Julian Chultarsky <jchultarsky@gmail.com>"]


### PR DESCRIPTION
Version bump, CHANGELOG entry and link references, and the released line in CLAUDE.md, in one commit.

Carries the battery (#248) and temperature (#250) panels. Default layout unchanged, so no demo re-recording.

Driven on `main` at 120x40 under tmux before this bump: default dashboard unchanged, `w` lists both new widgets unticked, clean `q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)